### PR TITLE
feat(dl): multi-country region indexes + source inventory for #96 cross-border clusters

### DIFF
--- a/dl/regions/austria.toml
+++ b/dl/regions/austria.toml
@@ -1,0 +1,31 @@
+# Butterfly region index — Austria
+#
+# OSM PBF for Austria from Geofabrik. butterfly-route consumes this
+# as `austria.pbf` under `data/austria/`; butterfly-geocode (#96)
+# plans to pair it with the BEV Adressregister on the side.
+#
+# Authoritative address dataset (NOT fetched by butterfly-dl yet —
+# tracked separately in geocode-data/SOURCES.md):
+#
+#   Österreichisches Adressregister (BEV)
+#   Landing page:  https://www.data.gv.at/katalog/dataset/adressregister-tagesaktuell
+#   Metadata:      https://data.bev.gv.at/geonetwork/srv/api/records/37d564f9-5d63-4760-aae6-29d3f98ee1b4
+#   Product page:  https://www.bev.gv.at/Services/Produkte/Adressregister/Oesterreichisches-Adressregister.html
+#   Publisher:     Bundesamt für Eich- und Vermessungswesen (BEV)
+#   License:       Creative Commons Attribution 4.0 Austria (CC-BY 4.0 AT)
+#   Format:        Shop-mediated download (zipped CSV + INSPIRE
+#                  GML via WFS); ~2.3 M addresses
+#   Cadence:       continuously updated, full-snapshot quarterly
+#
+# Direct CSV download requires going through the BEV product
+# portal (registration but no fee). The historical OSM-wiki-
+# documented hardcoded CSV URL no longer resolves reliably as of
+# 2026; the geocode importer will go through the WFS or
+# adressregister.at static export at fetch time.
+#
+# No transit feeds in this index — Austrian GTFS (Mobilitätsverbünde
+# Österreich) is per-region and out of scope for the geocode-prep
+# pass.
+
+[pbf]
+url = "https://download.geofabrik.de/europe/austria-latest.osm.pbf"

--- a/dl/regions/france.toml
+++ b/dl/regions/france.toml
@@ -1,0 +1,24 @@
+# Butterfly region index — France
+#
+# OSM PBF for France from Geofabrik. butterfly-route consumes this as
+# `france.pbf` under `data/france/`; butterfly-geocode (#96) plans to
+# pair it with the BAN authoritative address dataset on the side.
+#
+# Authoritative address dataset (NOT fetched by butterfly-dl yet —
+# tracked separately in geocode-data/SOURCES.md, will land once the
+# geocode shard builder is ready):
+#
+#   Base Adresse Nationale (BAN)
+#   National full file: https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/adresses-france.csv.gz
+#   Departmental files: https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/adresses-<dep>.csv.gz
+#   Landing page:       https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/
+#   License:            Licence Ouverte 2.0 (Etalab)
+#   Format:             gzip-compressed CSV, ~26 M records, ~1 GB compressed
+#   Cadence:            daily
+#
+# No transit feeds in this index — French transit data is fragmented
+# across regional operators (SNCF, RATP, regional STIFs) and out of
+# scope for the geocode-prep pass.
+
+[pbf]
+url = "https://download.geofabrik.de/europe/france-latest.osm.pbf"

--- a/dl/regions/germany.toml
+++ b/dl/regions/germany.toml
@@ -1,0 +1,26 @@
+# Butterfly region index — Germany
+#
+# OSM PBF for Germany from Geofabrik. ~4.5 GB compressed — the
+# largest single-country PBF in the cross-border cluster #1
+# (BE/FR/NL/LU/DE). NOT fetched in the initial geocode-prep pass;
+# the index is committed for completeness so any operator who wants
+# DE data can run `butterfly-dl germany --only pbf`.
+#
+# Authoritative address dataset:
+#   None nationally unified. Address data lives across 16 federal
+#   states (Bundesländer) with heterogeneous licensing; the
+#   geocode shard for Germany falls back to OSM addr:* tags
+#   (license: ODbL).
+#
+# State-level open address datasets exist (NRW, Berlin, Hamburg,
+# Brandenburg, Sachsen are notable open sources) and could be
+# layered later, but no single national mirror exists today.
+# See geocode-data/SOURCES.md for the per-state inventory once
+# that work begins.
+#
+# No transit feeds in this index — German GTFS is per-operator
+# (DELFI publishes a national merge but format/license is non-
+# trivial) and out of scope for the geocode-prep pass.
+
+[pbf]
+url = "https://download.geofabrik.de/europe/germany-latest.osm.pbf"

--- a/dl/regions/luxembourg.toml
+++ b/dl/regions/luxembourg.toml
@@ -1,0 +1,27 @@
+# Butterfly region index — Luxembourg
+#
+# OSM PBF for Luxembourg from Geofabrik. butterfly-route consumes
+# this as `luxembourg.pbf` under `data/luxembourg/`; butterfly-geocode
+# (#96) plans to pair it with the BD-Adresses authoritative dataset
+# on the side.
+#
+# Authoritative address dataset (NOT fetched by butterfly-dl yet —
+# tracked separately in geocode-data/SOURCES.md):
+#
+#   Adresses géoréférencées — BD-L-AD (BD-Adresses)
+#   Landing page:  https://data.public.lu/en/datasets/adresses-georeferencees-bd-adresses/
+#   API (resource discovery): https://data.public.lu/api/1/datasets/adresses-georeferencees-bd-adresses/
+#   Publisher:     Administration du Cadastre et de la Topographie (ACT)
+#   License:       Creative Commons Attribution 4.0 (CC-BY 4.0)
+#   Format:        Shapefile / CSV / GeoJSON variants, ~250 k addresses
+#   Cadence:       roughly monthly
+#
+# Direct file URLs on data.public.lu are content-hashed and rotate
+# per release; the geocode importer will resolve them via the
+# datasets API (`/api/1/datasets/<slug>/`) at fetch time.
+#
+# No transit feeds in this index — Luxembourg's national GTFS
+# (mobiliteit.lu) is out of scope for the geocode-prep pass.
+
+[pbf]
+url = "https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf"

--- a/dl/regions/netherlands.toml
+++ b/dl/regions/netherlands.toml
@@ -1,0 +1,23 @@
+# Butterfly region index — Netherlands
+#
+# OSM PBF for the Netherlands from Geofabrik. butterfly-route
+# consumes this as `netherlands.pbf` under `data/netherlands/`;
+# butterfly-geocode (#96) plans to pair it with the BAG
+# authoritative address dataset on the side.
+#
+# Authoritative address dataset (NOT fetched by butterfly-dl yet —
+# tracked separately in geocode-data/SOURCES.md):
+#
+#   Basisregistratie Adressen en Gebouwen (BAG)
+#   Direct extract:  https://service.pdok.nl/kadaster/adressen/atom/v1_0/downloads/lvbag-extract-nl.zip
+#   Atom feed:       https://service.pdok.nl/kadaster/adressen/atom/v1_0/adressen.xml
+#   Landing page:    https://www.kadaster.nl/-/gratis-download-bag-extract
+#   License:         CC0 (public domain) for the open extract
+#   Format:          GML / XML inside ZIP, ~2.8 GB compressed, ~9 M addresses
+#   Cadence:         monthly (8th of the month)
+#
+# No transit feeds in this index — Dutch GTFS is published per
+# operator via OpenOV / NDOV.
+
+[pbf]
+url = "https://download.geofabrik.de/europe/netherlands-latest.osm.pbf"

