### PR TITLE
feat(#152): kill DownReverseAdj + zero-copy ebg.* + madvise + RSS measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"

--- a/route/Cargo.toml
+++ b/route/Cargo.toml
@@ -45,7 +45,7 @@ libc = "0.2"
 # wraps the only `unsafe` (slice-of-u8 → slice-of-u32) in its own well-
 # audited internal carveout. The workspace's `unsafe_code` lint stays
 # `deny` everywhere outside `formats/mmap.rs`.
-bytemuck = "1.16"
+bytemuck = { version = "1.16", features = ["derive"] }
 
 # Logging
 env_logger = { workspace = true }

--- a/route/docs/152-redux-results.md
+++ b/route/docs/152-redux-results.md
@@ -34,7 +34,7 @@ Both runs use the same `belgium-v4.butterfly` container, the same 30-route warmu
 The RssAnon delta (2.46 GB) decomposes as roughly:
 - ~320 MB from dropping `DownReverseAdj` Vec-of-Vec across 4 modes (part A).
 - ~520 MB from zero-copy `ebg.nodes` / `ebg.csr` / `filtered_ebg` arrays moving from heap to mmap (part B). On Belgium this counts double in the delta because `ebg.csr` body and the `filtered_ebg` cold prefix are *both* zero-copy AND madvised, so the file_kb side also shrinks.
-- The remainder (~1.6 GB) is mainly the file-backed pages that the part-C madvise(DONTNEED) calls dropped (cold ebg.csr body + per-mode filtered_ebg cold prefixes). These show up as a `file_kb` reduction from 6.94 GB at `spatial.mode.truck` to 2.28 GB at `health.ready`.
+- The remainder (~1.6 GB) is mainly the file-backed pages that the part-C madvise(DONTNEED) calls dropped (cold ebg.csr body + per-mode filtered_ebg cold prefixes). These show up as a `file_kb` reduction from 6.94 GB at `spatial.mode.truck` to 2.28 GB at `boot.complete`.
 
 ## RSS checkpoint timeline (work-152)
 
@@ -51,12 +51,12 @@ phase=spatial.mode.bike        total_kb= 9634996  anon_kb=2695592  file_kb=69394
 phase=spatial.mode.car         total_kb=10233364  anon_kb=3293960  file_kb=6939404  elapsed_s=89.904
 phase=spatial.mode.foot        total_kb=11264376  anon_kb=4324972  file_kb=6939404  elapsed_s=92.135
 phase=spatial.mode.truck       total_kb=11765076  anon_kb=4825672  file_kb=6939404  elapsed_s=93.205
-phase=health.ready             total_kb= 7195340  anon_kb=4919796  file_kb=2275544  elapsed_s=100.594
+phase=boot.complete             total_kb= 7195340  anon_kb=4919796  file_kb=2275544  elapsed_s=100.594
 ```
 
 Three observations:
 
-1. **The drop between `spatial.mode.truck` and `health.ready` is the madvise reclaim**: total falls 11.77 → 7.20 GB (−4.57 GB), mostly in `file_kb` (6.94 → 2.28 GB). Anon ticks up slightly (+95 MB) because the transit subsystem boots in this window and allocates its RAPTOR scratch.
+1. **The drop between `spatial.mode.truck` and `boot.complete` is the madvise reclaim**: total falls 11.77 → 7.20 GB (−4.57 GB), mostly in `file_kb` (6.94 → 2.28 GB). Anon ticks up slightly (+95 MB) because the transit subsystem boots in this window and allocates its RAPTOR scratch.
 2. **Per-mode loads scale linearly** in anon (~37 MB/mode for the heap-resident parts: `mask`, `node_weights`, transit transfer caches). This is now the floor we'd attack in #153.
 3. **Spatial indexes are anon-heavy** (~1.0 GB per per-mode rstar tree). Codex/issue body explicitly defer this to #154 — the spatial.mode.* checkpoints validate that this is exactly where the remaining anon sits, ready for #154 to attack.
 
@@ -122,8 +122,8 @@ cargo build --workspace --release
     --port 13001 --grpc-port 13002 \
     --rss-checkpoints 2>&1 | tee /tmp/butterfly-152.log
 
-# Wait for health.ready
-until grep -q "RSS_CHECKPOINT phase=health.ready" /tmp/butterfly-152.log; do sleep 3; done
+# Wait for boot.complete
+until grep -q "RSS_CHECKPOINT phase=boot.complete" /tmp/butterfly-152.log; do sleep 3; done
 
 # 30-route warmup, 100-route bench, 100-iso bench
 # (see /tmp/route-pairs.txt and /tmp/iso-pairs.txt for exact pairs)

--- a/route/docs/152-redux-results.md
+++ b/route/docs/152-redux-results.md
@@ -1,0 +1,136 @@
+# Issue #152 redux — measurement results
+
+**Branch base:** `cch-topo-v4` (commit 8a96cdd, "chore(route): cargo fmt sweep alongside #151")
+**Work branch:** `work-152` (3 commits on top of cch-topo-v4)
+**Dataset:** `data/belgium-v4.butterfly` (27.3 GB container, 4 modes: bike/car/foot/truck)
+**Host:** Linux 6.12 / x86_64 / 8 cores
+**Date:** 2026-04-26
+**Methodology:** `/proc/self/smaps_rollup` (NOT `ps -o rss` — see issue body, codex flagged it).
+
+## Acceptance gates
+
+| # | Gate                                                   | Threshold | Result | Status |
+|---|--------------------------------------------------------|-----------|---------|--------|
+| 1 | Idle total RSS (smaps_rollup), 4 modes, after warmup   | ≤ 10 GB   | **7.93 GB** | PASS |
+| 2 | Idle RssAnon                                           | ≤ 6.4 GB  | **5.19 GB** | PASS |
+| 3 | 100-route correctness vs cch-topo-v4 baseline          | 0 mismatches | **0 mismatches** | PASS |
+| 4 | P50/P90 route latency                                  | ±10 % of baseline | identical p50, p90 within ±10 % | PASS |
+| 5 | P50/P90 isochrone latency                              | ±10 % of baseline | within ±10 % | PASS |
+| 6 | `cargo clippy --workspace --all-targets --all-features` | green     | green | PASS |
+| 7 | `cargo fmt --all -- --check`                           | green     | green for `route/` (dl/ has pre-existing diffs unrelated to #152) | PASS for in-scope crate |
+| 8 | RSS-checkpoint instrumentation runs in smoke test      | green     | 13 checkpoints emitted on Belgium boot | PASS |
+
+## RSS comparison
+
+Both runs use the same `belgium-v4.butterfly` container, the same 30-route warmup, and the same 100-route + 100-isochrone bench against `127.0.0.1:13001`.
+
+| Metric                         | cch-topo-v4 baseline | work-152      | Δ                | %      |
+|--------------------------------|----------------------|---------------|------------------|--------|
+| Idle Total RSS, post-warmup    | 11.07 GB (11 065 316 kB) | 7.52 GB (7 519 520 kB) | −3.55 GB    | −32 %  |
+| Idle RssAnon, post-warmup      |  7.38 GB (7 376 432 kB)  | 5.13 GB (5 131 368 kB) | −2.25 GB    | −31 %  |
+| Idle Total RSS, post-bench     | 11.75 GB (11 749 320 kB) | 7.93 GB (7 924 812 kB) | **−3.82 GB**    | **−32 %** |
+| Idle RssAnon, post-bench       |  7.65 GB (7 651 124 kB)  | 5.19 GB (5 192 404 kB) | **−2.46 GB**    | **−32 %** |
+
+The RssAnon delta (2.46 GB) decomposes as roughly:
+- ~320 MB from dropping `DownReverseAdj` Vec-of-Vec across 4 modes (part A).
+- ~520 MB from zero-copy `ebg.nodes` / `ebg.csr` / `filtered_ebg` arrays moving from heap to mmap (part B). On Belgium this counts double in the delta because `ebg.csr` body and the `filtered_ebg` cold prefix are *both* zero-copy AND madvised, so the file_kb side also shrinks.
+- The remainder (~1.6 GB) is mainly the file-backed pages that the part-C madvise(DONTNEED) calls dropped (cold ebg.csr body + per-mode filtered_ebg cold prefixes). These show up as a `file_kb` reduction from 6.94 GB at `spatial.mode.truck` to 2.28 GB at `health.ready`.
+
+## RSS checkpoint timeline (work-152)
+
+```
+phase=startup                  total_kb=    8336  anon_kb=   1500  file_kb=   6836  elapsed_s=0.000
+phase=load.container.opened    total_kb=    9888  anon_kb=   1836  file_kb=   8052  elapsed_s=0.004
+phase=load.shared              total_kb=  766328  anon_kb= 443352  file_kb= 322976  elapsed_s=1.536
+phase=load.mode.bike           total_kb= 3310788  anon_kb= 499780  file_kb=2811008  elapsed_s=32.580
+phase=load.mode.car            total_kb= 3946248  anon_kb= 539896  file_kb=3406352  elapsed_s=40.103
+phase=load.mode.foot           total_kb= 6969724  anon_kb= 598424  file_kb=6371300  elapsed_s=77.372
+phase=load.mode.truck          total_kb= 7575460  anon_kb= 636424  file_kb=6939036  elapsed_s=84.534
+phase=spatial.global           total_kb= 8621304  anon_kb=1681900  file_kb=6939404  elapsed_s=86.700
+phase=spatial.mode.bike        total_kb= 9634996  anon_kb=2695592  file_kb=6939404  elapsed_s=88.763
+phase=spatial.mode.car         total_kb=10233364  anon_kb=3293960  file_kb=6939404  elapsed_s=89.904
+phase=spatial.mode.foot        total_kb=11264376  anon_kb=4324972  file_kb=6939404  elapsed_s=92.135
+phase=spatial.mode.truck       total_kb=11765076  anon_kb=4825672  file_kb=6939404  elapsed_s=93.205
+phase=health.ready             total_kb= 7195340  anon_kb=4919796  file_kb=2275544  elapsed_s=100.594
+```
+
+Three observations:
+
+1. **The drop between `spatial.mode.truck` and `health.ready` is the madvise reclaim**: total falls 11.77 → 7.20 GB (−4.57 GB), mostly in `file_kb` (6.94 → 2.28 GB). Anon ticks up slightly (+95 MB) because the transit subsystem boots in this window and allocates its RAPTOR scratch.
+2. **Per-mode loads scale linearly** in anon (~37 MB/mode for the heap-resident parts: `mask`, `node_weights`, transit transfer caches). This is now the floor we'd attack in #153.
+3. **Spatial indexes are anon-heavy** (~1.0 GB per per-mode rstar tree). Codex/issue body explicitly defer this to #154 — the spatial.mode.* checkpoints validate that this is exactly where the remaining anon sits, ready for #154 to attack.
+
+## Latency
+
+100 random Belgium pairs, sequential over loopback HTTP, after a 30-route warmup.
+
+|                | baseline (cch-topo-v4) | work-152 |
+|----------------|------------------------|----------|
+| Route mean     | 7 ms                   | 7 ms     |
+| Route p50      | 5 ms                   | 5 ms     |
+| Route p90      | 12 ms                  | 12 ms    |
+| Route max      | 13 ms                  | 13 ms    |
+| Isochrone mean | 12 ms                  | 11 ms    |
+| Isochrone p50  | 7 ms                   | 7 ms     |
+| Isochrone p90  | 25 ms                  | 23 ms    |
+| Isochrone max  | 39 ms                  | 38 ms    |
+
+The cold custom-weight path (alternatives, exclude/avoid, transit access/egress, map matching) now reads through the same flats that the hot path uses, but the routes test exercises the hot path so route latency is unchanged. Isochrone numbers are noise-equivalent (the 1–2 ms shift is within bench variance).
+
+## Correctness
+
+100-route diff between baseline and work-152: **identical** (`diff -q` reports no difference).
+
+```
+$ diff -q /tmp/route-results.baseline.txt /tmp/route-results.work152.saved.txt
+$ echo $?
+0
+```
+
+Per-route output is `id src_lon,src_lat -> dst_lon,dst_lat duration_s distance_m`, formatted to floating-point, including unreachable pairs (`null null`). The fact that the byte-stream is bit-identical confirms:
+
+- The CustomWeights backend (replacing RawWeights) yields the exact same forward/backward parent edges as the legacy `DownReverseAdj` did. The two backends differ only in *how* they iterate the reverse-DOWN topology; the topology itself is identical, and the inline INF filter on the new backend has the same effect as the legacy backend's INF filter.
+- Zero-copy `ebg.nodes` / `ebg.csr` / `filtered_ebg` readers reproduce the same struct contents as the owning readers (CRC verifies on both paths).
+
+## What this ticket did NOT do
+
+By design, per the corrected scope in #152:
+
+- **Spatial index serialization** → still a heap rstar; #154 will pack it.
+- **Server-only mapping sections** → `FilteredEbg` + `OrderEbg` still loaded full at boot; #153 will split them.
+- **Geometry flattening** → `nbg.geo` still uses nested `Vec<Vec<_>>`; #155.
+
+## Files of interest
+
+- `route/src/server/query.rs` — backend rename + flat-driven CustomWeights
+- `route/src/server/state.rs` — DownReverseAdj field deletion + zero-copy wiring + madvise calls + RSS checkpoints
+- `route/src/formats/ebg_nodes.rs` — `EbgNode` Pod + zero-copy reader
+- `route/src/formats/ebg_csr.rs` — Cow + zero-copy reader
+- `route/src/formats/filtered_ebg.rs` — Cow + zero-copy reader (with cold-range accessor for madvise)
+- `route/src/server/rss.rs` — new module; smaps_rollup + checkpoint logger
+- `route/src/cli.rs` — `--rss-checkpoints` flag
+
+## Reproducer
+
+```bash
+# Build (release)
+cargo build --workspace --release
+
+# Start work-152 with checkpoints on
+./target/release/butterfly-route serve \
+    --data data/belgium-v4.butterfly \
+    --port 13001 --grpc-port 13002 \
+    --rss-checkpoints 2>&1 | tee /tmp/butterfly-152.log
+
+# Wait for health.ready
+until grep -q "RSS_CHECKPOINT phase=health.ready" /tmp/butterfly-152.log; do sleep 3; done
+
+# 30-route warmup, 100-route bench, 100-iso bench
+# (see /tmp/route-pairs.txt and /tmp/iso-pairs.txt for exact pairs)
+
+# Sample idle RSS
+PID=$(pgrep -fx 'butterfly-route serve --data data/belgium-v4.butterfly ...')
+cat /proc/$PID/smaps_rollup | grep -E "^Rss:|^Anonymous:"
+```
+
+The RSS-checkpoint stream is the foundation #153/#154/#155 will measure against.

--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -25,7 +25,6 @@ use butterfly_route::range::frontier::FrontierExtractor;
 use butterfly_route::range::phast::{PhastEngine, PhastStats};
 use butterfly_route::range::sparse_contour::{SparseContourConfig, generate_sparse_contour};
 use butterfly_route::range::wkb_stream::{IsochroneRecord, encode_polygon_wkb, write_ndjson};
-use butterfly_route::server::state::DownReverseAdj;
 
 #[derive(Parser)]
 #[command(name = "butterfly-bench")]
@@ -3016,9 +3015,9 @@ fn run_bucket_m2m_bench(
     let down_rev_flat = DownReverseAdjFlat::build(&topo, &weights);
     println!("  ✓ {} flat reverse entries", down_rev_flat.sources.len());
 
-    println!("Building DownReverseAdj (for P2P validation)...");
-    let down_rev = build_down_rev(&topo);
-    println!("  ✓ {} reverse entries", down_rev.sources.len());
+    println!("Building DownReverseAdjFlat with topo back-references (for P2P validation)...");
+    let down_rev_p2p = DownReverseAdjFlat::build_with(&topo, &weights, true);
+    println!("  ✓ {} reverse entries", down_rev_p2p.sources.len());
     println!();
 
     // Run benchmarks for each size
@@ -3163,7 +3162,7 @@ fn run_bucket_m2m_bench(
             let m2m_dist = par_matrix[si * 5 + ti]; // Use PARALLEL result
 
             // Run P2P query using the same algorithm as the server
-            let p2p_dist = run_p2p_query(&topo, &weights, &down_rev, s, t);
+            let p2p_dist = run_p2p_query(&topo, &weights, &down_rev_p2p, s, t);
 
             checked += 1;
             if m2m_dist != p2p_dist {
@@ -3200,11 +3199,17 @@ fn run_bucket_m2m_bench(
 }
 
 /// Run a single P2P query using bidirectional Dijkstra (same as server)
-/// Returns distance or u32::MAX if unreachable
+/// Returns distance or u32::MAX if unreachable.
+///
+/// After #152, the P2P validator reads its reverse-DOWN topology straight
+/// from the same `DownReverseAdjFlat` that production routing uses (built
+/// with `topo_edge_idx` so we can index `weights.down`). The legacy
+/// `DownReverseAdj` Vec-of-Vec was deleted along with its boot-path
+/// build site.
 fn run_p2p_query(
     topo: &butterfly_route::formats::CchTopo,
     weights: &butterfly_route::formats::CchWeights,
-    down_rev: &DownReverseAdj,
+    down_rev: &DownReverseAdjFlat,
     source: u32,
     target: u32,
 ) -> u32 {
@@ -3265,7 +3270,7 @@ fn run_p2p_query(
             }
         }
 
-        // Backward step - reversed DOWN edges
+        // Backward step - reversed DOWN edges (read from the flat).
         if let Some(Reverse((d, u))) = pq_bwd.pop() {
             if d > dist_bwd[u as usize] {
                 continue;
@@ -3279,16 +3284,15 @@ fn run_p2p_query(
                 }
             }
 
-            // Relax reversed DOWN edges
+            // Relax reversed DOWN edges via the flat. The flat already
+            // filtered INF entries at build time; `topo_edge_idx[slot]`
+            // recovers the original DOWN edge index for symmetry with the
+            // legacy implementation.
             let start = down_rev.offsets[u as usize] as usize;
             let end = down_rev.offsets[u as usize + 1] as usize;
-            for i in start..end {
-                let x = down_rev.sources[i];
-                let edge_idx = down_rev.edge_idx[i] as usize;
-                let w = weights.down[edge_idx];
-                if w == u32::MAX {
-                    continue;
-                }
+            for slot in start..end {
+                let x = down_rev.sources[slot];
+                let w = down_rev.weights[slot];
                 let new_d = d.saturating_add(w);
                 if new_d < dist_bwd[x as usize] {
                     dist_bwd[x as usize] = new_d;
@@ -3305,54 +3309,6 @@ fn run_p2p_query(
     }
 
     best_dist
-}
-
-/// Build reverse adjacency for DOWN edges
-///
-/// For each node u, collects all nodes x that have DOWN edges x→u.
-/// This enables reverse search: given target t, find all nodes that can reach t.
-fn build_down_rev(topo: &butterfly_route::formats::CchTopo) -> DownReverseAdj {
-    let n_nodes = topo.n_nodes as usize;
-
-    // Count incoming DOWN edges for each node
-    let mut counts = vec![0u32; n_nodes];
-    for &target in topo.down_targets.iter() {
-        counts[target as usize] += 1;
-    }
-
-    // Build offsets
-    let mut offsets = vec![0u64; n_nodes + 1];
-    for i in 0..n_nodes {
-        offsets[i + 1] = offsets[i] + counts[i] as u64;
-    }
-
-    let total_edges = offsets[n_nodes] as usize;
-    let mut sources = vec![0u32; total_edges];
-    let mut edge_idx = vec![0u32; total_edges];
-
-    // Reset counts for filling
-    counts.fill(0);
-
-    // Fill reverse edges
-    // For each source node src, iterate its outgoing DOWN edges
-    for src in 0..n_nodes {
-        let start = topo.down_offsets[src] as usize;
-        let end = topo.down_offsets[src + 1] as usize;
-
-        for i in start..end {
-            let target = topo.down_targets[i] as usize;
-            let pos = offsets[target] as usize + counts[target] as usize;
-            sources[pos] = src as u32;
-            edge_idx[pos] = i as u32;
-            counts[target] += 1;
-        }
-    }
-
-    DownReverseAdj {
-        offsets,
-        sources,
-        edge_idx,
-    }
 }
 
 /// Compare dense vs sparse contour generation

--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -421,6 +421,22 @@ pub enum Commands {
         /// Log format: "text" (default) or "json"
         #[arg(long, default_value = "text")]
         log_format: String,
+
+        /// Emit RSS / RssAnon / RssFile checkpoints (parsed from
+        /// `/proc/self/smaps_rollup`) at every boot phase: shared
+        /// section load, each per-mode bundle load, global spatial
+        /// index, each per-mode spatial index, and `/health` first
+        /// becomes ready. Lines are tagged `RSS_CHECKPOINT phase=...
+        /// total_kb=N anon_kb=M file_kb=K` so they can be grepped out
+        /// of the structured log stream.
+        ///
+        /// Also enabled by setting `BUTTERFLY_RSS_CHECKPOINTS=1`.
+        ///
+        /// This instrumentation is the foundation for the
+        /// #153/#154/#155 measurement discipline; it stays in the
+        /// codebase as a supported flag, not as a one-shot diagnostic.
+        #[arg(long, default_value = "false")]
+        rss_checkpoints: bool,
     },
 
     /// Validate CCH correctness by comparing bidirectional CCH vs CCH-Dijkstra
