### PR TITLE
docs: hyphenate drive time in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/butterfly-osm/butterfly-osm/workflows/CI/badge.svg)](https://github.com/butterfly-osm/butterfly-osm/actions/workflows/ci.yml)
 
-Hurricane-fast drivetime engine and OSM toolkit built for modern performance requirements.
+Hurricane-fast drive-time engine and OSM toolkit built for modern performance requirements.
 
 ## Vision
 


### PR DESCRIPTION
## Summary
- hyphenate "drive-time" in README tagline

## Testing
- `cargo test` *(fails: Network error: error sending request)*

------
https://chatgpt.com/codex/tasks/task_e_689753d5018083299d8f546c5eebbe5c