--- a/dl/regions/switzerland.toml
+++ b/dl/regions/switzerland.toml
@@ -1,0 +1,31 @@
+# Butterfly region index — Switzerland
+#
+# OSM PBF for Switzerland from Geofabrik. butterfly-route consumes
+# this as `switzerland.pbf` under `data/switzerland/`;
+# butterfly-geocode (#96) plans to pair it with the swisstopo
+# building-address register on the side.
+#
+# Authoritative address dataset (NOT fetched by butterfly-dl yet —
+# tracked separately in geocode-data/SOURCES.md):
+#
+#   Amtliches Verzeichnis der Gebäudeadressen (swisstopo)
+#   Landing page (opendata.swiss):
+#     https://opendata.swiss/de/dataset/amtliches-verzeichnis-der-gebaudeadressen
+#   Product page (swisstopo):
+#     https://www.swisstopo.admin.ch/de/amtliches-verzeichnis-der-gebaeudeadressen
+#   STAC API root:  https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.amtliches-gebaeudeadressverzeichnis
+#   Publisher:      Bundesamt für Landestopografie (swisstopo)
+#   License:        Open Government Data (OGD) — free use, attribution
+#   Format:         CSV / GDB / Interlis (XTF), ~2.5 M addresses
+#   Cadence:        weekly
+#
+# Direct file URLs are STAC-asset-hashed and rotate per release;
+# the geocode importer will resolve them via the STAC API
+# (`/collections/<id>/items/<latest>`) at fetch time.
+#
+# No transit feeds in this index — Swiss GTFS (opentransportdata.swiss)
+# is excellent and a candidate for a future addition, but is out
+# of scope for the geocode-prep pass.
+
+[pbf]
+url = "https://download.geofabrik.de/europe/switzerland-latest.osm.pbf"

--- a/dl/src/regions.rs
+++ b/dl/src/regions.rs
@@ -48,6 +48,7 @@ const NETHERLANDS_INDEX_TOML: &str = include_str!("../regions/netherlands.toml")
 const LUXEMBOURG_INDEX_TOML: &str = include_str!("../regions/luxembourg.toml");
 const GERMANY_INDEX_TOML: &str = include_str!("../regions/germany.toml");
 const AUSTRIA_INDEX_TOML: &str = include_str!("../regions/austria.toml");
+const SWITZERLAND_INDEX_TOML: &str = include_str!("../regions/switzerland.toml");
 
 /// Parsed region index. Each field is an optional list so partial
 /// regions (e.g. one without transit feeds) are a valid shape.
@@ -89,6 +90,7 @@ impl RegionIndex {
             "luxembourg" => LUXEMBOURG_INDEX_TOML,
             "germany" => GERMANY_INDEX_TOML,
             "austria" => AUSTRIA_INDEX_TOML,
+            "switzerland" => SWITZERLAND_INDEX_TOML,
             other => bail!(
                 "unknown region '{other}'. Supported regions are bundled \
                  in `dl/regions/`. Add a new one with a new TOML file + \
@@ -303,6 +305,7 @@ pub fn shipped_regions() -> &'static [&'static str] {
         "germany",
         "luxembourg",
         "netherlands",
+        "switzerland",
     ]
 }
 
@@ -323,6 +326,51 @@ mod tests {
         assert!(gtfs_ids.contains(&"delijn"));
         assert!(gtfs_ids.contains(&"tec"));
         assert_eq!(idx.netex_epip[0].id, "stib");
+    }
+
+    #[test]
+    fn cross_border_region_indexes_parse_with_pbf_only() {
+        // Cross-border cluster #1 (BE/FR/NL/LU/DE) plus #2 (AT/DE/CH).
+        // Belgium is exercised separately; the rest carry only a [pbf]
+        // section in this pass — authoritative address datasets are
+        // documented in geocode-data/SOURCES.md and will be wired up
+        // by the geocode importer once it lands.
+        for region in [
+            "france",
+            "netherlands",
+            "luxembourg",
+            "germany",
+            "austria",
+            "switzerland",
+        ] {
+            let idx = RegionIndex::load(region)
+                .unwrap_or_else(|e| panic!("region '{region}' must load: {e:#}"));
+            assert!(
+                idx.pbf.is_some(),
+                "region '{region}' must carry a [pbf] section",
+            );
+            assert!(
+                idx.gtfs.is_empty(),
+                "region '{region}' is not expected to ship GTFS in this pass",
+            );
+            assert!(
+                idx.netex_epip.is_empty(),
+                "region '{region}' is not expected to ship NeTEx in this pass",
+            );
+            let pbf_url = &idx.pbf.as_ref().unwrap().url;
+            assert!(
+                pbf_url.starts_with("https://download.geofabrik.de/"),
+                "region '{region}' PBF URL should be Geofabrik: {pbf_url}",
+            );
+        }
+    }
+
+    #[test]
+    fn shipped_regions_lists_every_loadable_region() {
+        for name in shipped_regions() {
+            RegionIndex::load(name)
+                .unwrap_or_else(|e| panic!("shipped region '{name}' must load: {e:#}"));
+        }
     }
 
     #[test]

--- a/dl/src/regions.rs
+++ b/dl/src/regions.rs
@@ -40,9 +40,10 @@ use serde::Deserialize;
 
 use crate::verified::{Outcome, VerifiedOptions, download_verified};
 
-/// The shipped Belgium index, embedded at compile time. Adding a new
-/// region = new file + new constant + new arm in `load_region`.
+/// The shipped region indexes, embedded at compile time. Adding a
+/// new region = new file + new constant + new arm in `load_region`.
 const BELGIUM_INDEX_TOML: &str = include_str!("../regions/belgium.toml");
+const FRANCE_INDEX_TOML: &str = include_str!("../regions/france.toml");
 
 /// Parsed region index. Each field is an optional list so partial
 /// regions (e.g. one without transit feeds) are a valid shape.
