### PR TITLE
test(common): add suggestion correction test

### DIFF
--- a/butterfly-common/src/lib.rs
+++ b/butterfly-common/src/lib.rs
@@ -6,10 +6,13 @@ pub use error::{Error, Result};
 
 #[cfg(test)]
 mod tests {
+    use crate::error::suggest_correction;
+
     #[test]
-    fn it_works() {
-        // Basic smoke test to ensure the library compiles
-        let _result = 2 + 2;
-        assert_eq!(_result, 4);
+    fn suggest_correction_returns_expected_country() {
+        assert_eq!(
+            suggest_correction("belgum"),
+            Some("europe/belgium".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary
- replace placeholder smoke test with unit test for `suggest_correction`

## Testing
- `cargo test -p butterfly-common`


------
https://chatgpt.com/codex/tasks/task_e_689753e6c4a8832994903b8d96e0e6ab