@@ -1395,9 +1411,21 @@ impl Cli {
                 transport,
                 modes,
                 log_format,
+                rss_checkpoints,
             } => {
                 // Initialize structured logging for the serve command
                 server::init_tracing(&log_format);
+
+                // Either CLI flag OR env var BUTTERFLY_RSS_CHECKPOINTS=1
+                // turns on the checkpoint instrumentation.
+                let rss_checkpoints = rss_checkpoints
+                    || std::env::var("BUTTERFLY_RSS_CHECKPOINTS")
+                        .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+                        .unwrap_or(false);
+                if rss_checkpoints {
+                    crate::server::rss::set_enabled(true);
+                    crate::server::rss::checkpoint("startup");
+                }
 
                 let transport_mode = server::Transport::parse(&transport)?;
                 let mode_filter = modes.map(|s| {

--- a/route/src/ebg/mod.rs
+++ b/route/src/ebg/mod.rs
@@ -207,7 +207,7 @@ pub fn build_ebg(config: EbgConfig) -> Result<EbgResult> {
         n_nodes: ebg_nodes.len() as u32,
         created_unix,
         inputs_sha,
-        nodes: ebg_nodes,
+        nodes: std::borrow::Cow::Owned(ebg_nodes),
     };
     EbgNodesFile::write(&nodes_path, &ebg_nodes_data)?;
     println!("  ✓ Wrote {}", nodes_path.display());
@@ -561,9 +561,9 @@ fn materialize_csr(
         n_arcs,
         created_unix,
         inputs_sha: [0u8; 32],
-        offsets,
-        heads,
-        turn_idx,
+        offsets: std::borrow::Cow::Owned(offsets),
+        heads: std::borrow::Cow::Owned(heads),
+        turn_idx: std::borrow::Cow::Owned(turn_idx),
     })
 }
 

--- a/route/src/formats/ebg_csr.rs
+++ b/route/src/formats/ebg_csr.rs
@@ -1,6 +1,19 @@
 //! ebg.csr format - EBG adjacency (CSR over EBG nodes)
+//!
+//! # Zero-copy reader (#152)
+//!
+//! Layout: header(64 bytes) | offsets ((n_nodes+1) × u64) | heads
+//! (n_arcs × u32) | turn_idx (n_arcs × u32) | footer(16 bytes).
+//!
+//! - The container guarantees 8-byte section alignment.
+//! - The 64-byte header keeps the offsets array u64-aligned.
+//! - The heads and turn_idx u32 arrays only need 4-byte alignment.
+//!
+//! No padding is required between arrays for the zero-copy reader to
+//! cast each slice with `bytemuck::cast_slice`.
 
 use anyhow::Result;
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
@@ -9,6 +22,8 @@ use super::crc;
 
 const MAGIC: u32 = 0x45424743; // "EBGC"
 const VERSION: u16 = 1;
+const HEADER_LEN: usize = 64;
+const FOOTER_LEN: usize = 16;
 
 #[derive(Debug)]
 pub struct EbgCsr {
@@ -16,9 +31,13 @@ pub struct EbgCsr {
     pub n_arcs: u64,
     pub created_unix: u64,
     pub inputs_sha: [u8; 32],
-    pub offsets: Vec<u64>,  // n_nodes + 1
-    pub heads: Vec<u32>,    // n_arcs
-    pub turn_idx: Vec<u32>, // n_arcs - index into turn_table
+    /// CSR offsets array (`n_nodes + 1`). Borrowed (zero-copy) when
+    /// loaded from a `'static` byte slice, owned otherwise.
+    pub offsets: Cow<'static, [u64]>,
+    /// CSR heads array (`n_arcs`).
+    pub heads: Cow<'static, [u32]>,
+    /// Turn-table index per arc (`n_arcs`).
+    pub turn_idx: Cow<'static, [u32]>,
 }
 
 pub struct EbgCsrFile;
@@ -57,21 +76,21 @@ impl EbgCsrFile {
         crc_digest.update(&padding);
 
         // Offsets
-        for &offset in &data.offsets {
+        for &offset in data.offsets.iter() {
             let bytes = offset.to_le_bytes();
             writer.write_all(&bytes)?;
             crc_digest.update(&bytes);
         }
 
         // Heads
-        for &head in &data.heads {
+        for &head in data.heads.iter() {
             let bytes = head.to_le_bytes();
             writer.write_all(&bytes)?;
             crc_digest.update(&bytes);
         }
 
         // Turn indices
-        for &idx in &data.turn_idx {
+        for &idx in data.turn_idx.iter() {
             let bytes = idx.to_le_bytes();
             writer.write_all(&bytes)?;
             crc_digest.update(&bytes);
@@ -99,7 +118,7 @@ impl EbgCsrFile {
     fn read_from_reader<R: Read>(mut reader: R) -> Result<EbgCsr> {
         let mut crc_digest = crc::Digest::new();
 
-        let mut header = vec![0u8; 64];
+        let mut header = vec![0u8; HEADER_LEN];
         reader.read_exact(&mut header)?;
         crc_digest.update(&header);
 
@@ -144,7 +163,7 @@ impl EbgCsrFile {
 
         // Verify CRC64
         let computed_crc = crc_digest.finalize();
-        let mut footer = [0u8; 16];
+        let mut footer = [0u8; FOOTER_LEN];
         reader.read_exact(&mut footer)?;
         let stored_crc = u64::from_le_bytes(footer[0..8].try_into().unwrap());
         anyhow::ensure!(
@@ -159,9 +178,114 @@ impl EbgCsrFile {
             n_arcs,
             created_unix,
             inputs_sha,
-            offsets,
-            heads,
-            turn_idx,
+            offsets: Cow::Owned(offsets),
+            heads: Cow::Owned(heads),
+            turn_idx: Cow::Owned(turn_idx),
+        })
+    }
+
+    /// Zero-copy reader for `'static` byte slices (mmap-backed
+    /// container sections). Reinterprets the body arrays as borrowed
+    /// slices into the mapping; CRC is verified before returning.
+    ///
+    /// Layout (#152):
+    ///   header(64) | offsets((n_nodes+1) × u64)
+    ///             | heads(n_arcs × u32)
+    ///             | turn_idx(n_arcs × u32)
+    ///             | footer(16)
+    ///
+    /// The 64-byte header keeps the offsets u64 array aligned. The
+    /// heads/turn_idx u32 arrays only need 4-byte alignment which
+    /// any cursor reaches naturally.
+    pub fn read_from_bytes_zero_copy(bytes: &'static [u8]) -> Result<EbgCsr> {
+        anyhow::ensure!(
+            bytes.len() >= HEADER_LEN + FOOTER_LEN,
+            "ebg.csr too short for header+footer: {} bytes",
+            bytes.len()
+        );
+        debug_assert_eq!(
+            bytes.as_ptr() as usize % 8,
+            0,
+            "ebg.csr section start must be 8-byte aligned"
+        );
+
+        let header = &bytes[..HEADER_LEN];
+        let magic = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+        anyhow::ensure!(
+            magic == MAGIC,
+            "Invalid magic in ebg.csr: expected 0x{:08X}, got 0x{:08X}",
+            MAGIC,
+            magic
+        );
+        let version = u16::from_le_bytes([header[4], header[5]]);
+        anyhow::ensure!(
+            version == VERSION,
+            "Unsupported ebg.csr version {version}, expected {VERSION}",
+        );
+
+        let n_nodes = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
+        let n_arcs = u64::from_le_bytes([
+            header[12], header[13], header[14], header[15], header[16], header[17], header[18],
+            header[19],
+        ]);
+        let created_unix = u64::from_le_bytes([
+            header[20], header[21], header[22], header[23], header[24], header[25], header[26],
+            header[27],
+        ]);
+        let mut inputs_sha = [0u8; 32];
+        inputs_sha.copy_from_slice(&header[28..60]);
+
+        let n_offsets = (n_nodes as usize)
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("ebg.csr offsets count overflow"))?;
+        let n_arcs_us =
+            usize::try_from(n_arcs).map_err(|_| anyhow::anyhow!("ebg.csr n_arcs > usize::MAX"))?;
+
+        let offsets_len = n_offsets
+            .checked_mul(8)
+            .ok_or_else(|| anyhow::anyhow!("ebg.csr offsets size overflow"))?;
+        let heads_len = n_arcs_us
+            .checked_mul(4)
+            .ok_or_else(|| anyhow::anyhow!("ebg.csr heads size overflow"))?;
+        let turn_len = heads_len;
+
+        let off_start = HEADER_LEN;
+        let off_end = off_start + offsets_len;
+        let heads_end = off_end + heads_len;
+        let turn_end = heads_end + turn_len;
+        anyhow::ensure!(
+            bytes.len() == turn_end + FOOTER_LEN,
+            "ebg.csr length mismatch: declared {}, expected body+footer {}",
+            bytes.len(),
+            turn_end + FOOTER_LEN
+        );
+
+        let offsets: &'static [u64] = bytemuck::cast_slice(&bytes[off_start..off_end]);
+        let heads: &'static [u32] = bytemuck::cast_slice(&bytes[off_end..heads_end]);
+        let turn_idx: &'static [u32] = bytemuck::cast_slice(&bytes[heads_end..turn_end]);
+
+        // CRC over header + body
+        let mut crc_digest = crc::Digest::new();
+        crc_digest.update(header);
+        crc_digest.update(&bytes[off_start..turn_end]);
+        let computed = crc_digest.finalize();
+        let footer = &bytes[turn_end..turn_end + FOOTER_LEN];
+        let stored = u64::from_le_bytes(footer[0..8].try_into().unwrap());
+        anyhow::ensure!(
+            computed == stored,
+            "CRC64 mismatch in ebg.csr: computed 0x{:016X}, stored 0x{:016X}",
+            computed,
+            stored
+        );
+
+        Ok(EbgCsr {
+            n_nodes,
+            n_arcs,
+            created_unix,
+            inputs_sha,
+            offsets: Cow::Borrowed(offsets),
+            heads: Cow::Borrowed(heads),
+            turn_idx: Cow::Borrowed(turn_idx),
         })
     }
 }

--- a/route/src/formats/ebg_csr.rs
+++ b/route/src/formats/ebg_csr.rs
@@ -122,6 +122,19 @@ impl EbgCsrFile {
         reader.read_exact(&mut header)?;
         crc_digest.update(&header);
 
+        let magic = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+        anyhow::ensure!(
+            magic == MAGIC,
+            "Invalid magic in ebg.csr: expected 0x{:08X}, got 0x{:08X}",
+            MAGIC,
+            magic
+        );
+        let version = u16::from_le_bytes([header[4], header[5]]);
+        anyhow::ensure!(
+            version == VERSION,
+            "Unsupported ebg.csr version {version}, expected {VERSION}",
+        );
+
         let n_nodes = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
         let n_arcs = u64::from_le_bytes([
             header[12], header[13], header[14], header[15], header[16], header[17], header[18],

--- a/route/src/formats/ebg_nodes.rs
+++ b/route/src/formats/ebg_nodes.rs
@@ -134,6 +134,19 @@ impl EbgNodesFile {
         reader.read_exact(&mut header)?;
         crc_digest.update(&header);
 
+        let magic = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+        anyhow::ensure!(
+            magic == MAGIC,
+            "Invalid magic in ebg.nodes: expected 0x{:08X}, got 0x{:08X}",
+            MAGIC,
+            magic
+        );
+        let version = u16::from_le_bytes([header[4], header[5]]);
+        anyhow::ensure!(
+            version == VERSION,
+            "Unsupported ebg.nodes version {version}, expected {VERSION}",
+        );
+
         let n_nodes = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
         let created_unix = u64::from_le_bytes([
             header[12], header[13], header[14], header[15], header[16], header[17], header[18],

--- a/route/src/formats/ebg_nodes.rs
+++ b/route/src/formats/ebg_nodes.rs
@@ -1,6 +1,17 @@
 //! ebg.nodes format - EBG node table (directed NBG edges)
+//!
+//! # Zero-copy reader (#152)
+//!
+//! The body is a flat array of fixed-size 24-byte records. `EbgNode`
+//! is `#[repr(C)]` with six `u32` fields in declared order, so its
+//! in-memory layout matches the on-disk record byte-for-byte. The
+//! container guarantees 8-byte section alignment and the 64-byte
+//! header keeps the body 4-byte-aligned at the section-relative
+//! offset, so `bytemuck::cast_slice::<u8, EbgNode>` works from the
+//! mmap with no heap copy.
 
 use anyhow::Result;
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
@@ -9,8 +20,15 @@ use super::crc;
 
 const MAGIC: u32 = 0x4542474E; // "EBGN"
 const VERSION: u16 = 1;
+const HEADER_LEN: usize = 64;
+const FOOTER_LEN: usize = 16;
+const NODE_RECORD_LEN: usize = 24;
 
-#[derive(Debug, Clone)]
+/// One EBG node record. `#[repr(C)]` + all-u32 fields makes this Pod
+/// with no padding; on-disk layout is byte-identical to in-memory
+/// layout, which is what the zero-copy reader (#152) relies on.
+#[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
 pub struct EbgNode {
     pub tail_nbg: u32,    // compact NBG node id
     pub head_nbg: u32,    // compact NBG node id
@@ -20,12 +38,18 @@ pub struct EbgNode {
     pub primary_way: u32, // lower 32 bits of first_osm_way_id
 }
 
+const _: () = assert!(std::mem::size_of::<EbgNode>() == NODE_RECORD_LEN);
+const _: () = assert!(std::mem::align_of::<EbgNode>() == 4);
+
 #[derive(Debug)]
 pub struct EbgNodes {
     pub n_nodes: u32,
     pub created_unix: u64,
     pub inputs_sha: [u8; 32],
-    pub nodes: Vec<EbgNode>,
+    /// Flat node array. Borrowed (zero-copy) when read from a
+    /// `'static` byte slice (mmap-backed container section), owned
+    /// otherwise. Indexed by `ebg_id`.
+    pub nodes: Cow<'static, [EbgNode]>,
 }
 
 pub struct EbgNodesFile;
@@ -61,7 +85,7 @@ impl EbgNodesFile {
         crc_digest.update(&padding);
 
         // Body: n_nodes records (24 bytes each)
-        for node in &data.nodes {
+        for node in data.nodes.iter() {
             let tail_bytes = node.tail_nbg.to_le_bytes();
             let head_bytes = node.head_nbg.to_le_bytes();
             let geom_bytes = node.geom_idx.to_le_bytes();
@@ -106,7 +130,7 @@ impl EbgNodesFile {
     fn read_from_reader<R: Read>(mut reader: R) -> Result<EbgNodes> {
         let mut crc_digest = crc::Digest::new();
 
-        let mut header = vec![0u8; 64];
+        let mut header = vec![0u8; HEADER_LEN];
         reader.read_exact(&mut header)?;
         crc_digest.update(&header);
 
@@ -118,25 +142,31 @@ impl EbgNodesFile {
         let mut inputs_sha = [0u8; 32];
         inputs_sha.copy_from_slice(&header[20..52]);
 
-        let mut nodes = Vec::with_capacity(n_nodes as usize);
-        for _ in 0..n_nodes {
-            let mut record = [0u8; 24];
-            reader.read_exact(&mut record)?;
-            crc_digest.update(&record);
+        // Read the body as one byte block, CRC it, then cast to
+        // `&[EbgNode]` and copy into an owned Vec. The cast is
+        // alignment-safe — the temporary buffer starts at an aligned
+        // address, but we copy into a new Vec anyway since the bytes
+        // here are not `'static`. Owned-path callers (e.g. directory
+        // load) end up with the same semantics as before.
+        let body_len = NODE_RECORD_LEN
+            .checked_mul(n_nodes as usize)
+            .ok_or_else(|| anyhow::anyhow!("ebg.nodes body size overflow for n_nodes={n_nodes}"))?;
+        let mut body = vec![0u8; body_len];
+        reader.read_exact(&mut body)?;
+        crc_digest.update(&body);
 
-            nodes.push(EbgNode {
-                tail_nbg: u32::from_le_bytes([record[0], record[1], record[2], record[3]]),
-                head_nbg: u32::from_le_bytes([record[4], record[5], record[6], record[7]]),
-                geom_idx: u32::from_le_bytes([record[8], record[9], record[10], record[11]]),
-                length_mm: u32::from_le_bytes([record[12], record[13], record[14], record[15]]),
-                class_bits: u32::from_le_bytes([record[16], record[17], record[18], record[19]]),
-                primary_way: u32::from_le_bytes([record[20], record[21], record[22], record[23]]),
-            });
+        let mut nodes: Vec<EbgNode> = Vec::with_capacity(n_nodes as usize);
+        // SAFETY-style note: bytemuck::pod_read_unaligned is safe and
+        // handles arbitrary alignment of the source bytes.
+        for chunk in body.chunks_exact(NODE_RECORD_LEN) {
+            let arr: [u8; NODE_RECORD_LEN] =
+                chunk.try_into().expect("chunks_exact yields full chunks");
+            nodes.push(bytemuck::pod_read_unaligned::<EbgNode>(&arr));
         }
 
         // Verify CRC64
         let computed_crc = crc_digest.finalize();
-        let mut footer = [0u8; 16];
+        let mut footer = [0u8; FOOTER_LEN];
         reader.read_exact(&mut footer)?;
         let stored_crc = u64::from_le_bytes(footer[0..8].try_into().unwrap());
         anyhow::ensure!(
@@ -150,7 +180,89 @@ impl EbgNodesFile {
             n_nodes,
             created_unix,
             inputs_sha,
-            nodes,
+            nodes: Cow::Owned(nodes),
+        })
+    }
+
+    /// Zero-copy reader for `'static` byte slices (mmap-backed
+    /// container sections). The body is reinterpreted as
+    /// `&'static [EbgNode]` directly from the mapping — no heap
+    /// allocation. CRC is verified before returning.
+    ///
+    /// The caller (the container) guarantees that the section bytes
+    /// start at an 8-byte boundary; combined with the 64-byte header,
+    /// the body slice starts at a 4-byte boundary, which matches
+    /// `align_of::<EbgNode>() == 4`.
+    pub fn read_from_bytes_zero_copy(bytes: &'static [u8]) -> Result<EbgNodes> {
+        anyhow::ensure!(
+            bytes.len() >= HEADER_LEN + FOOTER_LEN,
+            "ebg.nodes too short for header+footer: {} bytes",
+            bytes.len()
+        );
+        debug_assert_eq!(
+            bytes.as_ptr() as usize % 8,
+            0,
+            "ebg.nodes section start must be 8-byte aligned"
+        );
+
+        let header = &bytes[..HEADER_LEN];
+        let magic = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+        anyhow::ensure!(
+            magic == MAGIC,
+            "Invalid magic in ebg.nodes: expected 0x{:08X}, got 0x{:08X}",
+            MAGIC,
+            magic
+        );
+        let version = u16::from_le_bytes([header[4], header[5]]);
+        anyhow::ensure!(
+            version == VERSION,
+            "Unsupported ebg.nodes version {version}, expected {VERSION}",
+        );
+
+        let n_nodes = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
+        let created_unix = u64::from_le_bytes([
+            header[12], header[13], header[14], header[15], header[16], header[17], header[18],
+            header[19],
+        ]);
+        let mut inputs_sha = [0u8; 32];
+        inputs_sha.copy_from_slice(&header[20..52]);
+
+        let body_len = NODE_RECORD_LEN
+            .checked_mul(n_nodes as usize)
+            .ok_or_else(|| anyhow::anyhow!("ebg.nodes body size overflow for n_nodes={n_nodes}"))?;
+        let body_end = HEADER_LEN
+            .checked_add(body_len)
+            .ok_or_else(|| anyhow::anyhow!("ebg.nodes section size overflow"))?;
+        anyhow::ensure!(
+            bytes.len() == body_end + FOOTER_LEN,
+            "ebg.nodes length mismatch: declared {}, expected body+footer {}",
+            bytes.len(),
+            body_end + FOOTER_LEN
+        );
+
+        let body = &bytes[HEADER_LEN..body_end];
+        let footer = &bytes[body_end..body_end + FOOTER_LEN];
+
+        // CRC over header + body, mirroring the legacy reader.
+        let mut crc_digest = crc::Digest::new();
+        crc_digest.update(header);
+        crc_digest.update(body);
+        let computed = crc_digest.finalize();
+        let stored = u64::from_le_bytes(footer[0..8].try_into().unwrap());
+        anyhow::ensure!(
+            computed == stored,
+            "CRC64 mismatch in ebg.nodes: computed 0x{:016X}, stored 0x{:016X}",
+            computed,
+            stored
+        );
+
+        let nodes: &'static [EbgNode] = bytemuck::cast_slice(body);
+
+        Ok(EbgNodes {
+            n_nodes,
+            created_unix,
+            inputs_sha,
+            nodes: Cow::Borrowed(nodes),
         })
     }
 }
@@ -166,7 +278,7 @@ mod tests {
             n_nodes: 3,
             created_unix: 1700000000,
             inputs_sha: [0xAB; 32],
-            nodes: vec![
+            nodes: Cow::Owned(vec![
                 EbgNode {
                     tail_nbg: 0,
                     head_nbg: 1,
@@ -191,7 +303,7 @@ mod tests {
                     class_bits: 0,
                     primary_way: 44,
                 },
-            ],
+            ]),
         }
     }
 

--- a/route/src/formats/filtered_ebg.rs
+++ b/route/src/formats/filtered_ebg.rs
@@ -2,8 +2,21 @@
 //!
 //! Stores the filtered subgraph containing only mode-accessible nodes and transitions.
 //! Used by Step 6/7/8 to build per-mode CCH hierarchies.
+//!
+//! # Zero-copy reader (#152)
+//!
+//! Layout: header(64 bytes) | offsets((n_filt+1) × u64) | heads
+//! (n_arcs × u32) | original_arc_idx (n_arcs × u32) | filtered_to_original
+//! (n_filt × u32) | original_to_filtered (n_orig × u32) | footer(16 bytes).
+//!
+//! - The container guarantees 8-byte section alignment.
+//! - The 64-byte header keeps the offsets u64 array u64-aligned.
+//! - Every subsequent array is u32, which only needs 4-byte alignment;
+//!   any cursor that has consumed a multiple of 4 bytes (which all
+//!   prior arrays do) is sufficient.
 
 use anyhow::Result;
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::Path;
@@ -13,6 +26,8 @@ use crate::profile_abi::Mode;
 
 const MAGIC: u32 = 0x46454247; // "FEBG" = Filtered EBG
 const VERSION: u16 = 1;
+const HEADER_LEN: usize = 64;
+const FOOTER_LEN: usize = 16;
 
 /// Filtered EBG for a specific mode
 #[derive(Debug)]
@@ -24,13 +39,13 @@ pub struct FilteredEbg {
     pub inputs_sha: [u8; 32],
 
     // CSR in filtered space
-    pub offsets: Vec<u64>,          // n_filtered_nodes + 1
-    pub heads: Vec<u32>,            // n_filtered_arcs (filtered node IDs)
-    pub original_arc_idx: Vec<u32>, // n_filtered_arcs (original arc indices for turn penalties)
+    pub offsets: Cow<'static, [u64]>, // n_filtered_nodes + 1
+    pub heads: Cow<'static, [u32]>,   // n_filtered_arcs (filtered node IDs)
+    pub original_arc_idx: Cow<'static, [u32]>, // n_filtered_arcs
 
     // Node ID mappings
-    pub filtered_to_original: Vec<u32>, // n_filtered_nodes: filtered_id -> original_id
-    pub original_to_filtered: Vec<u32>, // n_original_nodes: original_id -> filtered_id (u32::MAX if not in filtered)
+    pub filtered_to_original: Cow<'static, [u32]>, // n_filtered_nodes
+    pub original_to_filtered: Cow<'static, [u32]>, // n_original_nodes (u32::MAX if not in filtered)
 }
 
 impl FilteredEbg {
@@ -135,11 +150,11 @@ impl FilteredEbg {
             n_filtered_arcs: heads.len() as u64,
             n_original_nodes,
             inputs_sha,
-            offsets,
-            heads,
-            original_arc_idx,
-            filtered_to_original,
-            original_to_filtered,
+            offsets: Cow::Owned(offsets),
+            heads: Cow::Owned(heads),
+            original_arc_idx: Cow::Owned(original_arc_idx),
+            filtered_to_original: Cow::Owned(filtered_to_original),
+            original_to_filtered: Cow::Owned(original_to_filtered),
         }
     }
 
@@ -192,35 +207,35 @@ impl FilteredEbgFile {
         crc_digest.update(&header);
 
         // Offsets
-        for &off in &data.offsets {
+        for &off in data.offsets.iter() {
             let bytes = off.to_le_bytes();
             writer.write_all(&bytes)?;
             crc_digest.update(&bytes);
         }
 
         // Heads
-        for &h in &data.heads {
+        for &h in data.heads.iter() {
             let bytes = h.to_le_bytes();
             writer.write_all(&bytes)?;
             crc_digest.update(&bytes);
         }
 
         // Original arc indices
-        for &idx in &data.original_arc_idx {
+        for &idx in data.original_arc_idx.iter() {
             let bytes = idx.to_le_bytes();
             writer.write_all(&bytes)?;
             crc_digest.update(&bytes);
         }
 
         // filtered_to_original
-        for &orig in &data.filtered_to_original {
+        for &orig in data.filtered_to_original.iter() {
             let bytes = orig.to_le_bytes();
             writer.write_all(&bytes)?;
             crc_digest.update(&bytes);
         }
 
         // original_to_filtered
-        for &filt in &data.original_to_filtered {
+        for &filt in data.original_to_filtered.iter() {
             let bytes = filt.to_le_bytes();
             writer.write_all(&bytes)?;
             crc_digest.update(&bytes);
@@ -341,11 +356,133 @@ impl FilteredEbgFile {
             n_filtered_arcs,
             n_original_nodes,
             inputs_sha,
-            offsets,
-            heads,
-            original_arc_idx,
-            filtered_to_original,
-            original_to_filtered,
+            offsets: Cow::Owned(offsets),
+            heads: Cow::Owned(heads),
+            original_arc_idx: Cow::Owned(original_arc_idx),
+            filtered_to_original: Cow::Owned(filtered_to_original),
+            original_to_filtered: Cow::Owned(original_to_filtered),
+        })
+    }
+
+    /// Zero-copy reader for `'static` byte slices (mmap-backed
+    /// container sections). Reinterprets the body arrays as borrowed
+    /// slices into the mapping; CRC is verified before returning.
+    ///
+    /// Layout (#152):
+    ///   header(64) | offsets((n_filt+1) × u64)
+    ///             | heads(n_arcs × u32)
+    ///             | original_arc_idx(n_arcs × u32)
+    ///             | filtered_to_original(n_filt × u32)
+    ///             | original_to_filtered(n_orig × u32)
+    ///             | footer(16)
+    ///
+    /// 8-byte section alignment guaranteed by the container; the
+    /// 64-byte header keeps the offsets u64 array aligned. Every
+    /// subsequent u32 array only needs 4-byte alignment.
+    pub fn read_from_bytes_zero_copy(bytes: &'static [u8]) -> Result<FilteredEbg> {
+        anyhow::ensure!(
+            bytes.len() >= HEADER_LEN + FOOTER_LEN,
+            "filtered_ebg too short for header+footer: {} bytes",
+            bytes.len()
+        );
+        debug_assert_eq!(
+            bytes.as_ptr() as usize % 8,
+            0,
+            "filtered_ebg section start must be 8-byte aligned"
+        );
+
+        let header = &bytes[..HEADER_LEN];
+        let magic = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+        anyhow::ensure!(
+            magic == MAGIC,
+            "Invalid magic in filtered_ebg: expected 0x{:08X}, got 0x{:08X}",
+            MAGIC,
+            magic
+        );
+        let version = u16::from_le_bytes([header[4], header[5]]);
+        anyhow::ensure!(
+            version == VERSION,
+            "Unsupported filtered_ebg version {version}, expected {VERSION}",
+        );
+        anyhow::ensure!(
+            (header[6] as usize) < crate::profile_abi::MAX_MODES,
+            "Invalid mode in filtered_ebg: {}",
+            header[6]
+        );
+        let mode = Mode(header[6]);
+
+        let n_filtered_nodes = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
+        let n_filtered_arcs = u64::from_le_bytes([
+            header[12], header[13], header[14], header[15], header[16], header[17], header[18],
+            header[19],
+        ]);
+        let n_original_nodes = u32::from_le_bytes([header[20], header[21], header[22], header[23]]);
+        let mut inputs_sha = [0u8; 32];
+        inputs_sha.copy_from_slice(&header[24..56]);
+
+        let n_filt = n_filtered_nodes as usize;
+        let n_orig = n_original_nodes as usize;
+        let n_arcs = usize::try_from(n_filtered_arcs)
+            .map_err(|_| anyhow::anyhow!("filtered_ebg n_arcs > usize::MAX"))?;
+
+        let offsets_bytes = (n_filt + 1)
+            .checked_mul(8)
+            .ok_or_else(|| anyhow::anyhow!("filtered_ebg offsets size overflow"))?;
+        let heads_bytes = n_arcs
+            .checked_mul(4)
+            .ok_or_else(|| anyhow::anyhow!("filtered_ebg heads size overflow"))?;
+        let oai_bytes = heads_bytes;
+        let f2o_bytes = n_filt
+            .checked_mul(4)
+            .ok_or_else(|| anyhow::anyhow!("filtered_ebg f2o size overflow"))?;
+        let o2f_bytes = n_orig
+            .checked_mul(4)
+            .ok_or_else(|| anyhow::anyhow!("filtered_ebg o2f size overflow"))?;
+
+        let off_start = HEADER_LEN;
+        let off_end = off_start + offsets_bytes;
+        let heads_end = off_end + heads_bytes;
+        let oai_end = heads_end + oai_bytes;
+        let f2o_end = oai_end + f2o_bytes;
+        let o2f_end = f2o_end + o2f_bytes;
+        anyhow::ensure!(
+            bytes.len() == o2f_end + FOOTER_LEN,
+            "filtered_ebg length mismatch: declared {}, expected body+footer {}",
+            bytes.len(),
+            o2f_end + FOOTER_LEN
+        );
+
+        let offsets: &'static [u64] = bytemuck::cast_slice(&bytes[off_start..off_end]);
+        let heads: &'static [u32] = bytemuck::cast_slice(&bytes[off_end..heads_end]);
+        let original_arc_idx: &'static [u32] = bytemuck::cast_slice(&bytes[heads_end..oai_end]);
+        let filtered_to_original: &'static [u32] = bytemuck::cast_slice(&bytes[oai_end..f2o_end]);
+        let original_to_filtered: &'static [u32] = bytemuck::cast_slice(&bytes[f2o_end..o2f_end]);
+
+        // CRC over header + body
+        let mut crc_digest = crc::Digest::new();
+        crc_digest.update(header);
+        crc_digest.update(&bytes[off_start..o2f_end]);
+        let computed = crc_digest.finalize();
+        let footer = &bytes[o2f_end..o2f_end + FOOTER_LEN];
+        let stored = u64::from_le_bytes(footer[0..8].try_into().unwrap());
+        anyhow::ensure!(
+            computed == stored,
+            "CRC64 mismatch in filtered_ebg: computed 0x{:016X}, stored 0x{:016X}",
+            computed,
+            stored
+        );
+
+        Ok(FilteredEbg {
+            mode,
+            n_filtered_nodes,
+            n_filtered_arcs,
+            n_original_nodes,
+            inputs_sha,
+            offsets: Cow::Borrowed(offsets),
+            heads: Cow::Borrowed(heads),
+            original_arc_idx: Cow::Borrowed(original_arc_idx),
+            filtered_to_original: Cow::Borrowed(filtered_to_original),
+            original_to_filtered: Cow::Borrowed(original_to_filtered),
         })
     }
 }

--- a/route/src/formats/filtered_ebg.rs
+++ b/route/src/formats/filtered_ebg.rs
@@ -380,6 +380,22 @@ impl FilteredEbgFile {
     /// 64-byte header keeps the offsets u64 array aligned. Every
     /// subsequent u32 array only needs 4-byte alignment.
     pub fn read_from_bytes_zero_copy(bytes: &'static [u8]) -> Result<FilteredEbg> {
+        Self::read_from_bytes_zero_copy_with_cold(bytes).map(|(out, _)| out)
+    }
+
+    /// Zero-copy reader that additionally returns the byte range of
+    /// the build-time-only cold prefix (`offsets`, `heads`,
+    /// `original_arc_idx`). Callers (`server/state.rs`) can pass this
+    /// range to `madvise(DONTNEED)` so the cold pages drop from RSS
+    /// — the borrowed Cow slices stay valid; the rare cold consumers
+    /// (build-only validators) page them back at fault cost.
+    ///
+    /// Hot serve-time arrays (`filtered_to_original`,
+    /// `original_to_filtered`) live AFTER the cold prefix and are
+    /// never advised away.
+    pub fn read_from_bytes_zero_copy_with_cold(
+        bytes: &'static [u8],
+    ) -> Result<(FilteredEbg, &'static [u8])> {
         anyhow::ensure!(
             bytes.len() >= HEADER_LEN + FOOTER_LEN,
             "filtered_ebg too short for header+footer: {} bytes",
@@ -472,7 +488,8 @@ impl FilteredEbgFile {
             stored
         );
 
-        Ok(FilteredEbg {
+        let cold = &bytes[off_start..oai_end];
+        let parsed = FilteredEbg {
             mode,
             n_filtered_nodes,
             n_filtered_arcs,
@@ -483,6 +500,7 @@ impl FilteredEbgFile {
             original_arc_idx: Cow::Borrowed(original_arc_idx),
             filtered_to_original: Cow::Borrowed(filtered_to_original),
             original_to_filtered: Cow::Borrowed(original_to_filtered),
-        })
+        };
+        Ok((parsed, cold))
     }
 }

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -18,7 +18,6 @@
 //! - **Version-stamped distances**: Amortized O(1) per-search initialization
 
 use crate::formats::{CchTopo, CchWeights};
-use crate::server::state::DownReverseAdj;
 use std::borrow::Cow;
 use std::cell::RefCell;
 
@@ -1164,7 +1163,6 @@ pub struct BucketM2MStats {
 pub fn table_bucket(
     topo: &CchTopo,
     weights: &CchWeights,
-    _down_rev: &DownReverseAdj,
     sources: &[u32],
     targets: &[u32],
 ) -> (Vec<u32>, BucketM2MStats) {

--- a/route/src/nbg_ch/turn_restrictions.rs
+++ b/route/src/nbg_ch/turn_restrictions.rs
@@ -174,7 +174,7 @@ impl NbgEdgeWayMap {
     pub fn from_ebg_nodes(ebg_nodes: &EbgNodes) -> Self {
         let mut edge_to_way = HashMap::with_capacity(ebg_nodes.n_nodes as usize);
 
-        for node in &ebg_nodes.nodes {
+        for node in ebg_nodes.nodes.iter() {
             // Each EBG node represents a directed NBG edge
             edge_to_way.insert((node.tail_nbg, node.head_nbg), node.primary_way);
         }

--- a/route/src/server/consistency_test.rs
+++ b/route/src/server/consistency_test.rs
@@ -240,7 +240,8 @@ fn test_route_table_distance_consistency() {
             // Get distance via P2P query with distance weights
             let _dist_query = CchQuery::with_custom_weights(
                 &mode_data.cch_topo,
-                &mode_data.down_rev,
+                &mode_data.up_adj_flat,
+                &mode_data.down_rev_flat,
                 // Note: we need distance weights for P2P too
                 // For now, use table result as ground truth
                 &mode_data.cch_weights, // time weights (not ideal, see below)
@@ -756,8 +757,12 @@ fn test_alternative_routes_differ() {
         }
     }
 
-    let alt_query =
-        CchQuery::with_custom_weights(&mode_data.cch_topo, &mode_data.down_rev, &penalized);
+    let alt_query = CchQuery::with_custom_weights(
+        &mode_data.cch_topo,
+        &mode_data.up_adj_flat,
+        &mode_data.down_rev_flat,
+        &penalized,
+    );
 
     let alt = alt_query
         .query(src_rank, dst_rank)
@@ -1364,8 +1369,12 @@ fn test_alternative_routes_all_modes() {
                 }
             }
 
-            let alt_query =
-                CchQuery::with_custom_weights(&mode_data.cch_topo, &mode_data.down_rev, &penalized);
+            let alt_query = CchQuery::with_custom_weights(
+                &mode_data.cch_topo,
+                &mode_data.up_adj_flat,
+                &mode_data.down_rev_flat,
+                &penalized,
+            );
 
             if let Some(alt) = alt_query.query(src_rank, dst_rank) {
                 // Alternative should exist

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -944,7 +944,8 @@ pub fn do_edges_batch(
                 // if the first consumer needs it).
                 let query = super::query::CchQuery::with_custom_weights(
                     &mode_data.cch_topo,
-                    &mode_data.down_rev,
+                    &mode_data.up_adj_flat,
+                    &mode_data.down_rev_flat,
                     &mode_data.cch_weights,
                 );
                 let Some(result) = query.query(src_rank, dst_rank) else {

--- a/route/src/server/map_match.rs
+++ b/route/src/server/map_match.rs
@@ -496,8 +496,12 @@ fn compute_transition_distances(
     let n_to = to.len();
     let mut result = vec![f64::INFINITY; n_from * n_to];
 
-    let query =
-        CchQuery::with_custom_weights(&mode_data.cch_topo, &mode_data.down_rev, cch_weights);
+    let query = CchQuery::with_custom_weights(
+        &mode_data.cch_topo,
+        &mode_data.up_adj_flat,
+        &mode_data.down_rev_flat,
+        cch_weights,
+    );
 
     for (i, from_cand) in from.iter().enumerate() {
         let src_filtered = mode_data.filtered_ebg.original_to_filtered[from_cand.ebg_id as usize];
@@ -620,8 +624,12 @@ fn find_path_between(
     let src_rank = mode_data.order.perm[src_filtered as usize];
     let dst_rank = mode_data.order.perm[dst_filtered as usize];
 
-    let query =
-        CchQuery::with_custom_weights(&mode_data.cch_topo, &mode_data.down_rev, cch_weights);
+    let query = CchQuery::with_custom_weights(
+        &mode_data.cch_topo,
+        &mode_data.up_adj_flat,
+        &mode_data.down_rev_flat,
+        cch_weights,
+    );
     let result = query.query(src_rank, dst_rank)?;
 
     let rank_path = super::unpack::unpack_path(

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -236,12 +236,13 @@ pub async fn serve(
 
     let state = Arc::new(state_owned);
 
-    // #152: emit the final RSS checkpoint just before listeners come
-    // up. By the time `/health` first answers OK every demand-paged
-    // section is paged in once, every spatial index is built, and
-    // every transit table is populated. This is the steady-state
-    // baseline #153/#154/#155 will measure against.
-    crate::server::rss::checkpoint("health.ready");
+    // #152: emit the final RSS checkpoint after every initialization
+    // step is done but before REST/gRPC listeners bind. Every
+    // demand-paged section has been paged in once, every spatial
+    // index is built, and every transit table is populated. This is
+    // the steady-state baseline #153/#154/#155 will measure against,
+    // captured prior to observable readiness on `/health`.
+    crate::server::rss::checkpoint("boot.complete");
 
     // Find free ports
     let http_port = match port {

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -48,6 +48,7 @@ pub mod matching;
 pub mod nearest;
 pub mod query;
 pub mod route;
+pub mod rss;
 pub mod spatial;
 pub mod state;
 pub mod table;
@@ -234,6 +235,13 @@ pub async fn serve(
     }
 
     let state = Arc::new(state_owned);
+
+    // #152: emit the final RSS checkpoint just before listeners come
+    // up. By the time `/health` first answers OK every demand-paged
+    // section is paged in once, every spatial index is built, and
+    // every transit table is populated. This is the steady-state
+    // baseline #153/#154/#155 will measure against.
+    crate::server::rss::checkpoint("health.ready");
 
     // Find free ports
     let http_port = match port {

--- a/route/src/server/query.rs
+++ b/route/src/server/query.rs
@@ -13,77 +13,7 @@ use crate::formats::CchTopo;
 use crate::matrix::bucket_ch::{DownReverseAdjFlat, UpAdjFlat};
 use crate::profile_abi::Mode;
 
-use super::state::{CchWeights, DownReverseAdj, ServerState};
-
-/// Validate backward adjacency invariant:
-/// For every entry in down_rev, the reversed edge must be "upward in reversed graph"
-/// i.e., for DOWN edge x→u (rank[x] >= rank[u]), reversed edge u→x has rank[u] <= rank[x]
-pub fn validate_down_rev(
-    topo: &CchTopo,
-    down_rev: &DownReverseAdj,
-    perm: &[u32],
-) -> Result<(), String> {
-    let n_nodes = topo.n_nodes as usize;
-    let mut violations = 0;
-
-    for u in 0..n_nodes {
-        let start = down_rev.offsets[u] as usize;
-        let end = down_rev.offsets[u + 1] as usize;
-
-        for i in start..end {
-            let x = down_rev.sources[i] as usize;
-            let edge_idx = down_rev.edge_idx[i] as usize;
-
-            // Verify this is a valid DOWN edge x→u
-            let rank_x = perm[x];
-            let rank_u = perm[u];
-
-            // DOWN edge: rank[x] >= rank[u]
-            // Reversed: u→x should be upward (rank[u] <= rank[x])
-            if rank_x < rank_u {
-                violations += 1;
-                if violations <= 5 {
-                    tracing::warn!(
-                        edge_from = x,
-                        edge_to = u,
-                        rank_x,
-                        rank_u,
-                        "down_rev violation: rank_x < rank_u (should be >=)"
-                    );
-                }
-            }
-
-            // Verify edge_idx points to valid DOWN edge
-            if edge_idx >= topo.down_targets.len() {
-                return Err(format!(
-                    "Invalid edge_idx {} >= {}",
-                    edge_idx,
-                    topo.down_targets.len()
-                ));
-            }
-
-            // Verify the target of this DOWN edge is actually u
-            let stored_target = topo.down_targets[edge_idx];
-            if stored_target != u as u32 {
-                violations += 1;
-                if violations <= 5 {
-                    tracing::warn!(
-                        edge_idx,
-                        stored_target,
-                        expected = u,
-                        "down_rev target mismatch"
-                    );
-                }
-            }
-        }
-    }
-
-    if violations > 0 {
-        Err(format!("{} down_rev violations found", violations))
-    } else {
-        Ok(())
-    }
-}
+use super::state::{CchWeights, ServerState};
 
 /// Query result
 #[derive(Debug, Clone)]
@@ -230,26 +160,39 @@ fn reconstruct_path_versioned(
 /// path, which is what makes `madvise(MADV_DONTNEED)` over those byte
 /// ranges actually reclaim RSS.
 ///
-/// `RawWeights` is the cold path used by `with_custom_weights`, i.e.
-/// alternative-route penalties and exclude/avoid recustomizations that
-/// build per-call weight arrays. Those paths do not benefit from the
-/// flat layout (no flats are built for the ephemeral weights) and
-/// running them off raw weights is correct — they just incur the INF
-/// branch in the hot loop.
+/// `CustomWeights` is the cold path used by `with_custom_weights`,
+/// i.e. alternative-route penalties and exclude/avoid recustomizations
+/// that build per-call weight arrays. After #152 it reuses the SAME
+/// `UpAdjFlat`/`DownReverseAdjFlat` topology that the hot path uses —
+/// the flats already carry `topo_edge_idx`, so we look up custom
+/// weights via `weights.up[topo_edge_idx]` / `weights.down[topo_edge_idx]`
+/// and ignore the flat's embedded weights. This eliminates the
+/// duplicate `DownReverseAdj` Vec-of-Vec topology that #149 left
+/// stranded on the heap (~320 MB on Belgium across 4 modes).
+///
+/// The custom-weight loop incurs an INF branch (custom weights may
+/// have INF entries from exclude/avoid recustomization); the hot
+/// path's flats backend has those edges filtered out at build time.
 enum Backend<'a> {
     Flats {
         up_adj_flat: &'a UpAdjFlat,
         down_rev_flat: &'a DownReverseAdjFlat,
     },
-    RawWeights {
+    CustomWeights {
         weights: &'a CchWeights,
-        down_rev: &'a DownReverseAdj,
+        up_adj_flat: &'a UpAdjFlat,
+        down_rev_flat: &'a DownReverseAdjFlat,
     },
 }
 
-/// Bidirectional CCH query
+/// Bidirectional CCH query.
+///
+/// After #152, the query reads its topology entirely through the flats
+/// (`UpAdjFlat` / `DownReverseAdjFlat`); the `CchTopo` reference is no
+/// longer plumbed through this type. Callers that need topology for
+/// non-query work (e.g. unpack) hold their own reference to the same
+/// `cch_topo` they passed when building the flats.
 pub struct CchQuery<'a> {
-    topo: &'a CchTopo,
     backend: Backend<'a>,
     n_nodes: usize,
 }
@@ -258,7 +201,6 @@ impl<'a> CchQuery<'a> {
     pub fn new(state: &'a ServerState, mode: Mode) -> Self {
         let mode_data = state.get_mode(mode);
         Self {
-            topo: &mode_data.cch_topo,
             backend: Backend::Flats {
                 up_adj_flat: &mode_data.up_adj_flat,
                 down_rev_flat: &mode_data.down_rev_flat,
@@ -270,12 +212,14 @@ impl<'a> CchQuery<'a> {
     /// Iterate UP edges out of node `u`, yielding (target, weight, parent_edge_idx).
     ///
     /// `parent_edge_idx` is whatever the unpack code expects in
-    /// `state.parent_fwd[v].1` — under the flats backend that's the topo
-    /// edge index recovered via `up_adj_flat.topo_edge_idx[slot]`, under
-    /// the raw backend that's the topo edge index `i` itself.
+    /// `state.parent_fwd[v].1` — the topo edge index recovered via
+    /// the flat's `topo_edge_idx[slot]`.
     ///
-    /// The flats backend never yields INF entries (filtered at build);
-    /// the raw backend filters inline.
+    /// The `Flats` backend never yields INF entries (filtered at
+    /// build time). The `CustomWeights` backend reuses the same flat
+    /// topology but reads weights from the caller-supplied
+    /// `CchWeights`, which can carry INF entries from exclude/avoid
+    /// recustomization — those are filtered inline.
     #[inline]
     fn for_up_edges<F: FnMut(u32, u32, u32)>(&self, u: u32, mut f: F) {
         match &self.backend {
@@ -289,16 +233,21 @@ impl<'a> CchQuery<'a> {
                     f(v, w, parent_idx);
                 }
             }
-            Backend::RawWeights { weights, .. } => {
-                let start = self.topo.up_offsets[u as usize] as usize;
-                let end = self.topo.up_offsets[u as usize + 1] as usize;
-                for i in start..end {
-                    let w = weights.up[i];
+            Backend::CustomWeights {
+                weights,
+                up_adj_flat,
+                ..
+            } => {
+                let start = up_adj_flat.offsets[u as usize] as usize;
+                let end = up_adj_flat.offsets[u as usize + 1] as usize;
+                for slot in start..end {
+                    let parent_idx = up_adj_flat.topo_edge_idx[slot];
+                    let w = weights.up[parent_idx as usize];
                     if w == u32::MAX {
                         continue;
                     }
-                    let v = self.topo.up_targets[i];
-                    f(v, w, i as u32);
+                    let v = up_adj_flat.targets[slot];
+                    f(v, w, parent_idx);
                 }
             }
         }
@@ -319,36 +268,55 @@ impl<'a> CchQuery<'a> {
                     f(x, w, parent_idx);
                 }
             }
-            Backend::RawWeights { weights, down_rev } => {
-                let start = down_rev.offsets[u as usize] as usize;
-                let end = down_rev.offsets[u as usize + 1] as usize;
-                for i in start..end {
-                    let x = down_rev.sources[i];
-                    let edge_idx = down_rev.edge_idx[i] as usize;
-                    let w = weights.down[edge_idx];
+            Backend::CustomWeights {
+                weights,
+                down_rev_flat,
+                ..
+            } => {
+                let start = down_rev_flat.offsets[u as usize] as usize;
+                let end = down_rev_flat.offsets[u as usize + 1] as usize;
+                for slot in start..end {
+                    let parent_idx = down_rev_flat.topo_edge_idx[slot];
+                    let w = weights.down[parent_idx as usize];
                     if w == u32::MAX {
                         continue;
                     }
-                    f(x, w, edge_idx as u32);
+                    let x = down_rev_flat.sources[slot];
+                    f(x, w, parent_idx);
                 }
             }
         }
     }
 
-    /// Create a query with custom weights (for alternative routes with penalties).
+    /// Create a query with custom weights (for alternative routes with
+    /// penalties, exclude/avoid recustomization, transit access/egress).
     ///
-    /// Cold path. Reads weights through the legacy `CchWeights` +
-    /// `DownReverseAdj` shape (with the INF branch in the hot loop).
-    /// New code on the routing hot path should go through `new()` /
-    /// the flats backend instead.
+    /// Cold path. Reuses the same flat topology that the hot path
+    /// uses (see #152) — `up_adj_flat` and `down_rev_flat` provide
+    /// `topo_edge_idx`, which is the index into the caller-supplied
+    /// `weights.up` / `weights.down`. The flat's embedded weights are
+    /// not read in this backend; only its topology is.
+    ///
+    /// Caller invariant: the custom `weights` are derived from the same
+    /// time metric as the flat (i.e. INF entries in `weights` are a
+    /// superset of INF entries in the flat's source). Every current
+    /// caller satisfies this — exclude/avoid only add INF, multiplicative
+    /// alternative-route penalties keep INF as INF (`saturating_mul`),
+    /// and the unmodified `cch_weights` paths are bytewise the flat's
+    /// source. This invariant is upheld by construction; we filter INF
+    /// entries inline in the hot loop as a defensive measure.
     pub fn with_custom_weights(
         topo: &'a CchTopo,
-        down_rev: &'a DownReverseAdj,
+        up_adj_flat: &'a UpAdjFlat,
+        down_rev_flat: &'a DownReverseAdjFlat,
         weights: &'a CchWeights,
     ) -> Self {
         Self {
-            topo,
-            backend: Backend::RawWeights { weights, down_rev },
+            backend: Backend::CustomWeights {
+                weights,
+                up_adj_flat,
+                down_rev_flat,
+            },
             n_nodes: topo.n_nodes as usize,
         }
     }
@@ -731,7 +699,7 @@ mod tests {
     ///     2 → 1 (w=3)
     ///     3 → 2 (w=7)
     ///     4 → 2 (w=5)
-    fn build_test_cch() -> (CchTopo, CchWeights, DownReverseAdj) {
+    fn build_test_cch() -> (CchTopo, CchWeights, UpAdjFlat, DownReverseAdjFlat) {
         let n_nodes = 5u32;
 
         let up_offsets = vec![0u64, 1, 2, 4, 4, 4];
@@ -769,27 +737,17 @@ mod tests {
             down_middle: vec![].into(),
         };
 
-        // Build DownReverseAdj from topo
-        // DOWN edges: 2→0 (idx=0), 2→1 (idx=1), 3→2 (idx=2), 4→2 (idx=3)
-        // Reversed (target → sources):
-        //   node 0: incoming from 2 (edge_idx=0)
-        //   node 1: incoming from 2 (edge_idx=1)
-        //   node 2: incoming from 3 (edge_idx=2), 4 (edge_idx=3)
-        //   node 3: none
-        //   node 4: none
-        let down_rev = DownReverseAdj {
-            offsets: vec![0u64, 1, 2, 4, 4, 4],
-            sources: vec![2u32, 2, 3, 4],
-            edge_idx: vec![0u32, 1, 2, 3],
-        };
+        // Build flats with topo_edge_idx populated (CchQuery hot path).
+        let up_adj_flat = UpAdjFlat::build_with(&topo, &weights, true);
+        let down_rev_flat = DownReverseAdjFlat::build_with(&topo, &weights, true);
 
-        (topo, weights, down_rev)
+        (topo, weights, up_adj_flat, down_rev_flat)
     }
 
     #[test]
     fn test_same_node_query() {
-        let (topo, weights, down_rev) = build_test_cch();
-        let query = CchQuery::with_custom_weights(&topo, &down_rev, &weights);
+        let (topo, weights, up_flat, down_rev_flat) = build_test_cch();
+        let query = CchQuery::with_custom_weights(&topo, &up_flat, &down_rev_flat, &weights);
 
         let result = query.query(0, 0).expect("same-node query should succeed");
         assert_eq!(result.distance, 0);
@@ -800,8 +758,8 @@ mod tests {
 
     #[test]
     fn test_basic_shortest_path() {
-        let (topo, weights, down_rev) = build_test_cch();
-        let query = CchQuery::with_custom_weights(&topo, &down_rev, &weights);
+        let (topo, weights, up_flat, down_rev_flat) = build_test_cch();
+        let query = CchQuery::with_custom_weights(&topo, &up_flat, &down_rev_flat, &weights);
 
         // Path 0 → 1: 0→UP→2→DOWN→1, cost = 10 + 3 = 13
         let result = query.query(0, 1).expect("path should exist");
@@ -818,8 +776,8 @@ mod tests {
 
     #[test]
     fn test_multi_hop_path() {
-        let (topo, weights, down_rev) = build_test_cch();
-        let query = CchQuery::with_custom_weights(&topo, &down_rev, &weights);
+        let (topo, weights, up_flat, down_rev_flat) = build_test_cch();
+        let query = CchQuery::with_custom_weights(&topo, &up_flat, &down_rev_flat, &weights);
 
         // Path 0 → 3: 0→UP→2→UP→3, cost = 10 + 7 = 17
         let result = query.query(0, 3).expect("path should exist");
@@ -838,8 +796,8 @@ mod tests {
     fn test_thread_local_state_reuse() {
         // Run many queries to verify thread-local state is correctly reused
         // across queries (generation stamping doesn't leak stale data)
-        let (topo, weights, down_rev) = build_test_cch();
-        let query = CchQuery::with_custom_weights(&topo, &down_rev, &weights);
+        let (topo, weights, up_flat, down_rev_flat) = build_test_cch();
+        let query = CchQuery::with_custom_weights(&topo, &up_flat, &down_rev_flat, &weights);
 
         for _ in 0..100 {
             assert_eq!(query.query(0, 1).unwrap().distance, 13);
@@ -922,13 +880,10 @@ mod tests {
             down_middle: vec![].into(),
         };
 
-        let down_rev = DownReverseAdj {
-            offsets: vec![0u64, 1, 2, 2, 3, 4, 4],
-            sources: vec![2u32, 2, 5, 5],
-            edge_idx: vec![0u32, 1, 2, 3],
-        };
+        let up_flat = UpAdjFlat::build_with(&topo, &weights, true);
+        let down_rev_flat = DownReverseAdjFlat::build_with(&topo, &weights, true);
 
-        let query = CchQuery::with_custom_weights(&topo, &down_rev, &weights);
+        let query = CchQuery::with_custom_weights(&topo, &up_flat, &down_rev_flat, &weights);
 
         // Same component works
         assert_eq!(query.query(0, 1).unwrap().distance, 13);

--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -566,9 +566,19 @@ pub async fn route_handler(
         None // avoid_result already incorporates exclude
     };
     let query = if let Some((ref time_weights, _)) = avoid_result {
-        CchQuery::with_custom_weights(&mode_data.cch_topo, &mode_data.down_rev, time_weights)
+        CchQuery::with_custom_weights(
+            &mode_data.cch_topo,
+            &mode_data.up_adj_flat,
+            &mode_data.down_rev_flat,
+            time_weights,
+        )
     } else if let Some(ref ew) = exclude_weights {
-        CchQuery::with_custom_weights(&mode_data.cch_topo, &mode_data.down_rev, &ew.time_weights)
+        CchQuery::with_custom_weights(
+            &mode_data.cch_topo,
+            &mode_data.up_adj_flat,
+            &mode_data.down_rev_flat,
+            &ew.time_weights,
+        )
     } else {
         CchQuery::new(&state, mode)
     };
@@ -696,7 +706,8 @@ pub async fn route_handler(
         for _alt_idx in 0..num_alternatives {
             let alt_query = CchQuery::with_custom_weights(
                 &mode_data.cch_topo,
-                &mode_data.down_rev,
+                &mode_data.up_adj_flat,
+                &mode_data.down_rev_flat,
                 &penalized_weights,
             );
 

--- a/route/src/server/rss.rs
+++ b/route/src/server/rss.rs
@@ -1,10 +1,11 @@
 //! RSS-checkpoint instrumentation (#152).
 //!
 //! Reads `/proc/self/smaps_rollup` (preferred — more accurate than
-//! `/proc/self/status` because it walks the process VMAs and gives a
-//! per-mapping breakdown) and emits a `tracing::info!` line tagged
-//! `RSS_CHECKPOINT` at every boot phase. Disabled by default; turned
-//! on by `--rss-checkpoints` or `BUTTERFLY_RSS_CHECKPOINTS=1`.
+//! `/proc/self/status` because it walks the process VMAs and aggregates
+//! the rollup fields, including the anon/file-backed RSS split we care
+//! about) and emits a `tracing::info!` line tagged `RSS_CHECKPOINT` at
+//! every boot phase. Disabled by default; turned on by
+//! `--rss-checkpoints` or `BUTTERFLY_RSS_CHECKPOINTS=1`.
 //!
 //! The lines are deterministic and grep-friendly:
 //!
@@ -16,9 +17,10 @@
 //! the #153/#154/#155 measurement discipline. It is NOT a one-shot
 //! diagnostic.
 //!
-//! `ps -o rss` is explicitly NOT used — codex flagged it: it reports
-//! the resident size at fork time, not the smaps-rollup post-mmap
-//! steady state we care about.
+//! `ps -o rss` is explicitly NOT used — codex flagged it: it only
+//! exposes a coarse current RSS value, whereas `smaps_rollup` provides
+//! the rollup fields and the anon/file-backed breakdown we need for
+//! post-mmap steady-state measurement.
 
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/route/src/server/rss.rs
+++ b/route/src/server/rss.rs
@@ -1,0 +1,169 @@
+//! RSS-checkpoint instrumentation (#152).
+//!
+//! Reads `/proc/self/smaps_rollup` (preferred — more accurate than
+//! `/proc/self/status` because it walks the process VMAs and gives a
+//! per-mapping breakdown) and emits a `tracing::info!` line tagged
+//! `RSS_CHECKPOINT` at every boot phase. Disabled by default; turned
+//! on by `--rss-checkpoints` or `BUTTERFLY_RSS_CHECKPOINTS=1`.
+//!
+//! The lines are deterministic and grep-friendly:
+//!
+//! ```text
+//! RSS_CHECKPOINT phase=load.shared total_kb=4012345 anon_kb=234567 file_kb=3777778 elapsed_s=1.234
+//! ```
+//!
+//! This instrumentation stays in the codebase as the foundation for
+//! the #153/#154/#155 measurement discipline. It is NOT a one-shot
+//! diagnostic.
+//!
+//! `ps -o rss` is explicitly NOT used — codex flagged it: it reports
+//! the resident size at fork time, not the smaps-rollup post-mmap
+//! steady state we care about.
+
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static START: OnceLock<Instant> = OnceLock::new();
+
+/// Turn the instrumentation on. Idempotent. Safe to call from any
+/// thread.
+pub fn set_enabled(enabled: bool) {
+    ENABLED.store(enabled, Ordering::Relaxed);
+    let _ = START.set(Instant::now());
+}
+
+/// Returns true iff `set_enabled(true)` has been called. Cheap to
+/// poll on the boot path so the checkpoint helper short-circuits when
+/// the operator hasn't asked for instrumentation.
+pub fn is_enabled() -> bool {
+    ENABLED.load(Ordering::Relaxed)
+}
+
+/// Sample `/proc/self/smaps_rollup` and emit one
+/// `RSS_CHECKPOINT phase=<phase> total_kb=N anon_kb=M file_kb=K
+/// elapsed_s=Z` line at `tracing::info!` level.
+///
+/// No-op when [`is_enabled`] returns false.
+pub fn checkpoint(phase: &str) {
+    if !is_enabled() {
+        return;
+    }
+    let elapsed_s = START
+        .get()
+        .map(|t| t.elapsed().as_secs_f64())
+        .unwrap_or(0.0);
+    match read_smaps_rollup() {
+        Ok(rss) => {
+            tracing::info!(
+                target: "rss_checkpoint",
+                phase = phase,
+                total_kb = rss.rss_kb,
+                anon_kb = rss.anon_kb,
+                file_kb = rss.file_kb,
+                elapsed_s = format!("{elapsed_s:.3}"),
+                "RSS_CHECKPOINT phase={phase} total_kb={t} anon_kb={a} file_kb={f} elapsed_s={elapsed_s:.3}",
+                t = rss.rss_kb,
+                a = rss.anon_kb,
+                f = rss.file_kb,
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                phase = phase,
+                error = %e,
+                "RSS_CHECKPOINT failed to read smaps_rollup"
+            );
+        }
+    }
+}
+
+/// Parsed smaps_rollup snapshot. All values in kibibytes (the units
+/// that `/proc/.../smaps_rollup` reports natively).
+#[derive(Debug, Clone, Copy)]
+pub struct RssSnapshot {
+    /// `Rss:` — total resident set size.
+    pub rss_kb: u64,
+    /// `Rss_anon` style: `Anonymous:` — heap + dirty COW pages. The
+    /// architecture KPI for #152.
+    pub anon_kb: u64,
+    /// File-backed resident bytes. Computed as `rss - anon`. Matches
+    /// the file-backed mmap pages (`butterfly.dat` content paged in
+    /// by demand).
+    pub file_kb: u64,
+}
+
+/// Read `/proc/self/smaps_rollup`. Returns the three KPI fields.
+///
+/// Public so handlers can sample without going through the
+/// checkpoint logging path (e.g. /metrics endpoint extension).
+pub fn read_smaps_rollup() -> std::io::Result<RssSnapshot> {
+    let s = std::fs::read_to_string("/proc/self/smaps_rollup")?;
+    let mut rss_kb = 0u64;
+    let mut anon_kb = 0u64;
+    for line in s.lines() {
+        if let Some(rest) = line.strip_prefix("Rss:") {
+            rss_kb = parse_kb_field(rest);
+        } else if let Some(rest) = line.strip_prefix("Anonymous:") {
+            anon_kb = parse_kb_field(rest);
+        }
+    }
+    let file_kb = rss_kb.saturating_sub(anon_kb);
+    Ok(RssSnapshot {
+        rss_kb,
+        anon_kb,
+        file_kb,
+    })
+}
+
+/// Parse a `/proc` field tail like `"   1234 kB"` or `" 1234 kB"`
+/// to `1234`. Tolerates leading whitespace and trailing unit token.
+fn parse_kb_field(tail: &str) -> u64 {
+    for tok in tail.split_whitespace() {
+        if let Ok(v) = tok.parse::<u64>() {
+            return v;
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_kb_field_handles_typical_format() {
+        assert_eq!(parse_kb_field("        1234 kB"), 1234);
+        assert_eq!(parse_kb_field("0 kB"), 0);
+        assert_eq!(parse_kb_field("   42 kB"), 42);
+    }
+
+    #[test]
+    fn read_smaps_rollup_returns_nonzero_on_linux() {
+        // smaps_rollup exists on every modern Linux kernel; this
+        // test runs in CI on Linux only. On non-Linux the file
+        // doesn't exist and we'd get an error, but the test target
+        // is Linux for this workspace anyway.
+        if std::path::Path::new("/proc/self/smaps_rollup").exists() {
+            let snap = read_smaps_rollup().expect("smaps_rollup readable");
+            assert!(snap.rss_kb > 0, "RSS should be > 0 for live process");
+            assert!(
+                snap.anon_kb <= snap.rss_kb,
+                "anon ({}) must not exceed RSS ({})",
+                snap.anon_kb,
+                snap.rss_kb
+            );
+        }
+    }
+
+    #[test]
+    fn checkpoint_is_noop_when_disabled() {
+        // The default state is disabled; calling checkpoint should
+        // not panic and should produce no output observable here.
+        // We don't assert log absence (that requires a tracing
+        // subscriber test harness), but we assert no panic.
+        ENABLED.store(false, Ordering::Relaxed);
+        checkpoint("test_disabled");
+    }
+}

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -207,6 +207,8 @@ impl ServerState {
         let mut mode_names = Vec::with_capacity(discovered_modes.len());
         let mut mode_lookup = HashMap::with_capacity(discovered_modes.len());
 
+        crate::server::rss::checkpoint("load.shared");
+
         for (mode_index, mode_name) in discovered_modes.iter().enumerate() {
             // Use GLOBAL index (from full alphabetical discovery) — must match step 4/5 indexing
             let mode = Mode(global_index[mode_name]);
@@ -223,11 +225,13 @@ impl ServerState {
             modes_data.push(mode_data);
             mode_lookup.insert(mode_name.clone(), mode_index as u8);
             mode_names.push(mode_name.clone());
+            crate::server::rss::checkpoint(&format!("load.mode.{}", mode_name));
         }
 
         tracing::info!("Building spatial index...");
         let spatial_index = SpatialIndex::build(&ebg_nodes, &nbg_geo);
         tracing::info!(nodes = ebg_nodes.n_nodes, "built spatial index");
+        crate::server::rss::checkpoint("spatial.global");
 
         // Per-mode spatial indexes: one R-tree per loaded mode,
         // pre-filtered to that mode's accessible nodes. Built once at
@@ -246,6 +250,7 @@ impl ServerState {
                 "built per-mode spatial index"
             );
             mode_spatial_indexes.insert(mode_index as u8, idx);
+            crate::server::rss::checkpoint(&format!("spatial.mode.{}", mode_names[mode_index]));
         }
 
         // Load road names from ways.raw for turn-by-turn instructions
@@ -384,14 +389,37 @@ impl ServerState {
         // numeric arrays (`nodes`, `offsets`, `heads`, `turn_idx`)
         // borrow straight from the mmap, so we save ~250 MB of heap
         // on Belgium that the legacy owning-Vec readers used to copy.
+        crate::server::rss::checkpoint("load.container.opened");
+
         tracing::info!("Loading EBG nodes (zero-copy)...");
         let ebg_nodes =
             EbgNodesFile::read_from_bytes_zero_copy(section_bytes("shared/ebg.nodes")?)?;
         tracing::info!(nodes = ebg_nodes.n_nodes, "loaded EBG nodes");
 
         tracing::info!("Loading EBG CSR (zero-copy)...");
-        let ebg_csr = EbgCsrFile::read_from_bytes_zero_copy(section_bytes("shared/ebg.csr")?)?;
+        let ebg_csr_section = section_bytes("shared/ebg.csr")?;
+        let ebg_csr = EbgCsrFile::read_from_bytes_zero_copy(ebg_csr_section)?;
         tracing::info!(arcs = ebg_csr.n_arcs, "loaded EBG CSR");
+        // #152: ebg.csr is build/validate-only at serve time. The only
+        // field any handler reads is `n_arcs` (a u64 in the header used
+        // by /health). The body arrays (offsets, heads, turn_idx) are
+        // touched by validate/step4 + ordering/contraction, none of
+        // which run on the serve path. Drop the file pages from RSS;
+        // the borrowed Cow slices stay valid and a rare cold reader
+        // pages them back at fault cost.
+        if let Err(e) = crate::formats::mmap::madvise_dontneed(ebg_csr_section) {
+            tracing::warn!(
+                section = "shared/ebg.csr",
+                error = %e,
+                "madvise(DONTNEED) on ebg.csr failed; ignoring"
+            );
+        } else {
+            tracing::info!(
+                section = "shared/ebg.csr",
+                bytes = ebg_csr_section.len(),
+                "madvise(DONTNEED) on cold ebg.csr section"
+            );
+        }
 
         tracing::info!("Loading NBG geo...");
         let nbg_geo = NbgGeoFile::read_from_bytes(section_bytes("shared/nbg.geo")?)?;
@@ -437,6 +465,8 @@ impl ServerState {
         }
         tracing::info!(modes = ?discovered_modes, "discovered transport modes");
 
+        crate::server::rss::checkpoint("load.shared");
+
         // ---- Per-mode bundle load -----------------------------------
         let mut modes_data = Vec::with_capacity(discovered_modes.len());
         let mut mode_names = Vec::with_capacity(discovered_modes.len());
@@ -455,17 +485,20 @@ impl ServerState {
             modes_data.push(mode_data);
             mode_lookup.insert(mode_name.clone(), mode_index as u8);
             mode_names.push(mode_name.clone());
+            crate::server::rss::checkpoint(&format!("load.mode.{}", mode_name));
         }
 
         // ---- Spatial indexes ----------------------------------------
         tracing::info!("Building spatial index...");
         let spatial_index = SpatialIndex::build(&ebg_nodes, &nbg_geo);
+        crate::server::rss::checkpoint("spatial.global");
 
         let mut mode_spatial_indexes: HashMap<u8, SpatialIndex> =
             HashMap::with_capacity(modes_data.len());
         for (mode_index, mode_data) in modes_data.iter().enumerate() {
             let idx = SpatialIndex::build_filtered(&ebg_nodes, &nbg_geo, &mode_data.mask);
             mode_spatial_indexes.insert(mode_index as u8, idx);
+            crate::server::rss::checkpoint(&format!("spatial.mode.{}", mode_names[mode_index]));
         }
 
         // #149: Now that every mode's flat adjacencies are built, hint
@@ -912,7 +945,28 @@ fn load_mode_data_from_bundle(
 
     // #152: zero-copy filtered_ebg — borrows arrays from the mmap
     // instead of copying ~80 MB/mode of CSR data into the heap.
-    let filtered_ebg = FilteredEbgFile::read_from_bytes_zero_copy(fetch("filtered_ebg")?)?;
+    // The reader returns the cold-after-parse byte range (offsets +
+    // heads + original_arc_idx) which we madvise(DONTNEED) right
+    // away: those arrays are build-time-only, none of the serve-path
+    // code reads them. Hot mappings (filtered_to_original /
+    // original_to_filtered) live after the cold prefix and stay
+    // resident on demand.
+    let filtered_section = fetch("filtered_ebg")?;
+    let (filtered_ebg, cold_filtered) =
+        FilteredEbgFile::read_from_bytes_zero_copy_with_cold(filtered_section)?;
+    if let Err(e) = crate::formats::mmap::madvise_dontneed(cold_filtered) {
+        tracing::warn!(
+            mode = mode_name,
+            error = %e,
+            "madvise(DONTNEED) on filtered_ebg cold prefix failed; ignoring"
+        );
+    } else {
+        tracing::info!(
+            mode = mode_name,
+            bytes = cold_filtered.len(),
+            "madvise(DONTNEED) on filtered_ebg cold prefix"
+        );
+    }
     let order = OrderEbgFile::read_from_bytes(fetch("order")?)?;
     let topo_section_bytes: &'static [u8] = fetch("topo")?;
     // #151: cch.topo is now v4. Header is 80 bytes (u64-aligned) and

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -380,12 +380,17 @@ impl ServerState {
         };
 
         // ---- Shared graph tables ------------------------------------
-        tracing::info!("Loading EBG nodes...");
-        let ebg_nodes = EbgNodesFile::read_from_bytes(section_bytes("shared/ebg.nodes")?)?;
+        // #152: ebg.nodes / ebg.csr are now read zero-copy. The
+        // numeric arrays (`nodes`, `offsets`, `heads`, `turn_idx`)
+        // borrow straight from the mmap, so we save ~250 MB of heap
+        // on Belgium that the legacy owning-Vec readers used to copy.
+        tracing::info!("Loading EBG nodes (zero-copy)...");
+        let ebg_nodes =
+            EbgNodesFile::read_from_bytes_zero_copy(section_bytes("shared/ebg.nodes")?)?;
         tracing::info!(nodes = ebg_nodes.n_nodes, "loaded EBG nodes");
 
-        tracing::info!("Loading EBG CSR...");
-        let ebg_csr = EbgCsrFile::read_from_bytes(section_bytes("shared/ebg.csr")?)?;
+        tracing::info!("Loading EBG CSR (zero-copy)...");
+        let ebg_csr = EbgCsrFile::read_from_bytes_zero_copy(section_bytes("shared/ebg.csr")?)?;
         tracing::info!(arcs = ebg_csr.n_arcs, "loaded EBG CSR");
 
         tracing::info!("Loading NBG geo...");
@@ -732,7 +737,7 @@ fn load_mode_data(
     let mask = {
         let n_words = n_original.div_ceil(64);
         let mut m = vec![0u64; n_words];
-        for &orig_id in &filtered_ebg.filtered_to_original {
+        for &orig_id in filtered_ebg.filtered_to_original.iter() {
             let word = orig_id as usize / 64;
             let bit = orig_id as usize % 64;
             m[word] |= 1u64 << bit;
@@ -905,7 +910,9 @@ fn load_mode_data_from_bundle(
         Ok(&static_bytes[off..off + len])
     };
 
-    let filtered_ebg = FilteredEbgFile::read_from_bytes(fetch("filtered_ebg")?)?;
+    // #152: zero-copy filtered_ebg — borrows arrays from the mmap
+    // instead of copying ~80 MB/mode of CSR data into the heap.
+    let filtered_ebg = FilteredEbgFile::read_from_bytes_zero_copy(fetch("filtered_ebg")?)?;
     let order = OrderEbgFile::read_from_bytes(fetch("order")?)?;
     let topo_section_bytes: &'static [u8] = fetch("topo")?;
     // #151: cch.topo is now v4. Header is 80 bytes (u64-aligned) and
@@ -941,7 +948,7 @@ fn load_mode_data_from_bundle(
     let mask = {
         let n_words = n_original.div_ceil(64);
         let mut m = vec![0u64; n_words];
-        for &orig_id in &filtered_ebg.filtered_to_original {
+        for &orig_id in filtered_ebg.filtered_to_original.iter() {
             let word = orig_id as usize / 64;
             let bit = orig_id as usize % 64;
             m[word] |= 1u64 << bit;

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -31,7 +31,6 @@ pub struct ModeData {
     // CCH hierarchy for this mode
     pub cch_topo: CchTopo,
     pub order: OrderEbg,
-    pub down_rev: DownReverseAdj,
     pub cch_weights: CchWeights,
     pub cch_weights_dist: CchWeights,
     // Filtered EBG for node ID mapping
@@ -40,6 +39,14 @@ pub struct ModeData {
     pub node_weights: Vec<u32>,
     pub mask: Vec<u64>,
     // Flat adjacencies for bucket M2M - TIME metric (pre-built for performance)
+    //
+    // After #152, the time flats also serve as the topology back-end for
+    // the cold custom-weight `CchQuery` path (alternatives, exclude/avoid,
+    // transit access/egress, map matching). They carry `topo_edge_idx`,
+    // which custom callers use to index their per-call `CchWeights.up` /
+    // `CchWeights.down` arrays. The legacy `DownReverseAdj` Vec-of-Vec
+    // that previously lived here is gone (~320 MB heap reclaimed on
+    // Belgium across 4 modes).
     pub up_adj_flat: UpAdjFlat,
     pub down_rev_flat: DownReverseAdjFlat,
     /// Forward DOWN flat (TIME metric). Used by the isochrone forward
@@ -57,15 +64,6 @@ pub struct ModeData {
 }
 
 // CchWeights is imported from crate::formats
-
-/// Reverse adjacency for DOWN edges (used in backward search)
-/// For each node y, stores all nodes x that have DOWN edges x→y
-/// along with the original edge index (to look up weights)
-pub struct DownReverseAdj {
-    pub offsets: Vec<u64>,  // n_nodes + 1
-    pub sources: Vec<u32>,  // source node x for reverse edge
-    pub edge_idx: Vec<u32>, // index into down_targets/down_weights for the original x→y edge
-}
 
 /// Server state containing all loaded data
 pub struct ServerState {
@@ -723,9 +721,6 @@ fn load_mode_data(
     let topo_path = step7_dir.join(format!("cch.{}.topo", mode_name));
     let cch_topo = CchTopoFile::read(&topo_path)?;
 
-    // Build reverse DOWN adjacency for this mode's CCH
-    let down_rev = build_down_reverse_adj(&cch_topo);
-
     // Load node weights from step 5 (indexed by original EBG node ID)
     let weights_path = step5_dir.join(format!("w.{}.u32", mode_name));
     let weights_data = mod_weights::read_all(&weights_path)?;
@@ -768,7 +763,6 @@ fn load_mode_data(
         mode,
         cch_topo,
         order,
-        down_rev,
         cch_weights,
         cch_weights_dist,
         filtered_ebg,
@@ -782,57 +776,6 @@ fn load_mode_data(
         down_adj_flat_dist,
         exclude_cache: parking_lot::RwLock::new(HashMap::new()),
     })
-}
-
-/// Load CCH weights from file
-/// Build reverse adjacency for DOWN edges
-/// For each node y, we want to find all edges x→y in the DOWN graph
-/// This allows backward search to iterate over incoming edges efficiently
-fn build_down_reverse_adj(topo: &CchTopo) -> DownReverseAdj {
-    let n_nodes = topo.n_nodes as usize;
-    let n_down = topo.down_targets.len();
-
-    // First pass: count incoming edges per node
-    let mut counts = vec![0usize; n_nodes];
-    for &target in topo.down_targets.iter() {
-        counts[target as usize] += 1;
-    }
-
-    // Build offsets
-    let mut offsets = Vec::with_capacity(n_nodes + 1);
-    let mut offset = 0u64;
-    for &count in &counts {
-        offsets.push(offset);
-        offset += count as u64;
-    }
-    offsets.push(offset);
-
-    // Allocate arrays
-    let mut sources = vec![0u32; n_down];
-    let mut edge_idx = vec![0u32; n_down];
-
-    // Second pass: fill in reverse edges
-    // Reset counts to use as position trackers
-    counts.fill(0);
-
-    for source in 0..n_nodes {
-        let start = topo.down_offsets[source] as usize;
-        let end = topo.down_offsets[source + 1] as usize;
-
-        for i in start..end {
-            let target = topo.down_targets[i] as usize;
-            let pos = offsets[target] as usize + counts[target];
-            sources[pos] = source as u32;
-            edge_idx[pos] = i as u32;
-            counts[target] += 1;
-        }
-    }
-
-    DownReverseAdj {
-        offsets,
-        sources,
-        edge_idx,
-    }
 }
 
 /// Load road names from ways.raw (step1 output).
@@ -991,7 +934,6 @@ fn load_mode_data_from_bundle(
             "madvise(DONTNEED) on cch.topo section"
         );
     }
-    let down_rev = build_down_reverse_adj(&cch_topo);
 
     let weights_data = mod_weights::read_all_from_bytes(fetch("node_weights.time")?)?;
 
@@ -1079,7 +1021,6 @@ fn load_mode_data_from_bundle(
         mode,
         cch_topo,
         order,
-        down_rev,
         cch_weights,
         cch_weights_dist,
         filtered_ebg,

--- a/route/src/server/transit_handler.rs
+++ b/route/src/server/transit_handler.rs
@@ -395,7 +395,8 @@ pub fn compute_access_context(
     // thread-local `CCH_QUERY_STATE` with O(1) per-query reset.
     let access_query = CchQuery::with_custom_weights(
         &access_mode_data.cch_topo,
-        &access_mode_data.down_rev,
+        &access_mode_data.up_adj_flat,
+        &access_mode_data.down_rev_flat,
         &access_mode_data.cch_weights,
     );
     let origin_to_stop_ranks: Vec<u32> = origin_ranks.iter().filter_map(|r| *r).collect();
@@ -576,7 +577,8 @@ pub fn compute_transit_journey_with_access(
     // Egress 1-to-N via distance-only CchQuery. K sources × 1 target.
     let egress_query = CchQuery::with_custom_weights(
         &egress_mode_data.cch_topo,
-        &egress_mode_data.down_rev,
+        &egress_mode_data.up_adj_flat,
+        &egress_mode_data.down_rev_flat,
         &egress_mode_data.cch_weights,
     );
     let egress_sources: Vec<u32> = egress_candidates
@@ -1184,7 +1186,8 @@ fn build_routed_road_leg(
     let mode_data = &state.modes[mode_idx as usize];
     let query = CchQuery::with_custom_weights(
         &mode_data.cch_topo,
-        &mode_data.down_rev,
+        &mode_data.up_adj_flat,
+        &mode_data.down_rev_flat,
         &mode_data.cch_weights,
     );
     let result = query.query(src_rank, dst_rank)?;

--- a/route/src/transit/transfers.rs
+++ b/route/src/transit/transfers.rs
@@ -595,13 +595,14 @@ pub fn build_transfer_graph(
     // reference wrapper so construction inside the parallel closure
     // is free.
     let topo = &foot.cch_topo;
-    let down_rev = &foot.down_rev;
+    let up_flat = &foot.up_adj_flat;
+    let down_rev_flat = &foot.down_rev_flat;
     let weights = &foot.cch_weights;
 
     let mut triples: Vec<(u32, u32, u32)> = work
         .par_iter()
         .flat_map_iter(|w| {
-            let query = CchQuery::with_custom_weights(topo, down_rev, weights);
+            let query = CchQuery::with_custom_weights(topo, up_flat, down_rev_flat, weights);
             let mut emitted: Vec<(u32, u32, u32)> = Vec::with_capacity(w.neighbours.len());
             for &(target_stop, target_rank) in &w.neighbours {
                 let Some(raw) = query.distance(w.source_rank, target_rank) else {

--- a/route/src/validate/step4.rs
+++ b/route/src/validate/step4.rs
@@ -222,7 +222,7 @@ fn verify_lock_condition_a_structural(
     }
 
     // Verify heads are in bounds
-    for &head in &ebg_csr.heads {
+    for &head in ebg_csr.heads.iter() {
         anyhow::ensure!(
             head < ebg_csr.n_nodes,
             "CSR head {} out of bounds (n_nodes={})",
@@ -232,7 +232,7 @@ fn verify_lock_condition_a_structural(
     }
 
     // Verify turn_idx are in bounds
-    for &tidx in &ebg_csr.turn_idx {
+    for &tidx in ebg_csr.turn_idx.iter() {
         anyhow::ensure!(
             (tidx as usize) < turn_table.n_entries as usize,
             "CSR turn_idx {} out of bounds (n_entries={})",

--- a/route/tests/transit_integration.rs
+++ b/route/tests/transit_integration.rs
@@ -1807,7 +1807,8 @@ fn belgium_flight_edges_batch_totals_match_matrix() {
     let dst_rank = mode_data.order.perm[dst_filt as usize];
     let query = CchQuery::with_custom_weights(
         &mode_data.cch_topo,
-        &mode_data.down_rev,
+        &mode_data.up_adj_flat,
+        &mode_data.down_rev_flat,
         &mode_data.cch_weights,
     );
     let result = query.query(src_rank, dst_rank).expect("valid CCH query");


### PR DESCRIPTION
## Summary

Closes the #152-redux scope on `cch-topo-v4`:

- **A. Drop `DownReverseAdj`** — the legacy Vec-of-Vec reverse-DOWN topology. Folded the cold custom-weight `CchQuery` path (alternatives, exclude/avoid, transit access/egress, map matching) onto the same `UpAdjFlat` / `DownReverseAdjFlat` that #149/#150 left in heap. The flats already carry `topo_edge_idx`, so the cold path indexes the caller-supplied `CchWeights` through it. ~320 MB heap reclaimed across 4 Belgium modes.
- **B. Zero-copy `ebg.nodes` / `ebg.csr` / `filtered_ebg`** — three new `read_from_bytes_zero_copy` readers built on the same `Cow<'static, [_]>` + `bytemuck::cast_slice` pattern #151 used for `cch.topo`. No format bump (the container's 8-byte section alignment + 64-byte headers already give us the alignment we need). ~520 MB heap reclaimed.
- **C. madvise(DONTNEED)** for cold-after-parse sections: the entire `ebg.csr` body (only `n_arcs` is read at serve time) and the `filtered_ebg` cold prefix (offsets / heads / original_arc_idx — build-time-only). New `read_from_bytes_zero_copy_with_cold` accessor on `FilteredEbgFile` returns the parsed struct + the byte range to advise.
- **D. RSS-checkpoint instrumentation** — new `route/src/server/rss.rs` module reading `/proc/self/smaps_rollup` (NOT `ps -o rss`, codex flagged it). Wired into the boot path with checkpoints at `load.container.opened`, `load.shared`, `load.mode.<name>` per mode, `spatial.global`, `spatial.mode.<name>` per mode, and `health.ready`. Disabled by default; `--rss-checkpoints` or `BUTTERFLY_RSS_CHECKPOINTS=1` turns it on. **This stays in the codebase** as the foundation for #153/#154/#155 measurement.

Headline numbers, Belgium 4 modes, container-mmap path:

| Metric                | cch-topo-v4 baseline | work-152 | Δ           | %     |
|-----------------------|----------------------|----------|-------------|-------|
| Idle Total RSS post-bench | 11.75 GB         | 7.93 GB  | −3.82 GB    | −32 % |
| Idle RssAnon post-bench   |  7.65 GB         | 5.19 GB  | −2.46 GB    | −32 % |

Full BEFORE/AFTER smaps_rollup table, latency, and correctness diff in `route/docs/152-redux-results.md`.

## All 8 acceptance gates pass

| # | Gate                                                  | Threshold | Result |
|---|-------------------------------------------------------|-----------|---------|
| 1 | Idle total RSS, 4 modes, after warmup                 | ≤ 10 GB   | 7.93 GB |
| 2 | Idle RssAnon                                          | ≤ 6.4 GB  | 5.19 GB |
| 3 | 100-route correctness vs cch-topo-v4 baseline         | 0 mismatches | 0 |
| 4 | P50/P90 route latency                                 | ±10 %     | identical |
| 5 | P50/P90 isochrone latency                             | ±10 %     | within ±10 % |
| 6 | clippy --workspace --all-targets --all-features       | green     | green |
| 7 | fmt --check (route crate)                             | green     | green |
| 8 | RSS-checkpoint instrumentation runs in smoke test     | green     | 13 checkpoints emitted |

## Workspace `unsafe_code` policy

Stays `deny`. The carveout remains exactly two sites:
- `Mmap::map` in `formats/mmap.rs::map_readonly` (existing)
- `libc::madvise` in `formats/mmap.rs::madvise_dontneed` (existing — used by parts B/C/D)

No new `unsafe` introduced. `bytemuck` (with `derive` feature added) handles all POD slice reinterpretation in safe code.

## Out of scope (defer)

- **Spatial index serialization** → #154. The `spatial.mode.*` checkpoints in this PR confirm where the remaining ~3 GB anon sits, ready for #154 to attack.
- **Server-only mapping sections** (full `FilteredEbg` + `OrderEbg` loads on serve path) → #153.
- **Geometry flattening** (`nbg.geo` nested vecs) → #155.

## Test plan

- [x] `cargo build --workspace --all-targets` (debug + release)
- [x] `cargo test -p butterfly-route --lib` (373 passed, 0 failed; +3 new RSS tests)
- [x] `cargo clippy --workspace --all-targets --all-features` (green)
- [x] `cargo fmt -p butterfly-route -- --check` (green)
- [x] Belgium smoke test: 30-route warmup + 100 routes + 100 isochrones; checked vs cch-topo-v4 baseline
- [x] RSS-checkpoint stream emits 13 lines on Belgium boot, all parseable
- [x] 100-route output `diff -q` against baseline: identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)