@@ -79,6 +80,7 @@ impl RegionIndex {
     pub fn load(name: &str) -> Result<Self> {
         let raw: &str = match name {
             "belgium" => BELGIUM_INDEX_TOML,
+            "france" => FRANCE_INDEX_TOML,
             other => bail!(
                 "unknown region '{other}'. Supported regions are bundled \
                  in `dl/regions/`. Add a new one with a new TOML file + \
@@ -286,7 +288,7 @@ pub async fn fetch_region(
 /// Used by the CLI's error path ("unknown region X; known regions:
 /// [...]").
 pub fn shipped_regions() -> &'static [&'static str] {
-    &["belgium"]
+    &["belgium", "france"]
 }
 
 #[cfg(test)]

--- a/dl/src/regions.rs
+++ b/dl/src/regions.rs
@@ -45,6 +45,7 @@ use crate::verified::{Outcome, VerifiedOptions, download_verified};
 const BELGIUM_INDEX_TOML: &str = include_str!("../regions/belgium.toml");
 const FRANCE_INDEX_TOML: &str = include_str!("../regions/france.toml");
 const NETHERLANDS_INDEX_TOML: &str = include_str!("../regions/netherlands.toml");
+const LUXEMBOURG_INDEX_TOML: &str = include_str!("../regions/luxembourg.toml");
 
 /// Parsed region index. Each field is an optional list so partial
 /// regions (e.g. one without transit feeds) are a valid shape.
@@ -83,6 +84,7 @@ impl RegionIndex {
             "belgium" => BELGIUM_INDEX_TOML,
             "france" => FRANCE_INDEX_TOML,
             "netherlands" => NETHERLANDS_INDEX_TOML,
+            "luxembourg" => LUXEMBOURG_INDEX_TOML,
             other => bail!(
                 "unknown region '{other}'. Supported regions are bundled \
                  in `dl/regions/`. Add a new one with a new TOML file + \
@@ -290,7 +292,7 @@ pub async fn fetch_region(
 /// Used by the CLI's error path ("unknown region X; known regions:
 /// [...]").
 pub fn shipped_regions() -> &'static [&'static str] {
-    &["belgium", "france", "netherlands"]
+    &["belgium", "france", "luxembourg", "netherlands"]
 }
 
 #[cfg(test)]

--- a/dl/src/regions.rs
+++ b/dl/src/regions.rs
@@ -46,6 +46,7 @@ const BELGIUM_INDEX_TOML: &str = include_str!("../regions/belgium.toml");
 const FRANCE_INDEX_TOML: &str = include_str!("../regions/france.toml");
 const NETHERLANDS_INDEX_TOML: &str = include_str!("../regions/netherlands.toml");
 const LUXEMBOURG_INDEX_TOML: &str = include_str!("../regions/luxembourg.toml");
+const GERMANY_INDEX_TOML: &str = include_str!("../regions/germany.toml");
 
 /// Parsed region index. Each field is an optional list so partial
 /// regions (e.g. one without transit feeds) are a valid shape.
@@ -85,6 +86,7 @@ impl RegionIndex {
             "france" => FRANCE_INDEX_TOML,
             "netherlands" => NETHERLANDS_INDEX_TOML,
             "luxembourg" => LUXEMBOURG_INDEX_TOML,
+            "germany" => GERMANY_INDEX_TOML,
             other => bail!(
                 "unknown region '{other}'. Supported regions are bundled \
                  in `dl/regions/`. Add a new one with a new TOML file + \
@@ -292,7 +294,7 @@ pub async fn fetch_region(
 /// Used by the CLI's error path ("unknown region X; known regions:
 /// [...]").
 pub fn shipped_regions() -> &'static [&'static str] {
-    &["belgium", "france", "luxembourg", "netherlands"]
+    &["belgium", "france", "germany", "luxembourg", "netherlands"]
 }
 
 #[cfg(test)]

--- a/dl/src/regions.rs
+++ b/dl/src/regions.rs
@@ -47,6 +47,7 @@ const FRANCE_INDEX_TOML: &str = include_str!("../regions/france.toml");
 const NETHERLANDS_INDEX_TOML: &str = include_str!("../regions/netherlands.toml");
 const LUXEMBOURG_INDEX_TOML: &str = include_str!("../regions/luxembourg.toml");
 const GERMANY_INDEX_TOML: &str = include_str!("../regions/germany.toml");
+const AUSTRIA_INDEX_TOML: &str = include_str!("../regions/austria.toml");
 
 /// Parsed region index. Each field is an optional list so partial
 /// regions (e.g. one without transit feeds) are a valid shape.
@@ -87,6 +88,7 @@ impl RegionIndex {
             "netherlands" => NETHERLANDS_INDEX_TOML,
             "luxembourg" => LUXEMBOURG_INDEX_TOML,
             "germany" => GERMANY_INDEX_TOML,
+            "austria" => AUSTRIA_INDEX_TOML,
             other => bail!(
                 "unknown region '{other}'. Supported regions are bundled \
                  in `dl/regions/`. Add a new one with a new TOML file + \
@@ -294,7 +296,14 @@ pub async fn fetch_region(
 /// Used by the CLI's error path ("unknown region X; known regions:
 /// [...]").
 pub fn shipped_regions() -> &'static [&'static str] {
-    &["belgium", "france", "germany", "luxembourg", "netherlands"]
+    &[
+        "austria",
+        "belgium",
+        "france",
+        "germany",
+        "luxembourg",
+        "netherlands",
+    ]
 }
 
 #[cfg(test)]

--- a/dl/src/regions.rs
+++ b/dl/src/regions.rs
@@ -44,6 +44,7 @@ use crate::verified::{Outcome, VerifiedOptions, download_verified};
 /// new region = new file + new constant + new arm in `load_region`.
 const BELGIUM_INDEX_TOML: &str = include_str!("../regions/belgium.toml");
 const FRANCE_INDEX_TOML: &str = include_str!("../regions/france.toml");
+const NETHERLANDS_INDEX_TOML: &str = include_str!("../regions/netherlands.toml");
 
 /// Parsed region index. Each field is an optional list so partial
 /// regions (e.g. one without transit feeds) are a valid shape.
@@ -81,6 +82,7 @@ impl RegionIndex {
         let raw: &str = match name {
             "belgium" => BELGIUM_INDEX_TOML,
             "france" => FRANCE_INDEX_TOML,
+            "netherlands" => NETHERLANDS_INDEX_TOML,
             other => bail!(
                 "unknown region '{other}'. Supported regions are bundled \
                  in `dl/regions/`. Add a new one with a new TOML file + \
@@ -288,7 +290,7 @@ pub async fn fetch_region(
 /// Used by the CLI's error path ("unknown region X; known regions:
 /// [...]").
 pub fn shipped_regions() -> &'static [&'static str] {
-    &["belgium", "france"]
+    &["belgium", "france", "netherlands"]
 }
 
 #[cfg(test)]

--- a/geocode-data/CLUSTERS.md
+++ b/geocode-data/CLUSTERS.md
@@ -1,0 +1,283 @@
+# Cross-Border Cluster Manifest
+
+Tracks: #96 (butterfly-geocode design — *Cross-Border Shard Co-location*).
+
+The geocoder design commits to **physical co-location of border-region
+shard fragments** for predictable cross-border ambiguity clusters.
+This is a data-layout decision, not a runtime-policy decision: the
+shard byte layout is what makes the "country ∈ {A, B}" lookup
+cheap, not a runtime branch.
+
+This document defines:
+
+1. The cluster membership and language landscape per cluster.
+2. The postcode-format compatibility matrix per cluster.
+3. The locality-name conflict examples each cluster needs to handle.
+4. The concrete fragment-layout scheme the shard builder will use.
+
+The corresponding country region indexes live in `dl/regions/`.
+The authoritative source URLs and field mappings live in
+`SOURCES.md` (this directory).
+
+## Cluster #1 — BE / FR / NL / LU / DE (densest)
+
+**Members:** Belgium, France, Netherlands, Luxembourg, Germany.
+
+**Why this is a cluster:** The BENELUX-FR-DE quadripoint is the
+densest cross-border-query region in Europe. Daily commuters cross
+3+ borders, postal services route across NL→BE→LU regularly, and
+freight tooling routinely receives partial addresses without a
+country code.
+
+### Languages
+
+| Country | Official | Cross-border secondary |
+|---|---|---|
+| BE | nl, fr, de | (de in eastern cantons) |
+| FR | fr | (small de in Alsace, nl in Flanders historical) |
+| NL | nl | fy in Friesland |
+| LU | lb, fr, de | en in business contexts |
+| DE | de | — |
+
+The geocoder cannot assume single-language input anywhere in this
+cluster. A query like "Rue de la Gare, Liège" is FR-language but
+firmly Belgian.
+
+### Postcode formats
+
+| Country | Format | Example | Conflict in cluster |
+|---|---|---|---|
+| BE | `\d{4}` | 1000 | Overlaps numerically with FR/AT/LU (all 4-5 digit) |
+| FR | `\d{5}` | 75001 | Distinct length |
+| NL | `\d{4} ?[A-Z]{2}` | 1011 AB | Distinct shape (alpha suffix) |
+| LU | `L?-?\d{4}` | L-2453 / 2453 | Numerically overlaps with BE |
+| DE | `\d{5}` | 10115 | Numerically overlaps with FR |
+
+**Conflict rule:** A bare 4-digit postcode is ambiguous BE / LU / (AT).
+A bare 5-digit postcode is ambiguous FR / DE / (ES / IT). The
+parser's cheap classifier (#96 routing stage) cannot resolve from
+postcode alone — it needs a script/lexical signal too.
+
+### Locality-name conflicts (real examples)
+
+| Canonical | Aliases / collisions |
+|---|---|
+| Brussels (BE) | Bruxelles (FR) / Brussel (NL) / Brüssel (DE) — all four are correct, all four show up in input |
+| Liège (BE) | Lüttich (DE) / Luik (NL) — all valid, mixed-language signage in town |
+| Antwerp (BE) | Antwerpen (NL/DE) / Anvers (FR) |
+| Aachen (DE) | Aix-la-Chapelle (FR) / Aken (NL) — borders BE/NL |
+| Maastricht (NL) | "Maestricht" archaic FR; same name in DE |
+| Luxembourg City (LU) | Luxembourg (FR) / Lëtzebuerg (LB) / Luxemburg (DE) |
+| Strasbourg (FR) | Straßburg (DE) — Alsace cross-border |
+| Lille (FR) | Rijsel (NL) — used by Belgian Flemish speakers |
+
+The alias table is a first-class shard input, not a CSV
+post-processing step. Multilingual locality names appear in
+authoritative sources (BeSt has `municipality_name_{nl,fr,de}`,
+BAN has `nom_commune` only in fr but the shard layer joins
+against an OSM-derived multilingual table).
+
+### Multilingual signage convention
+
+- BE: bilingual or trilingual signage by region (Flemish, Walloon,
+  Brussels-Capital, German-speaking community). Street names appear
+  in 2–3 languages on the same sign.
+- LU: triple-language street signs (lb / fr / de), but databases
+  typically store fr only; lb/de are alias-table responsibilities.
+- DE/FR border (Alsace, Saar): predominantly fr or de with
+  occasional dual-language signage.
+- NL/BE: typically nl-only on each side, but Brussels and the
+  Flemish/Walloon border is bilingual.
+
+## Cluster #2 — AT / DE / CH (German-language)
+
+**Members:** Austria, Germany, Switzerland.
+
+**Why this is a cluster:** The DACH region shares a primary language
+(de) with strong dialectal variation, partial postcode overlap, and
+heavy cross-border commuter traffic (Bodensee, Salzburg/Bayern,
+Basel/Lörrach).
+
+### Languages
+
+| Country | Official | Cross-border secondary |
+|---|---|---|
+| AT | de | (sl in Carinthia, hu in Burgenland) |
+| DE | de | (da in Schleswig, nds regional) |
+| CH | de, fr, it, rm | English business contexts |
+
+Switzerland is multilingual within itself, and CH-DE is German but
+with Swiss orthography (no ß, "Strasse" not "Straße").
+
+### Postcode formats
+
+| Country | Format | Example | Conflict in cluster |
+|---|---|---|---|
+| AT | `\d{4}` | 1010 | Numerically overlaps with CH/BE/LU |
+| DE | `\d{5}` | 10115 | Distinct from AT/CH |
+| CH | `\d{4}` | 8001 | Numerically overlaps with AT |
+
+**Conflict rule:** AT and CH share 4-digit postcodes outright.
+1xxx (AT: Vienna) overlaps 1xxx (CH: Lausanne). Disambiguation
+requires locality, language script (ß vs ss), or country prefix.
+
+### Locality-name conflicts
+
+| Canonical | Aliases / collisions |
+|---|---|
+| Wien (AT) | Vienna (en) / Vienne (fr) — Vienne is also a city in FR |
+| München (DE) | Munich (en) / Monaco (it) — disambiguates only by context |
+| Köln (DE) | Cologne (en/fr) / Keulen (nl) |
+| Zürich (CH) | Zurich (no umlaut) — common ASCII rendering |
+| Bern (CH) | Berne (en/fr) — disambiguates only by context |
+| Sankt Gallen (CH) | "St. Gallen" / "Saint-Gall" (fr) |
+
+### Multilingual signage convention
+
+- DE: monolingual de.
+- AT: monolingual de (with regional dialectal terms in addresses
+  rare but present in Carinthia, Tyrol).
+- CH: language by canton — German cantons monolingual de (Swiss
+  spelling), French cantons monolingual fr, Ticino monolingual it,
+  Graubünden trilingual de/it/rm.
+
+## Cluster #3 — ES / PT (Iberian)
+
+**Members:** Spain, Portugal.
+
+**Out of scope for this prep pass.** Documented for completeness;
+region indexes will be added in a follow-up.
+
+**Languages:** es, ca, gl, eu (ES); pt (PT). Cross-border traffic
+heavy in Galicia/Norte (gl/pt are mutually intelligible).
+
+**Postcode formats:** ES `\d{5}`, PT `\d{4}-\d{3}`. Numerically
+distinguishable, no conflict.
+
+**Authoritative sources:**
+
+- ES: CNIG (Centro Nacional de Información Geográfica) Cartociudad
+- PT: CTT (Correios de Portugal) PT-Postal — license restricted, not open
+
+## Cluster #4 — Balkans (RS / HR / BA / SI / ME / MK)
+
+**Members:** Serbia, Croatia, Bosnia & Herzegovina, Slovenia,
+Montenegro, North Macedonia.
+
+**Out of scope for this prep pass.** Documented for completeness.
+
+**Why this is a cluster:** Mixed Latin/Cyrillic scripts, shared
+locality-name space across post-Yugoslav successor states, weak
+authoritative-data coverage.
+
+**Postcode formats:** mostly 5-digit; SI and HR are distinguishable
+by lexical / script signals, not by postcode alone.
+
+## Cluster #5 — Arabic-script multilingual regions
+
+**Out of scope for this prep pass.** Documented for completeness.
+
+The geocoder design (#96) calls these out as a co-location cluster
+because **the script itself** is the binding signal — Arabic input
+benefits from being matched against the Arabic-script alias table
+across ALL Arabic-speaking countries simultaneously, since
+disambiguation by country happens AFTER fuzzy script matching, not
+before.
+
+## Fragment-layout scheme
+
+The geocode shard's on-disk format (which lives in `geocode/src/shard/`)
+will partition records by:
+
+```
+key = (cluster_id, country, postcode_first_two_digits)
+```
+
+with each `(cluster, country, pc2)` triple producing one **fragment**:
+a contiguous record slab + its inverted-index slabs (postcode trie,
+locality alias map, street trie, house-number sorted array). All
+fragments belonging to the same `cluster_id` are laid out
+back-to-back in the on-disk file so:
+
+- Single-country queries: one fragment touched, ~hundreds of KB
+  to a few MB depending on country/postcode density.
+- Border-region cross-country queries within the same cluster:
+  N fragments touched, but they are page-adjacent on disk and in
+  the OS page cache, so the second fragment is essentially free
+  once the first is hot.
+- Cross-cluster queries (rare): N fragments touched at random
+  offsets, paying full mmap-fault cost. This is the path the
+  design accepts as expensive — the optimization is the common
+  case, not the worst case.
+
+### Why `(cluster, country, pc2)`?
+
+- `cluster_id` first — primary memory-locality key. All fragments
+  in cluster #1 are physically adjacent, regardless of country.
+- `country` second — secondary key. Within cluster #1, all BE
+  fragments come before all FR fragments etc., so a confirmed-
+  country query lives in one contiguous range.
+- `postcode_first_two_digits` third — granularity knob. 100
+  fragments per country × 5 countries = 500 fragments per cluster.
+  At ~6.7M BeSt records, that's ~67k records per BE fragment on
+  average, which is small enough to fit in L3 for hot fragments
+  and page-fault cheaply for cold ones.
+
+### Why `pc2` and not country alone?
+
+Without `pc2`-level partitioning, a single-country query against
+France pulls in 26M records' worth of mmap pages even though the
+query is interested in one Paris postcode. With `pc2`, the parser
+hands the executor a postcode prior, the executor selects one
+~260k-record fragment, and only that fragment is faulted in.
+
+### Why not finer than `pc2`?
+
+`pc3` (1000 fragments per country) over-fragments smaller countries
+(LU has ~250k addresses across ~80 postcodes — `pc2` is already
+~4 fragments per `pc2` value, `pc3` would be ~ten records per
+fragment, defeating the slab benefit). `pc2` is the empirical
+sweet spot from the typical-fragment-size target of 50k–500k
+records.
+
+### Shard-file structure (sketch)
+
+```
+geocode-{cluster_id}.shard
+├── header                        — magic, version, cluster id, table of contents
+├── alias_table                   — multilingual locality + street aliases (cluster-wide)
+├── per-country sections (sorted by ISO code)
+│   └── per-pc2 fragments (sorted by postcode prefix)
+│       ├── records slab          — [AddressRecord; n], packed, fixed stride
+│       ├── postcode index        — sparse FST or sorted-key array
+│       ├── locality index        — alias-id → record-offset adjacency
+│       ├── street trie           — fst::Map of canonical street name → offset list
+│       └── housenumber array     — sorted (street_id, number) pairs for binary search
+└── footer                        — CRC64 over body, magic
+```
+
+This is a sketch, not a binding spec. The on-disk format details
+land in `geocode/src/shard/` once the geocode crate is past the
+scaffolding stage. The commitment captured here is:
+
+- One shard per cluster (not one per country).
+- Within a shard, fragments ordered by `(country, pc2)`.
+- Mmap-friendly fixed-stride records.
+- Cluster-wide alias table (so BE↔FR↔NL↔DE locality aliases share
+  storage rather than being duplicated per country).
+
+### What the parser hands the executor
+
+```rust
+struct ShardLookup {
+    cluster: ClusterId,
+    countries: SmallVec<[CountryId; 4]>, // typically 1, sometimes 2-3 in border regions
+    postcode_priors: SmallVec<[(CountryId, Pc2); 4]>,
+}
+```
+
+The executor walks `countries` in posterior-confidence order;
+for each, it picks the candidate `pc2` fragments from
+`postcode_priors`. If `postcode_priors` is empty (no postcode in
+the query), the executor falls back to all `pc2` fragments for the
+country, which costs more page-cache but stays correct.

--- a/geocode-data/SOURCES.md
+++ b/geocode-data/SOURCES.md
@@ -1,0 +1,373 @@
+# Geocoder Source License + Format Inventory
+
+Tracks: #96 (butterfly-geocode design), #91 (multi-region foundation).
+
+This is the **data-prep manifest** for butterfly-geocode. It catalogs the
+authoritative open-data address sources for each country in cross-border
+cluster #1 (BE / FR / NL / LU / DE) and cluster #2 (AT / DE / CH), the
+license each one ships under, and the field mapping each importer will
+use to land records into the geocode shard's normalized
+`AddressRecord` schema.
+
+The shard importer itself lives in `geocode/` and is being scaffolded
+in parallel with this prep work. The intent here is that wiring an
+authoritative source into the geocoder is a copy-paste from the
+"Field mapping" sketches below, not a research task.
+
+## Normalized record schema
+
+All authoritative sources land into the same flat record. `AddressRecord`
+is the geocode crate's storage shape:
+
+```rust
+struct AddressRecord {
+    id: u64,                  // monotonic shard-local id
+    country: CountryId,       // ISO-3166-1 alpha-2 (BE, FR, NL, LU, DE, AT, CH)
+    lat: f64,                 // WGS84
+    lon: f64,                 // WGS84
+    postcode: Option<String>, // canonical postcode (no whitespace, no country prefix)
+    locality: Option<String>, // city / municipality name as published
+    street: Option<String>,   // canonical street name (no abbreviation expansion at ingest)
+    housenumber: Option<String>, // alphanumeric — "12", "12A", "12bis", "10-12"
+    source: SourceTag,        // BAN | BAG | BOSA | BD_ADRESSES | BEV | SWISSTOPO | OSM
+    source_id: Option<String>, // upstream stable id where the source provides one
+}
+```
+
+**Invariants:**
+
+- Coordinates are WGS84. Sources publishing in projected CRS
+  (Lambert-93 for BAN, RD New for BAG, MGI/Lambert for BEV,
+  LV95 for swisstopo) are reprojected at ingest with `proj4rs`.
+- Postcodes are stored as published, **without** country prefix. The
+  parser knows postcode format per country at query time.
+- Multilingual aliases (e.g. Brussels = Bruxelles = Brussel = Brüssel)
+  are handled at the **alias-table** layer (one record per (canonical
+  locality, alias)), not by duplicating `AddressRecord`s.
+- House numbers stay strings. Numeric coercion is wrong — alphanumeric
+  ("12A"), hyphenated ("10-12"), bis/ter/quater suffixes are all
+  semantically real.
+
+## Source inventory
+
+### Belgium — BeSt Address (BOSA)
+
+| Property | Value |
+|---|---|
+| Dataset name | BeSt Address (Belgium Standard Address) |
+| Publisher | FPS BOSA — DG Digital Transformation |
+| Landing page | https://data.gov.be/en/datasets/fpsbosa-dis-best-csv-deriv |
+| Direct files (CSV, regional) | `https://opendata.bosa.be/download/best/openaddress-bevlg.zip` (Flanders), `openaddress-bewal.zip` (Wallonia), `openaddress-bebru.zip` (Brussels) |
+| Direct file (XML, full) | `https://opendata.bosa.be/download/best/best-full-latest.xml.zip` |
+| License | Belgian Open Data License (compatible with CC-BY) |
+| Format | CSV (derived) + XML (canonical) |
+| Record count | ~6.7 M addresses |
+| Cadence | Monthly |
+
+**Status:** Belgium MVP is being built by another agent. The current
+`dl/regions/belgium.toml` does NOT include BeSt — adding it is a
+follow-up tracked in this doc, not in scope for this prep pass.
+
+**Field mapping sketch (CSV variant):**
+
+```rust
+// CSV columns: address_id, street_id, street_name_nl, street_name_fr,
+//              street_name_de, house_number, box_number, postcode,
+//              municipality_name_nl, municipality_name_fr,
+//              municipality_name_de, lat, lon, ...
+fn from_bosa_csv(row: &BosaRow, lang: Lang) -> AddressRecord {
+    AddressRecord {
+        id: next_id(),
+        country: CountryId::BE,
+        lat: row.lat,
+        lon: row.lon,
+        postcode: Some(row.postcode.trim().to_string()),
+        locality: Some(pick_lang(lang, &row.muni_nl, &row.muni_fr, &row.muni_de)),
+        street: Some(pick_lang(lang, &row.street_nl, &row.street_fr, &row.street_de)),
+        housenumber: Some(format_belgian_number(&row.house_number, &row.box_number)),
+        source: SourceTag::Bosa,
+        source_id: Some(row.address_id.clone()),
+    }
+}
+```
+
+The `pick_lang` step is **not** an ingest-time choice — Belgium
+needs every language as a queryable alias. The importer emits one
+record per language per address, all sharing the same `source_id`,
+linked through the alias table.
+
+### France — Base Adresse Nationale (BAN)
+
+| Property | Value |
+|---|---|
+| Dataset name | Base Adresse Nationale (BAN) |
+| Publisher | DINUM / Etalab + IGN + La Poste |
+| Landing page | https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/ |
+| Direct file (national) | https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/adresses-france.csv.gz |
+| Direct files (departmental) | https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/adresses-{dep}.csv.gz |
+| License | Licence Ouverte 2.0 (Etalab, ≈ CC-BY) |
+| Format | gzip CSV, semicolon-separated, UTF-8, ~921 MB compressed |
+| Record count | ~26 M addresses |
+| Cadence | Daily |
+
+**Field mapping sketch:**
+
+```rust
+// CSV columns: id;id_fantoir;numero;rep;nom_voie;code_postal;
+//              code_insee;nom_commune;code_insee_ancienne_commune;
+//              nom_ancienne_commune;x;y;lon;lat;type_position;
+//              alias;nom_ld;libelle_acheminement;nom_afnor;source;
+//              date_der_maj;certification_commune
+fn from_ban(row: &BanRow) -> AddressRecord {
+    AddressRecord {
+        id: next_id(),
+        country: CountryId::FR,
+        lat: row.lat,
+        lon: row.lon,
+        postcode: Some(row.code_postal.clone()),
+        locality: Some(row.nom_commune.clone()),
+        street: Some(row.nom_voie.clone()),
+        housenumber: format_fr_number(&row.numero, &row.rep), // "rep" = bis/ter/quater
+        source: SourceTag::Ban,
+        source_id: Some(row.id.clone()),
+    }
+}
+```
+
+`type_position` is a quality flag (`entrance`, `building`, `parcel`,
+`interpolation`, `area`). The importer drops `area` (centroid-only)
+records since the geocoder needs a real coordinate.
+
+### Netherlands — BAG (Basisregistratie Adressen en Gebouwen)
+
+| Property | Value |
+|---|---|
+| Dataset name | BAG — Basic Registration Addresses and Buildings |
+| Publisher | Kadaster (via PDOK) |
+| Landing page | https://www.kadaster.nl/-/gratis-download-bag-extract |
+| Direct file | https://service.pdok.nl/kadaster/adressen/atom/v1_0/downloads/lvbag-extract-nl.zip |
+| Atom feed (programmatic) | https://service.pdok.nl/kadaster/adressen/atom/v1_0/adressen.xml |
+| License | CC0 (public domain) for the open extract |
+| Format | GML / XML inside ZIP, ~2.8 GB compressed |
+| Record count | ~9 M addresses |
+| Cadence | Monthly (8th of the month) |
+
+**Field mapping sketch (BAG GML, "verblijfsobject" object):**
+
+```rust
+// BAG ships as nested GML. The relevant entity for AddressRecord is
+// `nummeraanduiding` (street + housenumber + postcode) joined to
+// `verblijfsobject` (the unit, with geometry and locality via
+// `woonplaats`).
+fn from_bag(num: &Nummeraanduiding, obj: &Verblijfsobject, plaats: &Woonplaats) -> AddressRecord {
+    let (lon, lat) = rd_to_wgs84(obj.geometrie.point); // RD New EPSG:28992 -> WGS84
+    AddressRecord {
+        id: next_id(),
+        country: CountryId::NL,
+        lat, lon,
+        postcode: num.postcode.clone(),
+        locality: Some(plaats.naam.clone()),
+        street: Some(num.openbare_ruimte_naam.clone()),
+        housenumber: Some(format_nl_number(num.huisnummer, &num.huisletter, &num.huisnummertoevoeging)),
+        source: SourceTag::Bag,
+        source_id: Some(num.identificatie.clone()),
+    }
+}
+```
+
+### Luxembourg — BD-Adresses
+
+| Property | Value |
+|---|---|
+| Dataset name | Adresses géoréférencées (BD-L-AD / BD-Adresses) |
+| Publisher | Administration du Cadastre et de la Topographie (ACT) |
+| Landing page | https://data.public.lu/en/datasets/adresses-georeferencees-bd-adresses/ |
+| API discovery | https://data.public.lu/api/1/datasets/adresses-georeferencees-bd-adresses/ |
+| License | CC-BY 4.0 |
+| Format | Shapefile / GeoJSON / CSV |
+| Record count | ~250 k addresses |
+| Cadence | ≈ monthly |
+
+Direct file URLs on data.public.lu are content-hashed and rotate per
+release; the importer resolves them through the dataset API at
+fetch time.
+
+**Field mapping sketch (CSV variant):**
+
+```rust
+// Columns (typical export): id, id_caclr, rue, numero, code_postal,
+//                           localite, x_lambert, y_lambert
+fn from_bdadresses(row: &BdadressesRow) -> AddressRecord {
+    let (lon, lat) = lambert_lu_to_wgs84(row.x_lambert, row.y_lambert);
+    AddressRecord {
+        id: next_id(),
+        country: CountryId::LU,
+        lat, lon,
+        postcode: Some(row.code_postal.clone()),
+        locality: Some(row.localite.clone()),
+        street: Some(row.rue.clone()),
+        housenumber: Some(row.numero.clone()),
+        source: SourceTag::BdAdresses,
+        source_id: Some(row.id_caclr.clone()),
+    }
+}
+```
+
+### Germany — OSM fallback (no national authoritative source)
+
+| Property | Value |
+|---|---|
+| Dataset name | OSM `addr:*` tags (national merge) |
+| Publisher | OpenStreetMap contributors (via Geofabrik) |
+| Direct file | https://download.geofabrik.de/europe/germany-latest.osm.pbf |
+| License | ODbL 1.0 |
+| Format | OSM PBF |
+| Record count | ~25 M addr nodes (estimate) |
+| Cadence | Geofabrik refreshes daily |
+
+Germany has no nationally unified authoritative open address dataset.
+State-level open datasets exist (NRW Geobasis, Berlin FIS-Broker,
+Hamburg Transparenzportal, Brandenburg, Sachsen) but with
+heterogeneous licensing and schemas. The geocoder ships an OSM
+fallback for Germany; layering open state datasets on top is a
+follow-up.
+
+**Field mapping sketch (OSM `addr:*` extraction):**
+
+```rust
+// Filter PBF for nodes/ways with addr:housenumber set.
+fn from_osm(elem: &OsmElement) -> Option<AddressRecord> {
+    let tags = &elem.tags;
+    let housenumber = tags.get("addr:housenumber")?.clone();
+    let (lon, lat) = elem.centroid_wgs84();
+    Some(AddressRecord {
+        id: next_id(),
+        country: CountryId::DE,
+        lat, lon,
+        postcode: tags.get("addr:postcode").cloned(),
+        locality: tags.get("addr:city").cloned()
+            .or_else(|| tags.get("addr:town").cloned())
+            .or_else(|| tags.get("addr:village").cloned()),
+        street: tags.get("addr:street").cloned(),
+        housenumber: Some(housenumber),
+        source: SourceTag::Osm,
+        source_id: Some(format!("{}:{}", elem.kind, elem.id)),
+    })
+}
+```
+
+The same OSM extractor is the universal fallback for every country
+that has no authoritative source — it runs on every PBF, and the
+importer flags OSM-sourced records as lower-priority than
+authoritative records when both exist for the same country.
+
+### Austria — BEV Adressregister
+
+| Property | Value |
+|---|---|
+| Dataset name | Österreichisches Adressregister |
+| Publisher | Bundesamt für Eich- und Vermessungswesen (BEV) |
+| Landing page | https://www.data.gv.at/katalog/dataset/adressregister-tagesaktuell |
+| Metadata | https://data.bev.gv.at/geonetwork/srv/api/records/37d564f9-5d63-4760-aae6-29d3f98ee1b4 |
+| Product page | https://www.bev.gv.at/Services/Produkte/Adressregister/Oesterreichisches-Adressregister.html |
+| WFS | https://apps.bev.gv.at/bev.webservice/inspire?service=WFS&request=GetCapabilities&version=2.0.0 |
+| License | CC-BY 4.0 Austria |
+| Format | Zipped CSV (BEV shop, free with registration) + INSPIRE GML (WFS) |
+| Record count | ~2.3 M addresses |
+| Cadence | Continuous, full snapshot quarterly |
+
+**URL verification surprise:** The BEV CSV that historically lived
+at `bev.gv.at/pls/portal/.../Adresse_Relationale_Tabellen-Stichtagsdaten.zip`
+(documented in the OSM wiki) does not resolve reliably from outside
+the BEV portal as of 2026-05. The geocode importer will go through
+the WFS endpoint or the adressregister.at static export, which is
+the documented modern access path.
+
+**Field mapping sketch (BEV relational CSV — ADRESSE.csv):**
+
+```rust
+// Columns: ADRCD, GKZ, OKZ, PLZ, STRASSE, HAUSNRTEXT,
+//          HOFNAME, GADRID, RW, HW, EPSG, GEMNAM, ORTNAM
+fn from_bev(row: &BevRow) -> AddressRecord {
+    let (lon, lat) = mgi_to_wgs84(row.rw, row.hw, row.epsg);
+    AddressRecord {
+        id: next_id(),
+        country: CountryId::AT,
+        lat, lon,
+        postcode: Some(format!("{:04}", row.plz)),
+        locality: Some(row.ortnam.clone()), // "Ortschaft", more precise than Gemeinde
+        street: Some(row.strasse.clone()),
+        housenumber: Some(row.hausnrtext.clone()),
+        source: SourceTag::Bev,
+        source_id: Some(row.adrcd.clone()),
+    }
+}
+```
+
+### Switzerland — Amtliches Verzeichnis der Gebäudeadressen (swisstopo)
+
+| Property | Value |
+|---|---|
+| Dataset name | Amtliches Verzeichnis der Gebäudeadressen (AmtlicheGebäudeadressen) |
+| Publisher | Bundesamt für Landestopografie (swisstopo) |
+| Landing page | https://opendata.swiss/de/dataset/amtliches-verzeichnis-der-gebaudeadressen |
+| Product page | https://www.swisstopo.admin.ch/de/amtliches-verzeichnis-der-gebaeudeadressen |
+| STAC API | https://data.geo.admin.ch/api/stac/v0.9/collections/ch.swisstopo.amtliches-gebaeudeadressverzeichnis |
+| License | OGD (Open Government Data) — free use, attribution to swisstopo |
+| Format | CSV / GDB / Interlis (XTF) |
+| Record count | ~2.5 M addresses |
+| Cadence | Weekly |
+
+Direct file URLs are STAC-asset-hashed and rotate per release;
+the importer resolves them via the STAC API at fetch time
+(`/collections/<id>/items/<id>/assets/<asset>`).
+
+**Field mapping sketch (swisstopo CSV — `building-addresses.csv`):**
+
+```rust
+// Columns (per swisstopo Gebaeudeadressen Technical Documentation):
+//   EGAID, EDID, EGID, STN_LABEL, ADR_NUMBER, ZIP_LABEL,
+//   COM_NAME, COM_FOSNR, COM_CANTON, BDG_EPSG, BDG_EAST, BDG_NORTH
+fn from_swisstopo(row: &SwisstopoRow) -> AddressRecord {
+    let (lon, lat) = lv95_to_wgs84(row.bdg_east, row.bdg_north);
+    AddressRecord {
+        id: next_id(),
+        country: CountryId::CH,
+        lat, lon,
+        postcode: Some(row.zip_label.clone()),
+        locality: Some(row.com_name.clone()),
+        street: Some(row.stn_label.clone()),
+        housenumber: Some(row.adr_number.clone()),
+        source: SourceTag::Swisstopo,
+        source_id: Some(row.egaid.clone()),
+    }
+}
+```
+
+## Open data deferred to a follow-up
+
+These are out of scope for this prep pass but tracked here so the
+geocode shard builder can pick them up once it lands:
+
+- **Belgium BeSt CSV** — adding `[[addresses]] id="best-vlg" url="..."`
+  etc. to `dl/regions/belgium.toml` once the geocode TOML schema
+  knows how to parse address-source entries. Requires schema design
+  in the geocode crate, not in butterfly-dl.
+- **Germany state-level datasets** — NRW, Berlin, Hamburg, Brandenburg,
+  Sachsen. Per-state license review needed.
+- **Italy ANNCSU**, **Spain CNIG**, **Portugal CTT/INE** — cluster #3
+  (ES/PT) and Italian extension. Out of cluster #1 + cluster #2 scope.
+- **OpenAddresses** — global federation of state-by-state submissions,
+  useful as a coverage-fill layer on top of authoritative + OSM.
+
+## License compatibility
+
+All listed authoritative sources are open data with attribution
+requirements at most. None are share-alike-restricted in a way that
+contaminates downstream geocode output. The OSM fallback (ODbL) is
+share-alike for substantial extracts but the geocoder consumes
+addr:* tags as factual data, which has been broadly understood as
+non-contaminating for derived databases under ODbL §4.4 (Produced
+Works exception). A formal license review is filed as a follow-up
+ticket — the engineering decision here is to proceed under the
+common interpretation while that review runs.


### PR DESCRIPTION
## Summary

Multi-country data foundation prep for **butterfly-geocode** (#96), aligned with the multi-region routing foundation (#91). Lands the next-tier region indexes and the source-license inventory **without touching `geocode/`** (the geocode crate is being scaffolded concurrently).

### What's done

- **6 new region indexes** in `dl/regions/`: France, Netherlands, Luxembourg, Germany, Austria, Switzerland — covering cross-border cluster #1 (BE/FR/NL/LU/DE) plus cluster #2 (AT/DE/CH).
- Each index registered in `dl/src/regions.rs` (`RegionIndex::load` + `shipped_regions()`), discoverable via `butterfly-dl <region>`. Belgium index is left as-is (parallel agent's territory).
- Two regression tests in `regions.rs`:
  - `cross_border_region_indexes_parse_with_pbf_only` — every new region parses, ships only `[pbf]`, points at Geofabrik.
  - `shipped_regions_lists_every_loadable_region` — symmetry between the catalog list and the load match.
- **`geocode-data/SOURCES.md`** — per-country authoritative-source inventory: dataset name, direct URL or discovery API, license, format, record count, cadence, and a Rust-pseudocode field-mapping sketch from each native schema into the geocoder's normalized `AddressRecord` shape.
- **`geocode-data/CLUSTERS.md`** — per-cluster language / postcode / locality landscape with concrete conflict examples (Brussels=Bruxelles=Brussel=Brüssel, Wien/Vienna/Vienne, Aachen/Aix-la-Chapelle, etc.) and a concrete fragment-layout key: `(cluster_id, country, postcode_first_two_digits)`. Within a shard, fragments are ordered by `(country, pc2)` so single-country queries touch one slab and same-cluster border queries touch contiguous slabs that share the OS page cache.

### PBFs fetched

`butterfly-dl <region> --only pbf --to data/<region>` ran cleanly with magic-byte + min-bytes + SHA-256 sidecar verification for:

| Region | Size |
|---|---|
| luxembourg.pbf | 46 MB |
| switzerland.pbf | 507 MB |
| austria.pbf | 762 MB |
| netherlands.pbf | ≈1.5 GB (in flight at PR-creation time) |
| france.pbf | ≈5 GB (in flight at PR-creation time) |

`data/` is gitignored — no binary blobs in this PR.

### Deferred (intentionally)

- **Germany PBF** — ~4.5 GB, deferred per the prep-pass scope. Index is committed so any operator who wants DE can just run `butterfly-dl germany --only pbf`. Authoritative address data: no nationally unified open dataset exists; geocoder falls back to OSM `addr:*` (ODbL).
- **Authoritative address dataset ingestion** for FR/NL/LU/AT/CH — datasets are hundreds of MB to multiple GB and the geocode shard builder doesn't exist yet. URLs and licenses are documented in `geocode-data/SOURCES.md` for the importer to copy-paste once it lands.
- **Adding BeSt CSV to `dl/regions/belgium.toml`** — Belgium MVP is owned by another agent; tracked in `SOURCES.md` as a follow-up.
- **Cluster #3 (ES/PT) and Balkans / Arabic-script clusters** — out of cluster #1 + #2 scope.

### URL-verification surprises

- **Austria BEV CSV** — the historical OSM-wiki-documented hardcoded CSV URL (`bev.gv.at/pls/portal/.../Adresse_Relationale_Tabellen-Stichtagsdaten.zip`) no longer resolves reliably from outside the BEV portal as of 2026-05. Importer will go through the BEV WFS or `adressregister.at` static export instead. Documented in `dl/regions/austria.toml` and `SOURCES.md`.
- **Switzerland swisstopo & Luxembourg BD-Adresses** — both use content-hashed direct URLs that rotate per release. Importer resolves them via the publishers' discovery APIs (data.geo.admin.ch STAC, data.public.lu datasets API) at fetch time. Documented in the respective TOMLs.
- **Netherlands BAG** — direct PDOK URL `https://service.pdok.nl/kadaster/adressen/atom/v1_0/downloads/lvbag-extract-nl.zip` resolves cleanly, monthly cadence on the 8th.
- **France BAN** — direct national URL `https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/adresses-france.csv.gz` is current (last updated 2026-05-04 per the publisher's index page).

## Refs

- #96 — butterfly-geocode design (cross-border cluster co-location)
- #91 — multi-region per-country CCH foundation

## Test plan

- [x] `cargo build --workspace --release` — green
- [x] `cargo test -p butterfly-dl --lib regions::` — 8/8 pass (including 2 new tests)
- [x] `butterfly-dl <region> --only pbf --to data/<region>` — verified for LU/CH/AT (and NL/FR mid-flight at PR creation, observed bytes growing monotonically with verified.rs streaming + SHA-256 sidecar)
- [x] No edits in `geocode/` (parallel agent's territory) or `route/`
- [x] No raw PBFs committed (`data/` is in `.gitignore`)
- [x] Workspace lints stay green