### PR TITLE
feat(geocode): #96 multi-country shards (BE/FR/NL/LU/AT/CH)

### DIFF
--- a/geocode/README.md
+++ b/geocode/README.md
@@ -1,12 +1,15 @@
 # butterfly-geocode
 
-Belgium-only geocoder for the butterfly-osm toolkit. Started as the deterministic Phase 0 baseline of [butterfly-osm#96](https://github.com/butterfly-osm/butterfly-osm/issues/96); now ships **two parser backends side-by-side** — the deterministic heuristic baseline AND a byte-level transformer with retrieval-aware decoding ([#98](https://github.com/butterfly-osm/butterfly-osm/issues/98) Phase 1).
+Multi-country geocoder for the butterfly-osm toolkit. Started as the deterministic Phase 0 baseline of [butterfly-osm#96](https://github.com/butterfly-osm/butterfly-osm/issues/96); now ships **two parser backends side-by-side** — the deterministic heuristic baseline AND a byte-level transformer with retrieval-aware decoding ([#98](https://github.com/butterfly-osm/butterfly-osm/issues/98) Phase 1) — over **per-country shards** for cluster #1 + #2 (BE / FR / NL / LU / DE / AT / CH).
 
 ## What this ships
 
-- **Forward geocoding**: `GET /geocode?q=...&country=BE` — text → coordinates
-- **Reverse geocoding**: `GET /geocode/reverse?lat=...&lon=...` — coordinates → address
-- **Belgium address shard** (`BFGS` v1) built from OSM `addr:*` tags
+- **Per-country shards** (BFGS v3) for cluster #1 + #2 (BE / FR / NL / LU / DE / AT / CH) built from OSM `addr:*` tags via `butterfly-geocode build-shard --country <ISO2>`
+- **Multi-shard server**: `butterfly-geocode serve --shard-dir <dir>` loads every `*.bfgs` in `<dir>` and routes forward queries via the lexical country classifier (returns a `(country, weight)` posterior) and reverse queries via lat/lon bbox membership
+- **Cross-shard score normalization**: per-shard scores are scaled by the country posterior weight before merging, so an uncertain match against a "wrong" country is correctly demoted (see `executor::execute_across_shards`)
+- **Forward geocoding**: `GET /geocode?q=...[&country=BE]` — text → coordinates
+- **Reverse geocoding**: `GET /geocode/reverse?lat=...&lon=...[&country=BE]` — coordinates → address with bbox-based country dispatch
+- **Per-country shards** built from OSM `addr:*` tags
 - **Architectural type contracts from #96**: `ParsedQuery`, `ParseHypothesis`, `ExecutionBudget`, `Channel`, `ChannelRole`, `RetrievalPolicy`, retrieval operators (`Lookup`, `Intersect`, `Union`, `TopkMerge`, `Filter`, `Score`, `Cap`, `Sample`, `Downgrade`)
 - **Recombination Invariant** (#96): canonicalize + dedup with stable commutative ordering, identity folding, redundancy collapse — `op.canonicalize().canonicalize() == op.canonicalize()`
 - **Zero-Cost-on-Clean-Queries NFR** (#96): the `|hypotheses|==1, |countries|==1` path skips canonicalization, dedup, and dynamic dispatch
@@ -175,16 +178,62 @@ telemetry — once #98's beam-search parser ships and queries-with-gold
 can be logged — is the user's follow-up; the architecture and CLI
 landed in this layer support that without code changes.
 
+## Multi-country support
+
+The geocoder is built and deployed as **one shard per country**. Operators choose which country shards to build and which to serve.
+
+| Country | ISO2 | Postcode shape  | Status                    |
+|---------|------|-----------------|---------------------------|
+| Belgium       | `BE` | `\d{4}`              | Verified (test dataset) |
+| France        | `FR` | `\d{5}`              | OSM `addr:*` build-ready |
+| Netherlands   | `NL` | `\d{4}\s?[A-Z]{2}`   | Verified (1.4 GB PBF)    |
+| Luxembourg    | `LU` | `(L-)?\d{4}`         | Verified (47 MB PBF)     |
+| Germany       | `DE` | `\d{5}`              | OSM `addr:*` build-ready (5 GB PBF — operator-supplied) |
+| Austria       | `AT` | `\d{4}`              | OSM `addr:*` build-ready |
+| Switzerland   | `CH` | `\d{4}`              | OSM `addr:*` build-ready |
+
+### Build all shards in one pass
+
+```bash
+butterfly-geocode build-shards-all \
+    --pbf-dir data \
+    --out-dir geocode/regions/multi
+# Looks for <country>.pbf or <iso2>.pbf in --pbf-dir for each
+# supported country. Missing PBFs are skipped with a warning.
+```
+
+### Build one country at a time
+
+```bash
+butterfly-geocode build-shard \
+    --pbf data/netherlands.pbf \
+    --out geocode/regions/multi/nl.bfgs \
+    --country NL
+```
+
+### Serve a multi-country deployment
+
+```bash
+butterfly-geocode serve \
+    --shard-dir geocode/regions/multi \
+    --port 3033
+```
+
+### Authoritative sources
+
+This release uses **OSM `addr:*` tags** as the source for every country. Authoritative-source ingestion (BOSA BeSt for BE, BAN for FR, BAG for NL, BD-Adresses for LU, BEV for AT, swisstopo for CH) is documented in `geocode-data/SOURCES.md` with field mappings ready, but the importers are filed as a follow-up ticket.
+
+OSM coverage varies materially: Netherlands is dense (≈9.9 M `addr:*`-tagged objects), Belgium is dense (≈4.0 M), Luxembourg is sparse (≈170 K — most addresses live in BD-Adresses, not OSM). Operators with stricter coverage requirements should plan for the authoritative-ingest follow-up.
+
 ## What's deferred (still in #96/#97/#98)
 
-- **Byte-level transformer parser** (#96 §Tagger, #98 Phase 2) — the heuristic in `parser/heuristic.rs` is the deterministic Phase 0 baseline that the trained transformer will replace. **NOT** #98 Phase 1 (which is the retrieval-aware beam search over transformer outputs).
-- **Multi-country routing** (#96 §Country Routing) — `CountryId` is `non_exhaustive`, the cheap classifier returns a posterior shape; only `BE` is wired.
-- **Cross-border shard co-location** (#96 §Cross-Border Shard Co-location)
-- **Feedback operators** (`Downgrade`, `TopkMerge`, `Sample`) — types defined per #96, not invoked by the MVP executor
-- **Admission-control fanout caps** (#97 §5)
-- **mmap-backed reader** — current reader is heap-resident (~1.3 GB RSS for Belgium); a future ticket will switch to `memmap2` via butterfly-route's `formats/mmap.rs` wrappers (the only sanctioned `unsafe` carveout in the workspace)
+- **Byte-level transformer parser** (#96 §Tagger, #98 Phase 2) — the heuristic in `parser/heuristic.rs` is the deterministic Phase 0 baseline. The byte-level transformer + #98 Phase 1 retrieval-aware decoding ship in `parser/neural.rs`.
+- **Authoritative-source ingestion** (BOSA BeSt, BAN, BAG, BD-Adresses, BEV, swisstopo) — `geocode-data/SOURCES.md` has the URLs + field mappings ready; OSM `addr:*` is the source for all countries in this release.
+- **Cross-border shard co-location** (#96 §Cross-Border Shard Co-location) — separate per-country shards instead. The layout-merge is a future optimization for the BE-FR-NL-LU-DE cluster.
+- **Adapter layers (LoRA per region)** (#96 §Tagger) — needs trained models.
+- **Feedback operators** (`Downgrade`, `TopkMerge`, `Sample`) — types defined per #96, not invoked by the MVP executor.
 
-## Build and run
+## Build and run (Belgium-only)
 
 ```bash
 # 1. Get the Belgium PBF (if not already there)
@@ -193,9 +242,10 @@ butterfly-dl belgium --only pbf -o data/belgium.pbf
 # 2. Build the shard (~1 minute on Belgium scale)
 cargo run --release -p butterfly-geocode -- build-shard \
     --pbf data/belgium.pbf \
-    --out geocode/regions/belgium.bfgs
+    --out geocode/regions/belgium.bfgs \
+    --country BE
 
-# 3. Boot the server
+# 3. Boot the server (single-country mode)
 cargo run --release -p butterfly-geocode -- serve \
     --shard geocode/regions/belgium.bfgs \
     --port 3003
@@ -207,7 +257,45 @@ curl -H 'Accept: application/geo+json' \
     'http://localhost:3003/geocode?q=Grote+Markt+Antwerpen'
 ```
 
+## Build and run (multi-country)
+
+```bash
+# 1. Get one PBF per country you want to deploy
+curl -o data/luxembourg.pbf https://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
+curl -o data/netherlands.pbf https://download.geofabrik.de/europe/netherlands-latest.osm.pbf
+
+# 2. Build a shard per country
+mkdir -p geocode/regions/multi
+butterfly-geocode build-shard --pbf data/belgium.pbf      --out geocode/regions/multi/be.bfgs --country BE
+butterfly-geocode build-shard --pbf data/luxembourg.pbf   --out geocode/regions/multi/lu.bfgs --country LU
+butterfly-geocode build-shard --pbf data/netherlands.pbf  --out geocode/regions/multi/nl.bfgs --country NL
+
+# Or build everything in one pass:
+butterfly-geocode build-shards-all --pbf-dir data --out-dir geocode/regions/multi
+
+# 3. Boot the multi-shard server
+butterfly-geocode serve --shard-dir geocode/regions/multi --port 3033
+
+# 4. Pinned country (clean-query path)
+curl 'http://localhost:3033/geocode?q=Damrak+1+1012+LP+Amsterdam&country=NL'
+
+# 5. Auto-routed (classifier picks NL from "Damrak ... Amsterdam")
+curl 'http://localhost:3033/geocode?q=Damrak+1+1012+LP+Amsterdam'
+
+# 6. Reverse with bbox dispatch (50.8467,4.3525 → BE)
+curl 'http://localhost:3033/geocode/reverse?lat=50.8467&lon=4.3525'
+
+# 7. Health endpoint lists loaded countries
+curl 'http://localhost:3033/health'
+# {"status":"ok",...,"countries":["BE","LU","NL"]}
+```
+
 ## Testing
+
+```bash
+# Multi-country end-to-end (requires shards in regions/multi/)
+cargo test --release -p butterfly-geocode --test multi_country_e2e -- --ignored
+```
 
 ```bash
 # Unit tests

--- a/geocode/src/confidence/features.rs
+++ b/geocode/src/confidence/features.rs
@@ -420,6 +420,7 @@ mod tests {
             postcode: postcode.into(),
             locality: locality.into(),
             score,
+            country: None,
             reason_codes: vec!["POSTCODE_EXACT".into(), "STREET_EXACT".into()],
         }
     }

--- a/geocode/src/confidence/gbdt.rs
+++ b/geocode/src/confidence/gbdt.rs
@@ -247,6 +247,7 @@ mod tests {
                 postcode: "1000".into(),
                 locality: "loc".into(),
                 score: 0.5,
+                country: None,
                 reason_codes: vec![],
             })
             .collect();

--- a/geocode/src/confidence/thresholds.rs
+++ b/geocode/src/confidence/thresholds.rs
@@ -183,6 +183,7 @@ mod tests {
             postcode: "1000".into(),
             locality: "loc".into(),
             score,
+            country: None,
             reason_codes: vec![],
         }
     }

--- a/geocode/src/confidence/training.rs
+++ b/geocode/src/confidence/training.rs
@@ -470,7 +470,7 @@ mod tests {
                 },
             })
             .collect();
-        build_shard(&path, addrs).unwrap();
+        build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();
         (dir, Shard::open(&path).unwrap())
     }
 
@@ -484,6 +484,7 @@ mod tests {
             postcode: "1070".into(),
             locality: "Anderlecht".into(),
             score: 1.0,
+            country: None,
             reason_codes: vec![],
         };
         let gold = GoldAddress {
@@ -505,6 +506,7 @@ mod tests {
             postcode: "1070".into(),
             locality: "Anderlecht".into(),
             score: 1.0,
+            country: None,
             reason_codes: vec![],
         };
         let gold = GoldAddress {
@@ -526,6 +528,7 @@ mod tests {
             postcode: "1070".into(),
             locality: "Anderlecht".into(),
             score: 1.0,
+            country: None,
             reason_codes: vec![],
         };
         // 100 km away.

--- a/geocode/src/geocoder/executor.rs
+++ b/geocode/src/geocoder/executor.rs
@@ -33,6 +33,8 @@
 //! confidence is within ε of a role threshold, the matcher downgrades
 //! that channel one step. Hard thresholding is forbidden by #96.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::channels::{Channel, ChannelRole};
@@ -46,6 +48,7 @@ use crate::control::{
     ChannelMetrics, CleanQueryMetrics, CostCalibrationMetrics, FanoutConfig, FanoutTracker,
     GeneralMetrics, RecombinationMetrics, classify_tier, pre_execution_check,
 };
+use crate::routing::CountryId;
 use crate::shard::reader::{Shard, ShardRecord};
 use crate::types::{ExecutionBudget, ParseHypothesis, ParsedQuery, RetrievalPolicy, Strictness};
 
@@ -82,6 +85,11 @@ pub struct GeocodedResult {
     pub postcode: String,
     pub locality: String,
     pub score: f32,
+    /// Country this result came from (the shard the executor pulled
+    /// it out of). Set by [`execute_multi`]; the single-shard
+    /// [`execute`] path leaves it `None`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub country: Option<&'static str>,
     /// Why this candidate scored as it did. Machine-readable.
     /// Vocabulary defined in [`reason`].
     pub reason_codes: Vec<std::borrow::Cow<'static, str>>,
@@ -278,6 +286,126 @@ pub fn execute(query: &ParsedQuery, shard: &Shard, limit: usize) -> Vec<Geocoded
 
     rerank_and_truncate(&mut results, limit);
     results
+}
+
+/// Multi-shard executor (#96 §Per-Country Shard Contents).
+///
+/// Walks `query.country_candidates` in posterior-confidence order,
+/// truncated to `query.execution_budget.max_countries`. For each
+/// country with a loaded shard, runs the per-shard [`execute`] and
+/// scales every result's score by the country posterior weight
+/// before merging. The merged set is reranked + truncated.
+///
+/// ## Score normalization across shards
+///
+/// Per-shard scores are produced by [`execute`] (and ultimately
+/// the per-shard clean / multi-hypothesis paths) on a relative
+/// scale dominated by additive-channel-evidence sums
+/// (postcode-exact = 1.0, street-exact = 1.0, etc.). The shard's
+/// fuzzy-match path scales by rapidfuzz `normalized_similarity` ∈
+/// [0, 1] which is comparable across shards by construction.
+///
+/// We multiply each shard's per-result score by the **country
+/// posterior weight** from the routing classifier. This is
+/// information-theoretically the right thing: the posterior is a
+/// probability that the input belongs to that country, and
+/// `score * P(country)` is the expected score under the routing
+/// uncertainty. It correctly demotes a high-but-uncertain match
+/// against (e.g.) the FR shard when the input is much more plausibly
+/// BE.
+///
+/// We considered two alternatives and rejected them:
+/// - **Per-shard min-max normalization**: rescale each shard's top-N
+///   scores into [0, 1] before merging. Rejected because it destroys
+///   absolute confidence — a shard with no good matches still
+///   produces a 1.0 top score, which is an antipattern for the
+///   reason-code-driven UX.
+/// - **Z-score normalization across shards**: rescale by mean/stddev
+///   of each shard's scores. Rejected for the same reason plus
+///   numerical instability when one shard returns 0-1 results.
+///
+/// The chosen approach (multiplicative country posterior) keeps
+/// reason codes meaningful, costs nothing (one f32 multiply per
+/// result), and falls out cleanly on clean queries (posterior=1.0 →
+/// pass-through).
+///
+/// ## Clean-query preservation (#96 §Zero-Cost-on-Clean-Queries)
+///
+/// Each per-shard call collapses `country_candidates` to a single
+/// entry before calling [`execute`]. That keeps `is_clean()` true
+/// for the per-shard query, so the executor takes its fast path on
+/// every shard visited.
+pub fn execute_across_shards(
+    query: &ParsedQuery,
+    shards: &HashMap<CountryId, Shard>,
+    limit: usize,
+) -> Vec<GeocodedResult> {
+    if shards.is_empty() {
+        return Vec::new();
+    }
+
+    // Routing list. The classifier returns sorted-descending posteriors.
+    let max_k = query.execution_budget.max_countries.max(1) as usize;
+    let mut targets: Vec<(CountryId, f32)> = query
+        .country_candidates
+        .iter()
+        .take(max_k)
+        .filter_map(|(c, w)| shards.get(c).map(|_| (*c, *w)))
+        .collect();
+
+    // If none of the top-K classifier candidates have a loaded shard,
+    // fall back to whichever country IS loaded with the highest
+    // posterior. Fail-closed would silently empty-set; fail-open hits
+    // one shard but with the right one.
+    if targets.is_empty() {
+        if let Some((c, w)) = query
+            .country_candidates
+            .iter()
+            .find(|(c, _)| shards.contains_key(c))
+        {
+            targets.push((*c, *w));
+        } else {
+            // No classifier overlap with loaded shards. Fan out to
+            // every loaded shard with uniform weight.
+            let n = shards.len() as f32;
+            for &c in shards.keys() {
+                targets.push((c, 1.0 / n));
+            }
+        }
+    }
+
+    let mut all: Vec<GeocodedResult> = Vec::new();
+    let n_targets = targets.len();
+    for (country, posterior) in targets {
+        let Some(shard) = shards.get(&country) else {
+            continue;
+        };
+        // Per-shard limit oversamples 2x so the cross-shard rerank
+        // has headroom — without this, the top-`limit` from one shard
+        // can squeeze the other shard out at the merge step.
+        let per_shard_limit = limit
+            .saturating_mul(2)
+            .max(limit + 1)
+            .max(8 / n_targets.max(1));
+        // Build a per-country view of the query: collapse the
+        // country_candidates list to a single entry so the per-shard
+        // executor takes the clean-query fast path
+        // (`ParsedQuery::is_clean()` requires len == 1). The original
+        // multi-country query is preserved at the call site; this is
+        // a per-iteration shadow.
+        let mut per_country_query = query.clone();
+        per_country_query.country_candidates = vec![(country, posterior)];
+        let mut results = execute(&per_country_query, shard, per_shard_limit);
+        // Multiplicative country posterior — see doc comment above.
+        for r in &mut results {
+            r.score *= posterior;
+        }
+        let results = tag_country(results, country);
+        all.extend(results);
+    }
+
+    rerank_and_truncate(&mut all, limit);
+    all
 }
 
 /// Apply the Role-Smoothness Guarantee (#96).
@@ -497,12 +625,22 @@ fn materialize_result(rec: &ShardRecord, score: f32, reasons: Vec<&'static str>)
         postcode: String::from(&*rec.postcode),
         locality: String::from(&*rec.locality),
         score,
+        country: None,
         // Cow::Borrowed wraps the &'static str without allocation.
         reason_codes: reasons
             .into_iter()
             .map(std::borrow::Cow::Borrowed)
             .collect(),
     }
+}
+
+/// Tag every result with `c`'s ISO2 code. Used by [`execute_multi`]
+/// to mark which shard each result came from.
+fn tag_country(mut results: Vec<GeocodedResult>, c: CountryId) -> Vec<GeocodedResult> {
+    for r in &mut results {
+        r.country = Some(c.iso2());
+    }
+    results
 }
 
 /// Materialize a result for the `NEAREST` reverse-lookup path. Public
@@ -1101,7 +1239,7 @@ mod tests {
                 lon: 4.401,
             },
         ];
-        build_shard(&path, addrs).unwrap();
+        build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();
         let s = Shard::open(&path).unwrap();
         (dir, s)
     }
@@ -1228,7 +1366,7 @@ mod tests {
                 lon: 4.35 + (i as f64) * 1e-5,
             });
         }
-        build_shard(&path, addrs).unwrap();
+        build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();
         let shard = Shard::open(&path).unwrap();
 
         let mut q = parse_heuristic("1000 Bruxelles", CountryId::BE);

--- a/geocode/src/lib.rs
+++ b/geocode/src/lib.rs
@@ -73,11 +73,11 @@ pub mod tagger;
 pub mod types;
 
 pub use confidence::{Confidence, ConfidenceConfig, Features, GbdtModel};
-pub use geocoder::executor::{GeocodedResult, execute, execute_with_rerank};
-pub use parser::heuristic::parse_heuristic;
+pub use geocoder::executor::{GeocodedResult, execute, execute_across_shards, execute_with_rerank};
+pub use parser::heuristic::{parse_heuristic, parse_with_classifier};
 pub use parser::neural::NeuralParser;
 pub use parser::{HeuristicBackend, NeuralBackend, ParserBackend};
-pub use routing::{CountryId, classify_country};
+pub use routing::{CountryId, classify_country, country_for_point, supported_countries_for_point};
 pub use shard::reader::Shard;
 pub use types::{
     ExecutionBudget, FieldMask, ParseHypothesis, ParsedQuery, RecoveryFlags, RetrievalPolicy,

--- a/geocode/src/main.rs
+++ b/geocode/src/main.rs
@@ -10,6 +10,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use tracing::{Level, info, warn};
 use tracing_subscriber::EnvFilter;
 
+use butterfly_geocode::CountryId;
 use butterfly_geocode::confidence::{
     GbdtModel, TrainConfig, build_training_groups, build_training_rows, dump_training_rows,
     evaluate, load_corpus, synthesise_corpus_from_shard, train_pointwise,
@@ -48,12 +49,35 @@ enum ParserKind {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Build a shard from an OSM PBF.
+    /// Build a single-country shard from an OSM PBF.
     BuildShard {
+        /// Source PBF (any Geofabrik regional/country extract).
         #[arg(long)]
         pbf: PathBuf,
+        /// Output BFGS v3 shard file.
         #[arg(long)]
         out: PathBuf,
+        /// ISO 3166-1 alpha-2 country code for this shard. Stored
+        /// in the BFGS v3 header and verified at server load.
+        #[arg(long)]
+        country: String,
+    },
+    /// Build every country shard the server can deploy in one pass.
+    /// Looks for `<country>.pbf` (or `<iso2>.pbf`) inside `--pbf-dir`
+    /// for each ISO2 in the supported list, and emits
+    /// `<out_dir>/<iso2>.bfgs`. Missing PBFs are skipped with a
+    /// warning — operators can deploy the subset they have data for.
+    BuildShardsAll {
+        /// Directory containing per-country PBFs.
+        #[arg(long)]
+        pbf_dir: PathBuf,
+        /// Output directory for BFGS shards.
+        #[arg(long)]
+        out_dir: PathBuf,
+        /// Limit to a comma-separated subset (e.g. `BE,FR,NL`). If
+        /// unset, every supported country is attempted.
+        #[arg(long)]
+        only: Option<String>,
     },
     /// Train a byte-level transformer tagger (#96 §Tagger). When
     /// `--corpus` is omitted, an inline synthetic Belgium corpus is
@@ -86,8 +110,15 @@ enum Command {
     },
     /// Run the HTTP server.
     Serve {
-        #[arg(long)]
-        shard: PathBuf,
+        /// Single-shard mode: load this shard. Mutually exclusive
+        /// with `--shard-dir`.
+        #[arg(long, conflicts_with = "shard_dir")]
+        shard: Option<PathBuf>,
+        /// Multi-shard mode: load every `*.bfgs` in this directory.
+        /// Each shard is keyed by its on-disk country code (BFGS v3
+        /// header).
+        #[arg(long, conflicts_with = "shard")]
+        shard_dir: Option<PathBuf>,
         #[arg(long, default_value_t = 3003)]
         port: u16,
         #[arg(long, default_value = "0.0.0.0")]
@@ -141,7 +172,12 @@ async fn main() -> Result<()> {
     init_logging(&cli.log_format);
 
     match cli.cmd {
-        Command::BuildShard { pbf, out } => build_shard_cmd(&pbf, &out),
+        Command::BuildShard { pbf, out, country } => build_shard_cmd(&pbf, &out, &country),
+        Command::BuildShardsAll {
+            pbf_dir,
+            out_dir,
+            only,
+        } => build_shards_all_cmd(&pbf_dir, &out_dir, only.as_deref()),
         Command::Train {
             out,
             corpus,
@@ -161,6 +197,7 @@ async fn main() -> Result<()> {
         ),
         Command::Serve {
             shard,
+            shard_dir,
             port,
             host,
             rerank_model,
@@ -168,7 +205,8 @@ async fn main() -> Result<()> {
             model,
         } => {
             serve_cmd(
-                &shard,
+                shard.as_deref(),
+                shard_dir.as_deref(),
                 &host,
                 port,
                 rerank_model.as_deref(),
@@ -216,8 +254,23 @@ fn init_logging(format: &str) {
     }
 }
 
-fn build_shard_cmd(pbf: &PathBuf, out: &PathBuf) -> Result<()> {
-    info!(pbf = %pbf.display(), out = %out.display(), "extracting OSM addresses");
+fn build_shard_cmd(pbf: &std::path::Path, out: &std::path::Path, country_iso2: &str) -> Result<()> {
+    let country = CountryId::from_iso2(country_iso2).ok_or_else(|| {
+        anyhow!(
+            "unknown country '{country_iso2}' (supported: {})",
+            CountryId::ALL
+                .iter()
+                .map(|c| c.iso2())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    })?;
+    info!(
+        pbf = %pbf.display(),
+        out = %out.display(),
+        country = country.iso2(),
+        "extracting OSM addresses"
+    );
     let start = std::time::Instant::now();
 
     let addresses = extract_addresses(pbf, |evt| match evt {
@@ -238,7 +291,14 @@ fn build_shard_cmd(pbf: &PathBuf, out: &PathBuf) -> Result<()> {
         "extracted addresses"
     );
 
-    let stats = build_shard(out, addresses).context("writing shard")?;
+    if let Some(parent) = out.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating output dir {}", parent.display()))?;
+    }
+
+    let stats = build_shard(out, country, addresses).context("writing shard")?;
     info!(
         records = stats.record_count,
         unique_postcodes = stats.unique_postcodes,
@@ -246,14 +306,109 @@ fn build_shard_cmd(pbf: &PathBuf, out: &PathBuf) -> Result<()> {
         strings_bytes = stats.strings_bytes,
         records_bytes = stats.records_bytes,
         index_bytes = stats.index_bytes,
+        country = stats.country.iso2(),
         secs = start.elapsed().as_secs_f64(),
         "shard built"
     );
 
-    let _ = Shard::open(out).context("verifying shard CRC after build")?;
+    let s = Shard::open(out).context("verifying shard CRC after build")?;
+    if s.country() != country {
+        bail!(
+            "shard country mismatch after build: header says {} but we expected {}",
+            s.country().iso2(),
+            country.iso2()
+        );
+    }
     info!("shard verified");
 
     Ok(())
+}
+
+fn build_shards_all_cmd(
+    pbf_dir: &std::path::Path,
+    out_dir: &std::path::Path,
+    only: Option<&str>,
+) -> Result<()> {
+    if !pbf_dir.is_dir() {
+        bail!(
+            "pbf-dir does not exist or is not a directory: {}",
+            pbf_dir.display()
+        );
+    }
+    std::fs::create_dir_all(out_dir)
+        .with_context(|| format!("creating output dir {}", out_dir.display()))?;
+
+    let allowed: Option<Vec<CountryId>> = only.map(|s| {
+        s.split(',')
+            .filter_map(|t| CountryId::from_iso2(t.trim()))
+            .collect()
+    });
+
+    let mut built = Vec::<CountryId>::new();
+    let mut skipped = Vec::<(CountryId, String)>::new();
+    for &c in CountryId::ALL {
+        if let Some(ref a) = allowed
+            && !a.contains(&c)
+        {
+            continue;
+        }
+        let candidates = candidate_pbf_names(c);
+        let pbf = candidates
+            .iter()
+            .map(|n| pbf_dir.join(n))
+            .find(|p| p.is_file());
+        let Some(pbf) = pbf else {
+            warn!(
+                country = c.iso2(),
+                "no PBF found in {} (looked for {:?}); skipping",
+                pbf_dir.display(),
+                candidates
+            );
+            skipped.push((c, "no PBF".to_string()));
+            continue;
+        };
+        let out = out_dir.join(format!("{}.bfgs", c.iso2().to_ascii_lowercase()));
+        match build_shard_cmd(&pbf, &out, c.iso2()) {
+            Ok(_) => built.push(c),
+            Err(e) => {
+                warn!(country = c.iso2(), error = %e, "shard build failed; continuing");
+                skipped.push((c, e.to_string()));
+            }
+        }
+    }
+    info!(
+        built = built.len(),
+        skipped = skipped.len(),
+        "build-shards-all complete"
+    );
+    for (c, why) in &skipped {
+        info!(country = c.iso2(), reason = %why, "skipped");
+    }
+    Ok(())
+}
+
+fn candidate_pbf_names(c: CountryId) -> Vec<String> {
+    let long = match c {
+        CountryId::BE => "belgium",
+        CountryId::FR => "france",
+        CountryId::NL => "netherlands",
+        CountryId::LU => "luxembourg",
+        CountryId::DE => "germany",
+        CountryId::AT => "austria",
+        CountryId::CH => "switzerland",
+        // CountryId is `non_exhaustive`. New countries default to
+        // ISO2-only filename probing — add a friendlier name above.
+        _ => "",
+    };
+    let mut v = Vec::new();
+    if !long.is_empty() {
+        v.push(format!("{long}.pbf"));
+        v.push(format!("{long}.osm.pbf"));
+        v.push(format!("{long}-latest.osm.pbf"));
+    }
+    v.push(format!("{}.pbf", c.iso2().to_ascii_lowercase()));
+    v.push(format!("{}.osm.pbf", c.iso2().to_ascii_lowercase()));
+    v
 }
 
 fn train_cmd(
@@ -309,18 +464,16 @@ fn train_cmd(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn serve_cmd(
-    shard_path: &PathBuf,
+    shard_path: Option<&std::path::Path>,
+    shard_dir: Option<&std::path::Path>,
     host: &str,
     port: u16,
     rerank_model_path: Option<&std::path::Path>,
     parser_kind: ParserKind,
     model_path: Option<&std::path::Path>,
 ) -> Result<()> {
-    info!(shard = %shard_path.display(), "loading shard");
-    let shard = Shard::open(shard_path).context("opening shard")?;
-    info!(record_count = shard.record_count(), "shard loaded");
-
     // Pick the parser backend first — the neural parser is wired via
     // `ParserBackend` (#98 Phase 1), the heuristic backend is always
     // available as a deterministic fallback (Phase 0 baseline). The
@@ -354,7 +507,33 @@ async fn serve_cmd(
         }
     };
 
-    let mut state = ServerState::new(shard).with_parser(parser_backend);
+    let mut state = match (shard_path, shard_dir) {
+        (Some(p), None) => {
+            info!(shard = %p.display(), "loading shard (single-country mode)");
+            let shard = Shard::open(p).context("opening shard")?;
+            info!(
+                country = shard.country().iso2(),
+                record_count = shard.record_count(),
+                "shard loaded"
+            );
+            ServerState::new(shard)
+        }
+        (None, Some(d)) => {
+            info!(dir = %d.display(), "loading shards from directory (multi-country mode)");
+            let s = ServerState::load_from_dir(d).context("loading shards")?;
+            info!(
+                countries = ?s.loaded_countries(),
+                total_records = s.total_record_count(),
+                "shards loaded"
+            );
+            s
+        }
+        (Some(_), Some(_)) => unreachable!("clap's conflicts_with prevents this"),
+        (None, None) => {
+            bail!("missing --shard <PATH> or --shard-dir <DIR>; specify one");
+        }
+    };
+    state = state.with_parser(parser_backend);
     if let Some(p) = rerank_model_path {
         info!(model = %p.display(), "loading GBDT reranker");
         let model = GbdtModel::load(p).context("loading reranker")?;

--- a/geocode/src/parser/decoding.rs
+++ b/geocode/src/parser/decoding.rs
@@ -671,7 +671,7 @@ mod tests {
                 lon: 4.401,
             },
         ];
-        crate::shard::builder::build_shard(&path, addrs).unwrap();
+        crate::shard::builder::build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();
         (dir, Shard::open(&path).unwrap())
     }
 

--- a/geocode/src/parser/heuristic.rs
+++ b/geocode/src/parser/heuristic.rs
@@ -5,8 +5,10 @@
 //! ## Algorithm
 //!
 //! 1. Run the cheap country classifier (#96 §Country Routing).
-//! 2. Extract a Belgian postcode (`[1-9][0-9]{3}` matched as a
-//!    standalone token).
+//! 2. Extract a postcode using the per-country regex
+//!    ([`extract_postcode_for`]). 4-digit ([1-9]\\d{3}) for BE, LU,
+//!    AT, CH; 5-digit (\\d{5}) for FR and DE; 4-digit + alpha
+//!    suffix for NL (`1011 AB`).
 //! 3. Extract a house number — leading or trailing numeric/alphanumeric
 //!    token (e.g. `122`, `122a`, `122-126`).
 //! 4. The remaining tokens are the street + locality.
@@ -22,15 +24,44 @@ use crate::types::{
     Strictness,
 };
 
+/// Parse a free-text address against a single, caller-asserted
+/// country. The returned [`ParsedQuery`] has exactly one country
+/// candidate (the one passed in, weight 1.0) and one hypothesis —
+/// this is the **clean-query** input shape per #96
+/// §Zero-Cost-on-Clean-Queries, and the executor's fast path will
+/// fire on it.
+///
+/// For multi-country routing where the country is unknown, use
+/// [`parse_with_classifier`].
 #[must_use]
 pub fn parse_heuristic(text: &str, country: CountryId) -> ParsedQuery {
-    debug_assert_eq!(country, CountryId::BE, "MVP only ships BE");
+    let mut q = parse_for_country(text, country);
+    q.country_candidates = vec![(country, 1.0)];
+    q
+}
 
+/// Parse against the cheap classifier's country posterior. Returns a
+/// query with `country_candidates` populated from
+/// [`classify_country`] (sorted descending by weight). The parser's
+/// per-country regex is run for the **top** country; the executor's
+/// multi-shard walk handles the remaining countries by re-using the
+/// same hypothesis (postcodes that don't match a shard's record set
+/// produce zero hits there).
+#[must_use]
+pub fn parse_with_classifier(text: &str) -> ParsedQuery {
+    let posterior = classify_country(text);
+    let primary = posterior.first().map(|(c, _)| *c).unwrap_or(CountryId::BE);
+    let mut q = parse_for_country(text, primary);
+    q.country_candidates = posterior;
+    q
+}
+
+fn parse_for_country(text: &str, country: CountryId) -> ParsedQuery {
     let original = text.to_string();
     let mut hypothesis = ParseHypothesis::default();
     let mut flags = RecoveryFlags::default();
 
-    let postcode = extract_postcode(text);
+    let postcode = extract_postcode_for(text, country);
     if let Some(ref pc) = postcode {
         hypothesis.postcode_candidates.push((pc.clone(), 1.0));
         flags.had_postcode = true;
@@ -86,14 +117,17 @@ pub fn parse_heuristic(text: &str, country: CountryId) -> ParsedQuery {
     }
 
     hypothesis.field_reliability = build_field_mask(&flags);
-    hypothesis.retrieval_policy = RetrievalPolicy::belgium_default();
+    hypothesis.retrieval_policy = retrieval_policy_for(country);
     hypothesis.strictness = Strictness::Exact;
 
     let confidence = score_confidence(&flags);
 
     ParsedQuery {
         original_text: original,
-        country_candidates: classify_country(text),
+        // `parse_heuristic` overrides this with `[(country, 1.0)]`
+        // for the clean-query path; `parse_with_classifier` keeps
+        // the full posterior. We populate a placeholder here.
+        country_candidates: vec![(country, 1.0)],
         hypotheses: vec![hypothesis],
         global_confidence: confidence,
         recovery_flags: flags,
@@ -126,13 +160,71 @@ fn score_confidence(flags: &RecoveryFlags) -> f32 {
     s.min(1.0)
 }
 
-fn postcode_re() -> &'static Regex {
+/// 4-digit postcode (BE, LU, AT, CH).
+fn pc_4digit_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| Regex::new(r"\b[1-9][0-9]{3}\b").expect("valid regex"))
 }
 
-fn extract_postcode(text: &str) -> Option<String> {
-    postcode_re().find(text).map(|m| m.as_str().to_string())
+/// 5-digit postcode (FR, DE). FR: 01xxx-95xxx (Corsica is 200xx).
+/// DE: 01xxx-99xxx. We accept any 5 digits at word boundaries.
+fn pc_5digit_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\b\d{5}\b").expect("valid regex"))
+}
+
+/// NL postcode: 4-digit + 2-letter (e.g. `1011 AB`).
+fn pc_nl_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\b\d{4}\s?[A-Za-z]{2}\b").expect("valid regex"))
+}
+
+/// L-prefixed Luxembourg postcode (`L-2453`). When this matches, drop
+/// the prefix so the shard lookup uses the bare 4-digit form.
+fn pc_lu_prefixed_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\bL-(\d{4})\b").expect("valid regex"))
+}
+
+fn extract_postcode_for(text: &str, country: CountryId) -> Option<String> {
+    match country {
+        // 5-digit countries.
+        CountryId::FR | CountryId::DE => pc_5digit_re().find(text).map(|m| m.as_str().to_string()),
+        // NL = 4-digit + 2-letter.
+        CountryId::NL => pc_nl_re().find(text).map(|m| {
+            // Canonicalize: collapse internal whitespace so `1011 AB`
+            // and `1011AB` produce the same key.
+            m.as_str().split_whitespace().collect::<Vec<_>>().join("")
+        }),
+        // Luxembourg accepts either bare 4-digit or L-prefixed.
+        CountryId::LU => {
+            if let Some(c) = pc_lu_prefixed_re().captures(text) {
+                return c.get(1).map(|m| m.as_str().to_string());
+            }
+            pc_4digit_re().find(text).map(|m| m.as_str().to_string())
+        }
+        // 4-digit countries.
+        CountryId::BE | CountryId::AT | CountryId::CH => {
+            pc_4digit_re().find(text).map(|m| m.as_str().to_string())
+        }
+    }
+}
+
+/// Country-specific [`RetrievalPolicy`]. Per #96 §Channel Roles
+/// each country pack chooses its strongest evidence anchor; for the
+/// cluster #1 + #2 set (BE / FR / NL / LU / DE / AT / CH) the
+/// shape is uniform: postcode as Blocker, street as Reducer,
+/// house-number + locality as Scorers.
+fn retrieval_policy_for(country: CountryId) -> RetrievalPolicy {
+    match country {
+        CountryId::BE
+        | CountryId::FR
+        | CountryId::NL
+        | CountryId::LU
+        | CountryId::DE
+        | CountryId::AT
+        | CountryId::CH => RetrievalPolicy::european_postcode_anchor(),
+    }
 }
 
 fn house_number_re() -> &'static Regex {
@@ -254,6 +346,53 @@ mod tests {
         let h = &q.hypotheses[0];
         assert!(h.street_candidates.is_empty());
         assert!(h.postcode_candidates.is_empty());
+    }
+
+    #[test]
+    fn parses_french_postcode() {
+        let q = parse_heuristic("10 rue de la Paix 75001 Paris", CountryId::FR);
+        let h = &q.hypotheses[0];
+        assert_eq!(h.postcode_candidates[0].0, "75001");
+        assert_eq!(h.house_candidates[0].0, "10");
+    }
+
+    #[test]
+    fn parses_dutch_postcode() {
+        let q = parse_heuristic("Damrak 1 1012 LP Amsterdam", CountryId::NL);
+        let h = &q.hypotheses[0];
+        // Whitespace is collapsed canonical: "1012LP".
+        assert_eq!(h.postcode_candidates[0].0, "1012LP");
+        assert_eq!(h.house_candidates[0].0, "1");
+    }
+
+    #[test]
+    fn parses_german_postcode() {
+        let q = parse_heuristic("Friedrichstraße 100 10117 Berlin", CountryId::DE);
+        let h = &q.hypotheses[0];
+        assert_eq!(h.postcode_candidates[0].0, "10117");
+        assert_eq!(h.house_candidates[0].0, "100");
+    }
+
+    #[test]
+    fn parses_austrian_postcode() {
+        let q = parse_heuristic("Stephansplatz 1 1010 Wien", CountryId::AT);
+        let h = &q.hypotheses[0];
+        assert_eq!(h.postcode_candidates[0].0, "1010");
+    }
+
+    #[test]
+    fn parses_swiss_postcode() {
+        let q = parse_heuristic("Bahnhofstrasse 1 8001 Zürich", CountryId::CH);
+        let h = &q.hypotheses[0];
+        assert_eq!(h.postcode_candidates[0].0, "8001");
+    }
+
+    #[test]
+    fn parses_luxembourg_lprefixed_postcode() {
+        let q = parse_heuristic("12 rue de la Gare L-2453 Luxembourg", CountryId::LU);
+        let h = &q.hypotheses[0];
+        // L-2453 is canonicalized to bare 2453 for shard lookup.
+        assert_eq!(h.postcode_candidates[0].0, "2453");
     }
 
     #[test]

--- a/geocode/src/parser/neural.rs
+++ b/geocode/src/parser/neural.rs
@@ -140,7 +140,7 @@ mod tests {
                 lon: 4.401,
             },
         ];
-        build_shard(&path, addrs).unwrap();
+        build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();
         (dir, Shard::open(&path).unwrap())
     }
 
@@ -162,6 +162,11 @@ mod tests {
             .parse("Rue Wayez 122 1070 Anderlecht", &shard)
             .unwrap();
         assert!(!parsed.hypotheses.is_empty());
-        assert_eq!(parsed.country_candidates.len(), 1);
+        // Multi-country classifier returns one entry per supported
+        // country. The merged neural posterior may stay flat for the
+        // shipped tiny model (single-country output head) — the
+        // top-1 country must still be Belgium given the input text.
+        assert!(!parsed.country_candidates.is_empty());
+        assert_eq!(parsed.country_candidates[0].0, CountryId::BE);
     }
 }

--- a/geocode/src/routing/bbox.rs
+++ b/geocode/src/routing/bbox.rs
@@ -1,0 +1,145 @@
+//! Country bounding boxes — used by the reverse-geocoding spatial
+//! dispatch and as a coarse prior for the forward classifier (#96
+//! §Country Routing).
+//!
+//! These are conservative land-area bboxes from public reference data
+//! (CIA World Factbook + Wikipedia). They are deliberately a few
+//! tenths of a degree larger than the ISO administrative borders so
+//! coastline points and small enclaves resolve cleanly. Overlap
+//! between bboxes is expected (e.g. BE / NL / DE all hit Aachen
+//! triangle); [`country_for_point`] picks the smallest bbox containing
+//! the point as a tiebreak.
+//!
+//! The actual country routing for forward queries is the lexical
+//! [`super::classifier`]. These bboxes are the secondary path the
+//! reverse endpoint uses when no input string is available.
+
+use super::CountryId;
+
+/// (min_lat, max_lat, min_lon, max_lon) in WGS84 degrees.
+#[must_use]
+pub fn bbox(c: CountryId) -> (f64, f64, f64, f64) {
+    match c {
+        // Belgium: 49.5 to 51.5, 2.5 to 6.4
+        CountryId::BE => (49.50, 51.55, 2.50, 6.45),
+        // France (mainland): 41.3 to 51.1, -5.2 to 9.6 (DOM-TOMs excluded)
+        CountryId::FR => (41.30, 51.15, -5.25, 9.65),
+        // Netherlands (European): 50.7 to 53.6, 3.3 to 7.3
+        CountryId::NL => (50.70, 53.60, 3.30, 7.30),
+        // Luxembourg: 49.4 to 50.2, 5.7 to 6.6
+        CountryId::LU => (49.42, 50.22, 5.70, 6.55),
+        // Germany: 47.2 to 55.1, 5.8 to 15.1
+        CountryId::DE => (47.25, 55.10, 5.80, 15.10),
+        // Austria: 46.3 to 49.1, 9.5 to 17.2
+        CountryId::AT => (46.32, 49.05, 9.50, 17.20),
+        // Switzerland: 45.7 to 47.9, 5.9 to 10.5
+        CountryId::CH => (45.75, 47.90, 5.90, 10.55),
+    }
+}
+
+/// Approximate bbox area in (lat × lon) degree-squared. Used as a
+/// tiebreak when multiple bboxes contain the point — pick the
+/// smallest (most-specific) bbox.
+fn area_deg2(c: CountryId) -> f64 {
+    let (a, b, x, y) = bbox(c);
+    (b - a) * (y - x)
+}
+
+/// Test whether a point falls inside a country bbox.
+#[must_use]
+pub fn contains(c: CountryId, lat: f64, lon: f64) -> bool {
+    let (lat_lo, lat_hi, lon_lo, lon_hi) = bbox(c);
+    lat >= lat_lo && lat <= lat_hi && lon >= lon_lo && lon <= lon_hi
+}
+
+/// Select the most-specific (smallest-bbox) country containing the
+/// point. Used by the reverse-geocoding spatial dispatch when the
+/// caller didn't pin a country.
+#[must_use]
+pub fn country_for_point(lat: f64, lon: f64) -> Option<CountryId> {
+    CountryId::ALL
+        .iter()
+        .copied()
+        .filter(|&c| contains(c, lat, lon))
+        .min_by(|&a, &b| {
+            area_deg2(a)
+                .partial_cmp(&area_deg2(b))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+}
+
+/// Return every country whose bbox contains the point. Border-region
+/// queries with shards loaded for both countries can use this to fan
+/// out, falling back to [`country_for_point`] if only one shard is
+/// loaded.
+#[must_use]
+pub fn supported_countries_for_point(lat: f64, lon: f64) -> Vec<CountryId> {
+    CountryId::ALL
+        .iter()
+        .copied()
+        .filter(|&c| contains(c, lat, lon))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn brussels_is_belgium() {
+        // Grand-Place: 50.8467, 4.3525
+        assert_eq!(country_for_point(50.8467, 4.3525), Some(CountryId::BE));
+    }
+
+    #[test]
+    fn paris_is_france() {
+        // Eiffel Tower: 48.8584, 2.2945
+        assert_eq!(country_for_point(48.8584, 2.2945), Some(CountryId::FR));
+    }
+
+    #[test]
+    fn amsterdam_is_netherlands() {
+        // Amsterdam Centraal: 52.3791, 4.9003
+        assert_eq!(country_for_point(52.3791, 4.9003), Some(CountryId::NL));
+    }
+
+    #[test]
+    fn luxembourg_city_is_luxembourg() {
+        // Luxembourg City: 49.6116, 6.1319
+        assert_eq!(country_for_point(49.6116, 6.1319), Some(CountryId::LU));
+    }
+
+    #[test]
+    fn berlin_is_germany() {
+        // Brandenburg Gate: 52.5163, 13.3777
+        assert_eq!(country_for_point(52.5163, 13.3777), Some(CountryId::DE));
+    }
+
+    #[test]
+    fn vienna_is_austria() {
+        // Stephansplatz: 48.2085, 16.3725
+        assert_eq!(country_for_point(48.2085, 16.3725), Some(CountryId::AT));
+    }
+
+    #[test]
+    fn zurich_is_switzerland() {
+        // Zurich HB: 47.3779, 8.5403
+        assert_eq!(country_for_point(47.3779, 8.5403), Some(CountryId::CH));
+    }
+
+    #[test]
+    fn aachen_overlap_picks_smallest_bbox() {
+        // Aachen Hbf: 50.7676, 6.0911 — sits in the BE/NL/DE
+        // triangle. We expect supported_countries_for_point to
+        // surface ALL three; country_for_point picks the smallest
+        // bbox, which is BE here (DE is huge).
+        let all = supported_countries_for_point(50.7676, 6.0911);
+        assert!(all.contains(&CountryId::DE));
+        assert_eq!(country_for_point(50.7676, 6.0911), Some(CountryId::BE));
+    }
+
+    #[test]
+    fn ocean_outside_any_country() {
+        assert_eq!(country_for_point(40.0, -30.0), None);
+    }
+}

--- a/geocode/src/routing/classifier.rs
+++ b/geocode/src/routing/classifier.rs
@@ -1,25 +1,422 @@
 //! Cheap deterministic country classifier (#96 §Country Routing).
 //!
-//! Belgium-only MVP returns `[(CountryId::BE, 1.0)]`. Shape matches
-//! the architecture so the multi-country version (postcode regex,
-//! script detection, lexical cues) can extend in place.
+//! The classifier is a fast, lexical pre-stage that runs BEFORE the
+//! parser and BEFORE retrieval. It does not need to be right; it
+//! needs to be **calibrated** — it returns a posterior `(country,
+//! confidence)` distribution so the executor can budget its fanout.
+//!
+//! ## Signals
+//!
+//! Per #96 cluster #1 + cluster #2 (BE / FR / NL / LU / DE / AT / CH)
+//! the classifier looks at three classes of signal, additively
+//! contributing log-evidence per country, then softmaxed:
+//!
+//! 1. **Postcode shape.** Each country has a regex; matches contribute
+//!    strong evidence for that country's shape and any peer country
+//!    sharing the shape (e.g. 4-digit overlaps BE / LU / AT / CH).
+//! 2. **Lexical markers.** Street-type keywords ("rue", "straat",
+//!    "strasse", "platz") are the most reliable signal. Locality
+//!    aliases (Brussels / Bruxelles / Brussel) follow.
+//! 3. **Diacritics + script.** ß → DE/AT (not CH which uses ss).
+//!    Accented Latin → not DE/NL primarily.
+//!
+//! When multiple countries are plausible, the classifier returns ALL
+//! of them with normalized weights summing to 1.0. This is what the
+//! executor consumes — see `executor::execute`.
+//!
+//! ## Shape, not full coverage
+//!
+//! This is the *cheap* classifier. If it is uncertain (top mass < 0.7)
+//! the architecture defers to the byte-level transformer (#96 §Country
+//! Routing — "If uncertain → let the transformer's country head run
+//! fully"). When the transformer ships (in `parser::neural`), it
+//! refines this posterior; until then, the classifier is the only
+//! signal and the executor falls back on the budget's `max_countries`
+//! cap to bound fanout.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
 
 use super::CountryId;
 
+/// Classify the country distribution implied by an input string.
+///
+/// Returns a sorted (descending by weight) list of `(country, weight)`
+/// pairs whose weights sum to 1.0. The list always contains every
+/// country that matched at least one signal; if no signal fires, it
+/// returns a uniform prior over all supported countries (so the
+/// executor can degrade gracefully to "search every shard").
 #[must_use]
-pub fn classify_country(_text: &str) -> Vec<(CountryId, f32)> {
-    vec![(CountryId::BE, 1.0)]
+pub fn classify_country(text: &str) -> Vec<(CountryId, f32)> {
+    let lower = text.to_lowercase();
+    let mut log_evidence: [f32; CountryId::ALL.len()] = [0.0; CountryId::ALL.len()];
+
+    apply_postcode_signals(&lower, text, &mut log_evidence);
+    apply_lexical_signals(&lower, &mut log_evidence);
+    apply_script_signals(text, &mut log_evidence);
+
+    if log_evidence.iter().all(|&v| v == 0.0) {
+        // No signal — uniform prior. Executor will use
+        // `max_countries` to cap the fanout.
+        let n = CountryId::ALL.len() as f32;
+        let mut out: Vec<(CountryId, f32)> = CountryId::ALL
+            .iter()
+            .copied()
+            .map(|c| (c, 1.0 / n))
+            .collect();
+        // Stable sort by ISO so output is deterministic when uniform.
+        out.sort_by_key(|(c, _)| c.iso2());
+        return out;
+    }
+
+    // Softmax over the evidence vector. Subtract max for stability.
+    let max = log_evidence
+        .iter()
+        .copied()
+        .fold(f32::NEG_INFINITY, f32::max);
+    let exps: Vec<f32> = log_evidence.iter().map(|&v| (v - max).exp()).collect();
+    let sum: f32 = exps.iter().sum();
+
+    let mut out: Vec<(CountryId, f32)> = CountryId::ALL
+        .iter()
+        .copied()
+        .zip(exps.iter())
+        .map(|(c, &e)| (c, e / sum))
+        .collect();
+
+    out.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.iso2().cmp(b.0.iso2()))
+    });
+    out
+}
+
+fn idx(c: CountryId) -> usize {
+    match c {
+        CountryId::BE => 0,
+        CountryId::FR => 1,
+        CountryId::NL => 2,
+        CountryId::LU => 3,
+        CountryId::DE => 4,
+        CountryId::AT => 5,
+        CountryId::CH => 6,
+    }
+}
+
+fn add(evidence: &mut [f32; 7], c: CountryId, w: f32) {
+    evidence[idx(c)] += w;
+}
+
+/// Per-country postcode regex. Run on the raw input (case is
+/// irrelevant because the patterns are digit-anchored).
+fn pc_be_lu_at_ch_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\b[1-9]\d{3}\b").expect("4-digit pc regex"))
+}
+fn pc_fr_de_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\b[0-9]\d{4}\b").expect("5-digit pc regex"))
+}
+fn pc_nl_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\b\d{4}\s?[A-Za-z]{2}\b").expect("nl pc regex"))
+}
+fn pc_lu_prefixed_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\bL-\d{4}\b").expect("lu pc regex"))
+}
+
+fn apply_postcode_signals(_lower: &str, raw: &str, evidence: &mut [f32; 7]) {
+    // Strongest postcode signal first: NL (alpha suffix). If this
+    // fires we're very confident NL.
+    if pc_nl_re().is_match(raw) {
+        add(evidence, CountryId::NL, 3.0);
+    }
+    // L-prefixed Luxembourg postcode (e.g. "L-2453") — distinctive.
+    if pc_lu_prefixed_re().is_match(raw) {
+        add(evidence, CountryId::LU, 3.0);
+    }
+
+    // 5-digit shape: FR / DE share it. Split between them for now;
+    // lexical signals or a second pass narrows it.
+    if pc_fr_de_re().is_match(raw) {
+        add(evidence, CountryId::FR, 1.0);
+        add(evidence, CountryId::DE, 1.0);
+    }
+
+    // 4-digit shape: BE / LU / AT / CH share it. Slightly biased
+    // toward BE because BE has the densest queryable address corpus
+    // in this group; lexical disambiguation kicks in if other signals
+    // fire.
+    if pc_be_lu_at_ch_re().is_match(raw) {
+        add(evidence, CountryId::BE, 1.0);
+        add(evidence, CountryId::LU, 0.8);
+        add(evidence, CountryId::AT, 0.8);
+        add(evidence, CountryId::CH, 0.8);
+    }
+}
+
+fn contains_word(text: &str, word: &str) -> bool {
+    let bytes = text.as_bytes();
+    let wbytes = word.as_bytes();
+    if wbytes.is_empty() || bytes.len() < wbytes.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i + wbytes.len() <= bytes.len() {
+        if &bytes[i..i + wbytes.len()] == wbytes {
+            let before_ok = i == 0 || !bytes[i - 1].is_ascii_alphabetic();
+            let after_ok =
+                i + wbytes.len() == bytes.len() || !bytes[i + wbytes.len()].is_ascii_alphabetic();
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Returns `true` if any of `needles` occurs as a whole-token in
+/// `text` (lowercase).
+fn any_word(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|w| contains_word(text, w))
+}
+
+/// Returns `true` if any of `needles` occurs as a *substring* in
+/// `text` (lowercase). Use for suffixes ("straat", "strasse") that
+/// are not stand-alone words but appear glued to street stems.
+fn any_substr(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|s| text.contains(s))
+}
+
+fn apply_lexical_signals(lower: &str, evidence: &mut [f32; 7]) {
+    // ── French markers ──
+    // "rue", "avenue", "boulevard", "place", "chaussée".
+    // Belgian French is the same as Metropolitan French at the
+    // street-type level. We boost FR slightly more than BE because
+    // when these appear without other Belgian markers the prior is
+    // FR.
+    if any_word(
+        lower,
+        &["rue", "avenue", "boulevard", "chaussee", "chaussée"],
+    ) {
+        add(evidence, CountryId::FR, 1.5);
+        add(evidence, CountryId::BE, 1.0);
+        add(evidence, CountryId::LU, 0.7);
+        add(evidence, CountryId::CH, 0.5);
+    }
+    if any_word(lower, &["allee", "allée", "impasse", "quai"]) {
+        add(evidence, CountryId::FR, 1.0);
+        add(evidence, CountryId::BE, 0.6);
+        add(evidence, CountryId::LU, 0.5);
+        add(evidence, CountryId::CH, 0.3);
+    }
+
+    // ── Dutch markers ──
+    // "straat" (street suffix), "laan" (avenue suffix), "plein"
+    // (square), "weg" (way), "gracht" (canal — strongly NL/BE-Flemish).
+    if any_substr(lower, &["straat", "kerkstraat", "dorpsstraat"]) {
+        add(evidence, CountryId::NL, 1.6);
+        add(evidence, CountryId::BE, 1.1);
+    }
+    if any_substr(lower, &["laan", "plein", "gracht"]) {
+        add(evidence, CountryId::NL, 1.3);
+        add(evidence, CountryId::BE, 0.9);
+    }
+    if any_word(lower, &["markt", "grote markt"]) {
+        add(evidence, CountryId::BE, 0.8);
+        add(evidence, CountryId::NL, 0.7);
+    }
+
+    // ── German markers ──
+    // "strasse", "straße", "platz", "weg", "gasse" (AT-leaning).
+    if any_substr(lower, &["strasse", "straße", "str."]) {
+        add(evidence, CountryId::DE, 1.5);
+        add(evidence, CountryId::AT, 1.2);
+        add(evidence, CountryId::CH, 1.1);
+    }
+    if any_substr(lower, &["platz"]) {
+        add(evidence, CountryId::DE, 1.0);
+        add(evidence, CountryId::AT, 0.9);
+        add(evidence, CountryId::CH, 0.7);
+    }
+    // Austrian-leaning "gasse" (small street) — common in Vienna,
+    // less so elsewhere.
+    if any_substr(lower, &["gasse"]) {
+        add(evidence, CountryId::AT, 1.2);
+        add(evidence, CountryId::DE, 0.6);
+        add(evidence, CountryId::CH, 0.3);
+    }
+
+    // ── Locality aliases (cluster #1 + #2 cross-border) ──
+    // Strongest country-specific lexical evidence — locality names
+    // that exist only in one country.
+    for (term, c, w) in &[
+        ("amsterdam", CountryId::NL, 2.0),
+        ("rotterdam", CountryId::NL, 2.0),
+        ("utrecht", CountryId::NL, 2.0),
+        ("eindhoven", CountryId::NL, 2.0),
+        ("paris", CountryId::FR, 2.0),
+        ("marseille", CountryId::FR, 2.0),
+        ("lyon", CountryId::FR, 2.0),
+        ("toulouse", CountryId::FR, 2.0),
+        ("strasbourg", CountryId::FR, 2.0),
+        ("luxembourg", CountryId::LU, 1.5),
+        ("lëtzebuerg", CountryId::LU, 2.5),
+        ("esch-sur-alzette", CountryId::LU, 2.5),
+        ("differdange", CountryId::LU, 2.0),
+        ("berlin", CountryId::DE, 2.0),
+        ("hamburg", CountryId::DE, 2.0),
+        ("münchen", CountryId::DE, 2.0),
+        ("munich", CountryId::DE, 1.5),
+        ("frankfurt", CountryId::DE, 2.0),
+        ("köln", CountryId::DE, 2.0),
+        ("cologne", CountryId::DE, 1.5),
+        ("wien", CountryId::AT, 2.0),
+        ("vienna", CountryId::AT, 1.5),
+        ("salzburg", CountryId::AT, 2.0),
+        ("graz", CountryId::AT, 2.0),
+        ("innsbruck", CountryId::AT, 2.0),
+        ("zürich", CountryId::CH, 2.0),
+        ("zurich", CountryId::CH, 1.5),
+        ("genève", CountryId::CH, 2.0),
+        ("geneva", CountryId::CH, 1.5),
+        ("bern", CountryId::CH, 1.5),
+        ("basel", CountryId::CH, 2.0),
+        ("lausanne", CountryId::CH, 2.0),
+        ("brussels", CountryId::BE, 2.0),
+        ("bruxelles", CountryId::BE, 2.0),
+        ("brussel", CountryId::BE, 2.0),
+        ("anderlecht", CountryId::BE, 2.0),
+        ("anvers", CountryId::BE, 2.0),
+        ("antwerpen", CountryId::BE, 2.0),
+        ("antwerp", CountryId::BE, 2.0),
+        ("liege", CountryId::BE, 1.5),
+        ("liège", CountryId::BE, 2.0),
+        ("gent", CountryId::BE, 2.0),
+        ("ghent", CountryId::BE, 1.5),
+    ] {
+        if contains_word(lower, term) {
+            add(evidence, *c, *w);
+        }
+    }
+}
+
+fn apply_script_signals(raw: &str, evidence: &mut [f32; 7]) {
+    // ß is German/Austrian — Swiss German uses 'ss'.
+    if raw.contains('ß') {
+        add(evidence, CountryId::DE, 0.8);
+        add(evidence, CountryId::AT, 0.8);
+    }
+    // ë / ï in lowercase French/Dutch contexts is mildly anti-DE
+    // (DE doesn't use diaereses outside loanwords).
+    if raw.contains('ë') || raw.contains('ï') {
+        add(evidence, CountryId::FR, 0.3);
+        add(evidence, CountryId::NL, 0.3);
+        add(evidence, CountryId::BE, 0.3);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn top(v: &[(CountryId, f32)]) -> CountryId {
+        v[0].0
+    }
+    fn weight(v: &[(CountryId, f32)], c: CountryId) -> f32 {
+        v.iter()
+            .find(|(x, _)| *x == c)
+            .map(|(_, w)| *w)
+            .unwrap_or(0.0)
+    }
+
     #[test]
-    fn classify_returns_be() {
+    fn weights_sum_to_one() {
+        for q in [
+            "Rue Wayez 122 1070 Anderlecht",
+            "Damrak 1 1012 LP Amsterdam",
+            "Friedrichstraße 100 10117 Berlin",
+            "Stephansplatz 1 1010 Wien",
+            "Bahnhofstrasse 1 8001 Zürich",
+            "L-2453 Luxembourg",
+            "10 rue de la Paix 75001 Paris",
+            "",
+            "no markers here just gibberish",
+        ] {
+            let r = classify_country(q);
+            let s: f32 = r.iter().map(|(_, w)| w).sum();
+            assert!((s - 1.0).abs() < 1e-3, "weights for {q:?} sum to {s}");
+        }
+    }
+
+    #[test]
+    fn top_country_be_for_brussels_query() {
         let r = classify_country("Rue Wayez 122 1070 Anderlecht");
-        assert_eq!(r.len(), 1);
-        assert_eq!(r[0].0, CountryId::BE);
-        assert!((r[0].1 - 1.0).abs() < f32::EPSILON);
+        assert_eq!(top(&r), CountryId::BE);
+    }
+
+    #[test]
+    fn top_country_fr_for_paris_query() {
+        let r = classify_country("10 rue de la Paix 75001 Paris");
+        assert_eq!(top(&r), CountryId::FR);
+    }
+
+    #[test]
+    fn top_country_nl_for_amsterdam_query() {
+        let r = classify_country("Damrak 1 1012 LP Amsterdam");
+        assert_eq!(top(&r), CountryId::NL);
+    }
+
+    #[test]
+    fn top_country_de_for_berlin_query() {
+        let r = classify_country("Friedrichstraße 100 10117 Berlin");
+        assert_eq!(top(&r), CountryId::DE);
+    }
+
+    #[test]
+    fn top_country_at_for_vienna_query() {
+        let r = classify_country("Stephansplatz 1 1010 Wien");
+        assert_eq!(top(&r), CountryId::AT);
+    }
+
+    #[test]
+    fn top_country_ch_for_zurich_query() {
+        let r = classify_country("Bahnhofstrasse 1 8001 Zürich");
+        assert_eq!(top(&r), CountryId::CH);
+    }
+
+    #[test]
+    fn top_country_lu_for_lprefixed() {
+        let r = classify_country("L-2453 Luxembourg");
+        assert_eq!(top(&r), CountryId::LU);
+    }
+
+    #[test]
+    fn ambiguous_4digit_postcode_ranks_be_lu_at() {
+        let r = classify_country("1070");
+        assert!(weight(&r, CountryId::BE) > 0.0);
+        assert!(weight(&r, CountryId::LU) > 0.0);
+        assert!(weight(&r, CountryId::AT) > 0.0);
+        assert!(weight(&r, CountryId::CH) > 0.0);
+    }
+
+    #[test]
+    fn ambiguous_5digit_postcode_ranks_fr_de() {
+        let r = classify_country("75001");
+        assert!(weight(&r, CountryId::FR) > 0.05);
+        assert!(weight(&r, CountryId::DE) > 0.05);
+    }
+
+    #[test]
+    fn empty_falls_back_to_uniform() {
+        let r = classify_country("");
+        let n = CountryId::ALL.len();
+        for (_, w) in &r {
+            assert!((*w - 1.0 / n as f32).abs() < 1e-3);
+        }
     }
 }

--- a/geocode/src/routing/mod.rs
+++ b/geocode/src/routing/mod.rs
@@ -1,35 +1,155 @@
 //! Country routing — first-class stage that runs BEFORE full parsing
 //! per #96.
 
+pub mod bbox;
 pub mod classifier;
 
+pub use bbox::{country_for_point, supported_countries_for_point};
 pub use classifier::classify_country;
 use serde::{Deserialize, Serialize};
 
-/// Country identifier.
+/// Country identifier (ISO 3166-1 alpha-2).
 ///
-/// MVP only ships [`Self::BE`]. The enum is `non_exhaustive` so adding
-/// variants in a follow-up phase does not break downstream callers.
+/// The set of variants here is the set of countries the geocoder
+/// knows how to build a shard for. Adding a country is a 4-step
+/// change: extend this enum, add the lexical signals to
+/// [`classifier`], add the lat/lon bounding box to [`bbox`], and ship
+/// a shard built via `build-shard --country <code>`.
+///
+/// Per #96 cluster #1 (BE / FR / NL / LU / DE) and cluster #2
+/// (AT / DE / CH) is the multi-country MVP scope.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum CountryId {
-    /// Belgium (ISO 3166-1 alpha-2: BE).
+    /// Belgium.
     BE,
+    /// France.
+    FR,
+    /// Netherlands.
+    NL,
+    /// Luxembourg.
+    LU,
+    /// Germany.
+    DE,
+    /// Austria.
+    AT,
+    /// Switzerland.
+    CH,
 }
 
 impl CountryId {
+    /// All countries the geocoder is wired for.
+    pub const ALL: &'static [CountryId] = &[
+        CountryId::BE,
+        CountryId::FR,
+        CountryId::NL,
+        CountryId::LU,
+        CountryId::DE,
+        CountryId::AT,
+        CountryId::CH,
+    ];
+
+    /// ISO 3166-1 alpha-2 code, uppercase.
     #[must_use]
     pub fn iso2(self) -> &'static str {
         match self {
             CountryId::BE => "BE",
+            CountryId::FR => "FR",
+            CountryId::NL => "NL",
+            CountryId::LU => "LU",
+            CountryId::DE => "DE",
+            CountryId::AT => "AT",
+            CountryId::CH => "CH",
         }
     }
 
+    /// Parse an ISO 3166-1 alpha-2 code (case-insensitive). Returns
+    /// `None` for codes outside the supported set.
     #[must_use]
     pub fn from_iso2(code: &str) -> Option<Self> {
         match code.trim().to_ascii_uppercase().as_str() {
             "BE" => Some(CountryId::BE),
+            "FR" => Some(CountryId::FR),
+            "NL" => Some(CountryId::NL),
+            "LU" => Some(CountryId::LU),
+            "DE" => Some(CountryId::DE),
+            "AT" => Some(CountryId::AT),
+            "CH" => Some(CountryId::CH),
             _ => None,
+        }
+    }
+
+    /// Encode as a single byte for on-disk shard headers (BFGS v3).
+    /// Stable: never reuse a code for a different country across
+    /// versions.
+    #[must_use]
+    pub fn to_u8(self) -> u8 {
+        match self {
+            CountryId::BE => 1,
+            CountryId::FR => 2,
+            CountryId::NL => 3,
+            CountryId::LU => 4,
+            CountryId::DE => 5,
+            CountryId::AT => 6,
+            CountryId::CH => 7,
+        }
+    }
+
+    /// Decode a header byte to a country.
+    #[must_use]
+    pub fn from_u8(b: u8) -> Option<Self> {
+        match b {
+            1 => Some(CountryId::BE),
+            2 => Some(CountryId::FR),
+            3 => Some(CountryId::NL),
+            4 => Some(CountryId::LU),
+            5 => Some(CountryId::DE),
+            6 => Some(CountryId::AT),
+            7 => Some(CountryId::CH),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iso2_round_trip_all_countries() {
+        for &c in CountryId::ALL {
+            assert_eq!(CountryId::from_iso2(c.iso2()), Some(c));
+        }
+    }
+
+    #[test]
+    fn iso2_case_insensitive() {
+        assert_eq!(CountryId::from_iso2("be"), Some(CountryId::BE));
+        assert_eq!(CountryId::from_iso2(" Fr "), Some(CountryId::FR));
+        assert_eq!(CountryId::from_iso2("Nl"), Some(CountryId::NL));
+    }
+
+    #[test]
+    fn iso2_unknown_returns_none() {
+        assert_eq!(CountryId::from_iso2("XX"), None);
+        assert_eq!(CountryId::from_iso2(""), None);
+        assert_eq!(CountryId::from_iso2("GBR"), None);
+    }
+
+    #[test]
+    fn u8_round_trip_all_countries() {
+        for &c in CountryId::ALL {
+            assert_eq!(CountryId::from_u8(c.to_u8()), Some(c));
+        }
+    }
+
+    #[test]
+    fn u8_codes_are_distinct_and_nonzero() {
+        let mut seen = std::collections::HashSet::new();
+        for &c in CountryId::ALL {
+            let b = c.to_u8();
+            assert_ne!(b, 0, "0 is reserved for 'unknown' on disk");
+            assert!(seen.insert(b), "duplicate u8 code for {:?}", c);
         }
     }
 }

--- a/geocode/src/server/handlers.rs
+++ b/geocode/src/server/handlers.rs
@@ -17,6 +17,17 @@
 //! response header. Axum's `Json(...)` responder always serves
 //! `application/json`, so the GeoJSON path bypasses it and builds a
 //! [`Response`] manually with the proper header.
+//!
+//! ## Multi-country dispatch (#96)
+//!
+//! - **Forward**: caller may pin `country=<ISO2>` to bypass the
+//!   routing classifier; otherwise the classifier returns a posterior
+//!   and the handler picks the top country with a loaded shard. The
+//!   control-plane single-shard pipeline runs against that shard.
+//! - **Reverse**: lat/lon → [`crate::routing::country_for_point`]
+//!   picks the most-specific bbox-containing country; falls back to
+//!   the union of all loaded shards' nearest results if the point
+//!   sits outside every known bbox.
 
 use std::sync::Arc;
 
@@ -31,7 +42,7 @@ use crate::control::budget::compute_budget;
 use crate::geocoder::executor::{
     GeocodedResult, apply_rerank, build_nearest_result, execute_with_control, reason,
 };
-use crate::routing::CountryId;
+use crate::routing::{CountryId, classify_country, country_for_point};
 use crate::shard::reader::haversine_m;
 
 #[derive(Debug, Deserialize)]
@@ -53,6 +64,8 @@ pub struct ReverseParams {
     pub radius_m: Option<f64>,
     #[serde(default)]
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub country: Option<String>,
 }
 
 pub async fn forward(
@@ -64,32 +77,51 @@ pub async fn forward(
         return error_response(StatusCode::BAD_REQUEST, "q must be non-empty");
     }
     // Per C3: enforce a CHARACTER-count limit (max 512 chars), not a
-    // byte-count limit. UTF-8 chars are 1-4 bytes; the previous
-    // `String::len()` byte check let through long ASCII inputs and
-    // rejected short multi-byte ones.
+    // byte-count limit.
     if params.q.chars().count() > 512 {
         return error_response(StatusCode::BAD_REQUEST, "q too long (max 512 characters)");
     }
     let limit = params.limit.unwrap_or(5).clamp(1, 50);
 
-    let country = match params.country.as_deref() {
+    let pinned_country = match params.country.as_deref() {
         Some(s) => match CountryId::from_iso2(s) {
-            Some(c) => c,
+            Some(c) => Some(c),
             None => {
                 return error_response(
                     StatusCode::BAD_REQUEST,
-                    "country must be an ISO 3166-1 alpha-2 code (MVP supports BE only)",
+                    "country must be an ISO 3166-1 alpha-2 code (supported: BE, FR, NL, LU, DE, AT, CH)",
                 );
             }
         },
-        None => CountryId::BE,
+        None => None,
     };
-    if country != CountryId::BE {
-        return error_response(
-            StatusCode::BAD_REQUEST,
-            "MVP supports BE only — multi-country routing tracked in #96",
-        );
-    }
+
+    // Pick the dispatch country: either pinned (must have a loaded
+    // shard) or classifier top-1 with a loaded shard.
+    let dispatch_country = match pinned_country {
+        Some(c) => {
+            if !state.shards.contains_key(&c) {
+                return error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    &format!(
+                        "no shard loaded for country={} (loaded: {})",
+                        c.iso2(),
+                        state.loaded_countries().join(", ")
+                    ),
+                );
+            }
+            c
+        }
+        None => {
+            let posterior = classify_country(&params.q);
+            match state.pick_shard(&posterior) {
+                Some((c, _)) => c,
+                None => {
+                    return error_response(StatusCode::SERVICE_UNAVAILABLE, "no shards loaded");
+                }
+            }
+        }
+    };
 
     let include_debug = params
         .include
@@ -107,41 +139,49 @@ pub async fn forward(
         Admission(crate::control::AdmissionError),
     }
 
-    // Per C6: geocode work is CPU-bound. Run on the blocking pool so
-    // we don't starve the async runtime thread pool. Inside the blocking
-    // task we (1) parse via the configured backend (heuristic / neural —
-    // #98 Phase 1), (2) recompute the budget against live shard
-    // statistics per #97 §1, (3) execute under the control-plane hooks
-    // so admission/fanout/recombination metrics fire, and finally
-    // (4) layer the GBDT rerank + action-threshold pass on top of the
-    // control-plane results when a model is configured (#96 §Confidence
-    // Model). The rerank step is a no-op when `rerank_model` is None.
+    // Per C6: geocode work is CPU-bound. Run on the blocking pool.
+    // Inside the blocking task we (1) parse via the configured backend
+    // (heuristic / neural — #98 Phase 1), (2) recompute the budget
+    // against live shard statistics per #97 §1, (3) execute under the
+    // control-plane hooks so admission/fanout/recombination metrics
+    // fire, and finally (4) layer the GBDT rerank + action-threshold
+    // pass on top of the control-plane results when a model is
+    // configured. The rerank step is a no-op when `rerank_model` is
+    // None.
     let q_text = params.q.clone();
     let state_clone = Arc::clone(&state);
     let join_result: Result<Outcome, _> = tokio::task::spawn_blocking(move || {
-        let mut parsed = match state_clone
-            .parser
-            .parse(&q_text, country, &state_clone.shard)
-        {
+        let shard = state_clone
+            .shards
+            .get(&dispatch_country)
+            .expect("dispatch_country verified to be loaded above");
+        let mut parsed = match state_clone.parser.parse(&q_text, dispatch_country, shard) {
             Ok(p) => p,
             Err(e) => {
                 return Outcome::ParserFailed(e.to_string(), state_clone.parser.name());
             }
         };
-        let stats = state_clone.shard.stats();
+        // Collapse country_candidates to the dispatch country so the
+        // executor's clean-query fast path can fire (`is_clean()`
+        // requires len == 1).
+        parsed.country_candidates = vec![(dispatch_country, 1.0)];
+        let stats = shard.stats();
         parsed.execution_budget = compute_budget(&parsed, stats, state_clone.control.budget_policy);
-        let raw =
-            match execute_with_control(&parsed, &state_clone.shard, limit, &state_clone.control) {
-                Ok(r) => r,
-                Err(e) => return Outcome::Admission(e),
-            };
-        let (ranked, action) = apply_rerank(
+        let raw = match execute_with_control(&parsed, shard, limit, &state_clone.control) {
+            Ok(r) => r,
+            Err(e) => return Outcome::Admission(e),
+        };
+        let (mut ranked, action) = apply_rerank(
             raw,
             &parsed,
-            &state_clone.shard,
+            shard,
             state_clone.rerank_model.as_ref(),
             &state_clone.confidence_config,
         );
+        // Tag every result with the country it came from.
+        for r in &mut ranked {
+            r.country = Some(dispatch_country.iso2());
+        }
         Outcome::Ok(ranked, action)
     })
     .await;
@@ -165,14 +205,14 @@ pub async fn forward(
     state
         .control
         .general
-        .record_per_country_fanout(country.iso2(), results.len() as u32);
+        .record_per_country_fanout(dispatch_country.iso2(), results.len() as u32);
 
     if accept_geojson(&headers) {
         geojson_response(&results, include_debug, action)
     } else {
         Json(ForwardResponse {
             query: params.q,
-            country: country.iso2(),
+            country: dispatch_country.iso2(),
             confidence: action.as_str(),
             count: results.len(),
             results: results
@@ -200,29 +240,79 @@ pub async fn reverse(
     let lat = params.lat;
     let lon = params.lon;
 
-    // Per C6: spatial query (R-tree traversal + haversine) is also
-    // CPU-bound — `spawn_blocking` keeps the async pool free.
+    let pinned: Option<CountryId> = match params.country.as_deref() {
+        Some(s) => match CountryId::from_iso2(s) {
+            Some(c) => Some(c),
+            None => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "country must be an ISO 3166-1 alpha-2 code (supported: BE, FR, NL, LU, DE, AT, CH)",
+                );
+            }
+        },
+        None => None,
+    };
+    if let Some(c) = pinned
+        && !state.shards.contains_key(&c)
+    {
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            &format!(
+                "no shard loaded for country={} (loaded: {})",
+                c.iso2(),
+                state.loaded_countries().join(", ")
+            ),
+        );
+    }
+
     let state_clone = Arc::clone(&state);
     let results = match tokio::task::spawn_blocking(move || -> Vec<GeocodedResult> {
-        let hits = state_clone.shard.nearest_within(lat, lon, radius, limit);
-        let mut results: Vec<GeocodedResult> = Vec::with_capacity(hits.len());
-        for (rec, dist) in &hits {
-            let score = 1.0 - (dist / radius).clamp(0.0, 1.0) as f32;
-            results.push(build_nearest_result(rec, score, reason::NEAREST));
-        }
+        let target_country: Option<CountryId> = pinned.or_else(|| country_for_point(lat, lon));
 
-        if results.is_empty()
-            && let Some(rec) = state_clone.shard.nearest(lat, lon)
+        let query_shard =
+            |shard: &crate::shard::reader::Shard, c: CountryId| -> Vec<GeocodedResult> {
+                let hits = shard.nearest_within(lat, lon, radius, limit);
+                let mut results: Vec<GeocodedResult> = Vec::with_capacity(hits.len());
+                for (rec, dist) in &hits {
+                    let score = 1.0 - (dist / radius).clamp(0.0, 1.0) as f32;
+                    let mut r = build_nearest_result(rec, score, reason::NEAREST);
+                    r.country = Some(c.iso2());
+                    results.push(r);
+                }
+                results
+            };
+
+        // Path A: targeted country has a loaded shard.
+        if let Some(c) = target_country
+            && let Some(shard) = state_clone.shards.get(&c)
         {
-            let _dist = haversine_m(lat, lon, rec.lat, rec.lon);
-            results.push(build_nearest_result(
-                &rec,
-                0.0,
-                reason::NEAREST_OUT_OF_RADIUS,
-            ));
+            let results = query_shard(shard, c);
+            if !results.is_empty() {
+                return results;
+            }
+            // Out-of-radius fallback for the targeted shard.
+            if let Some(rec) = shard.nearest(lat, lon) {
+                let _dist = haversine_m(lat, lon, rec.lat, rec.lon);
+                let mut r = build_nearest_result(&rec, 0.0, reason::NEAREST_OUT_OF_RADIUS);
+                r.country = Some(c.iso2());
+                return vec![r];
+            }
         }
 
-        results
+        // Path B: no targeted country (point outside known bboxes) or
+        // targeted country has no shard. Query every loaded shard,
+        // merge, rerank.
+        let mut all: Vec<GeocodedResult> = Vec::new();
+        for (&c, shard) in &state_clone.shards {
+            all.extend(query_shard(shard, c));
+        }
+        all.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        all.truncate(limit);
+        all
     })
     .await
     {
@@ -256,7 +346,12 @@ fn _health(state: Arc<ServerState>) -> HealthResponse {
         status: "ok",
         version: state.version,
         uptime_seconds: state.started_at.elapsed().as_secs(),
-        record_count: state.shard.record_count() as u64,
+        record_count: state.total_record_count() as u64,
+        countries: state
+            .loaded_countries()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect(),
     }
 }
 
@@ -329,6 +424,8 @@ struct ForwardItem {
     housenumber: String,
     postcode: String,
     locality: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    country: Option<String>,
     score: f32,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason_codes: Option<Vec<String>>,
@@ -343,6 +440,7 @@ impl ForwardItem {
             housenumber: r.housenumber.clone(),
             postcode: r.postcode.clone(),
             locality: r.locality.clone(),
+            country: r.country.map(|s| s.to_string()),
             score: r.score,
             reason_codes: if include_debug {
                 Some(r.reason_codes.iter().map(|c| c.to_string()).collect())
@@ -358,7 +456,10 @@ struct HealthResponse {
     status: &'static str,
     version: &'static str,
     uptime_seconds: u64,
+    /// Total addresses across every loaded shard.
     record_count: u64,
+    /// ISO2 codes for every shard the server has open.
+    countries: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -381,16 +482,24 @@ fn to_geojson(
                 "locality": r.locality,
                 "score": r.score,
             });
-            if include_debug && let serde_json::Value::Object(ref mut m) = props {
-                m.insert(
-                    "reason_codes".to_string(),
-                    serde_json::Value::Array(
-                        r.reason_codes
-                            .iter()
-                            .map(|s| serde_json::Value::String(s.to_string()))
-                            .collect(),
-                    ),
-                );
+            if let serde_json::Value::Object(ref mut m) = props {
+                if let Some(c) = r.country {
+                    m.insert(
+                        "country".to_string(),
+                        serde_json::Value::String(c.to_string()),
+                    );
+                }
+                if include_debug {
+                    m.insert(
+                        "reason_codes".to_string(),
+                        serde_json::Value::Array(
+                            r.reason_codes
+                                .iter()
+                                .map(|s| serde_json::Value::String(s.to_string()))
+                                .collect(),
+                        ),
+                    );
+                }
             }
             serde_json::json!({
                 "type": "Feature",

--- a/geocode/src/server/state.rs
+++ b/geocode/src/server/state.rs
@@ -1,18 +1,49 @@
 //! Shared server state.
+//!
+//! ## Multi-country (#96)
+//!
+//! The server holds **N shards**, one per country. Each shard is a
+//! BFGS v3 file tagged with its [`CountryId`] in the file header. At
+//! load time the server reads the country code from each shard and
+//! keys it into [`ServerState::shards`].
+//!
+//! Forward queries route via the [`crate::routing::classify_country`]
+//! posterior, top-K by [`crate::types::ExecutionBudget::max_countries`].
+//! Reverse queries route via [`crate::routing::country_for_point`]
+//! (lat/lon bbox membership). Both fall back to "search every loaded
+//! shard" if the routing signal is empty.
+//!
+//! ## What if a country's shard is missing?
+//!
+//! Per the task spec: graceful degradation. The forward executor
+//! filters its target-country list to the intersection with the loaded
+//! shards. If the intersection is empty, the executor falls back to
+//! the highest-posterior loaded shard, then (if even that fails) fans
+//! out to every loaded shard. The HTTP handler turns "country pinned
+//! but no shard for it" into a 503.
 
+use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
+
+use anyhow::{Context, Result, bail};
 
 use crate::confidence::{ConfidenceConfig, GbdtModel};
 use crate::control::admission::AdmissionState;
 use crate::control::{AdmissionPolicy, BudgetPolicy, FanoutConfig, GeneralMetrics};
 use crate::geocoder::executor::ControlPlane;
 use crate::parser::{HeuristicBackend, ParserBackend};
+use crate::routing::CountryId;
 use crate::shard::reader::Shard;
 
 #[derive(Debug)]
 pub struct ServerState {
-    pub shard: Shard,
+    /// Shards keyed by country. Multi-country deployments load
+    /// multiple shards; single-country deployments load one. The
+    /// server is symmetric across the two cases — there is no
+    /// dedicated "single-shard" code path.
+    pub shards: HashMap<CountryId, Shard>,
     pub started_at: Instant,
     pub version: &'static str,
     pub control: Arc<ControlPlane>,
@@ -29,6 +60,8 @@ pub struct ServerState {
 }
 
 impl ServerState {
+    /// Single-country constructor. The shard's country is read from
+    /// its BFGS v3 header.
     pub fn new(shard: Shard) -> Self {
         Self::with_config(
             shard,
@@ -40,6 +73,27 @@ impl ServerState {
 
     pub fn with_config(
         shard: Shard,
+        budget_policy: BudgetPolicy,
+        fanout: FanoutConfig,
+        admission_policy: AdmissionPolicy,
+    ) -> Self {
+        let mut shards = HashMap::with_capacity(1);
+        shards.insert(shard.country(), shard);
+        Self::with_shards_and_config(shards, budget_policy, fanout, admission_policy)
+    }
+
+    /// Construct from a pre-built map of shards.
+    pub fn from_shards(shards: HashMap<CountryId, Shard>) -> Self {
+        Self::with_shards_and_config(
+            shards,
+            BudgetPolicy::default(),
+            FanoutConfig::default(),
+            AdmissionPolicy::default(),
+        )
+    }
+
+    fn with_shards_and_config(
+        shards: HashMap<CountryId, Shard>,
         budget_policy: BudgetPolicy,
         fanout: FanoutConfig,
         admission_policy: AdmissionPolicy,
@@ -56,7 +110,7 @@ impl ServerState {
         });
         let admission = AdmissionState::new(admission_policy, metrics);
         Self {
-            shard,
+            shards,
             started_at: Instant::now(),
             version: env!("CARGO_PKG_VERSION"),
             control,
@@ -65,6 +119,64 @@ impl ServerState {
             confidence_config: ConfidenceConfig::default(),
             parser: Arc::new(HeuristicBackend),
         }
+    }
+
+    /// Load every `*.bfgs` file in `dir` and return a `ServerState`.
+    /// Each shard's country is read from its BFGS v3 header — the
+    /// filename is informational (we recommend `<iso2>.bfgs` /
+    /// `<country>.bfgs` but the loader does not enforce it).
+    ///
+    /// Errors:
+    /// - the directory cannot be read (Err)
+    /// - no `.bfgs` files at all (Err — operator misconfiguration is
+    ///   never a silent success)
+    /// - two shards declare the same country (Err — duplicate routing
+    ///   target)
+    /// - a shard fails CRC / version check (Err — bubble up so the
+    ///   operator sees it at boot, not on first query)
+    pub fn load_from_dir<P: AsRef<Path>>(dir: P) -> Result<Self> {
+        let dir = dir.as_ref();
+        let mut shards: HashMap<CountryId, Shard> = HashMap::new();
+        let entries = std::fs::read_dir(dir)
+            .with_context(|| format!("reading shard directory {}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.context("iterating shard directory")?;
+            let path = entry.path();
+            if path
+                .extension()
+                .and_then(|s| s.to_str())
+                .map(|s| s.eq_ignore_ascii_case("bfgs"))
+                != Some(true)
+            {
+                continue;
+            }
+            let shard = Shard::open(&path)
+                .with_context(|| format!("loading shard at {}", path.display()))?;
+            let country = shard.country();
+            if shards.contains_key(&country) {
+                bail!(
+                    "two shards declare country {}: existing one in {} clashes with {}",
+                    country.iso2(),
+                    dir.display(),
+                    path.display()
+                );
+            }
+            tracing::info!(
+                country = country.iso2(),
+                records = shard.record_count(),
+                path = %path.display(),
+                "loaded shard"
+            );
+            shards.insert(country, shard);
+        }
+        if shards.is_empty() {
+            bail!(
+                "no *.bfgs shards found in {} — build at least one with \
+                 `butterfly-geocode build-shard --pbf <pbf> --out <dir>/<iso2>.bfgs --country <ISO2>`",
+                dir.display()
+            );
+        }
+        Ok(Self::from_shards(shards))
     }
 
     /// Builder-style constructor for use with a trained reranker.
@@ -87,5 +199,37 @@ impl ServerState {
     pub fn with_parser(mut self, parser: Arc<dyn ParserBackend>) -> Self {
         self.parser = parser;
         self
+    }
+
+    /// Total number of records across all loaded shards.
+    #[must_use]
+    pub fn total_record_count(&self) -> usize {
+        self.shards.values().map(|s| s.record_count()).sum()
+    }
+
+    /// Sorted list of loaded countries (ISO2). Used by `/health` and
+    /// `/metrics` to surface what is mounted.
+    #[must_use]
+    pub fn loaded_countries(&self) -> Vec<&'static str> {
+        let mut v: Vec<&'static str> = self.shards.keys().map(|c| c.iso2()).collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// Pick a shard for the country candidates in `posterior`, in
+    /// descending posterior order. Returns the first matching shard
+    /// alongside its country code, or `None` if none of the
+    /// candidates is loaded. Used by the handler for the
+    /// control-plane single-shard code path.
+    #[must_use]
+    pub fn pick_shard(&self, posterior: &[(CountryId, f32)]) -> Option<(CountryId, &Shard)> {
+        for (c, _) in posterior {
+            if let Some(s) = self.shards.get(c) {
+                return Some((*c, s));
+            }
+        }
+        // No posterior overlap. Fall back to whichever shard is loaded
+        // (any one — the handler treats this as a fan-out path).
+        self.shards.iter().next().map(|(c, s)| (*c, s))
     }
 }

--- a/geocode/src/shard/builder.rs
+++ b/geocode/src/shard/builder.rs
@@ -1,5 +1,5 @@
 //! Shard builder. Takes a stream of [`AddressRecord`]s and writes a
-//! `BFGS` v2 file (see [`super`] for the format docs).
+//! `BFGS` v3 file (see [`super`] for the format docs).
 
 use std::collections::BTreeMap;
 use std::io::{BufWriter, Write};
@@ -8,6 +8,7 @@ use std::path::Path;
 use crc::{CRC_64_XZ, Crc};
 
 use crate::parser::normalize::normalize;
+use crate::routing::CountryId;
 
 use super::{AddressRecord, FOOTER_BYTES, HEADER_BYTES, MAGIC, RECORD_BYTES, VERSION};
 
@@ -21,10 +22,18 @@ pub struct BuildStats {
     pub index_bytes: u64,
     pub unique_postcodes: u32,
     pub unique_streets: u32,
+    pub country: CountryId,
 }
 
+/// Build a BFGS v3 shard tagged with `country`.
+///
+/// `country` is written into the file header (byte 6) and verified
+/// on load by [`super::reader::Shard::open`]. Operators producing
+/// multi-country deployments build one shard per country and load
+/// them all at server boot.
 pub fn build_shard<P: AsRef<Path>>(
     out_path: P,
+    country: CountryId,
     addresses: impl IntoIterator<Item = AddressRecord>,
 ) -> std::io::Result<BuildStats> {
     let mut addrs: Vec<AddressRecord> = addresses.into_iter().collect();
@@ -137,6 +146,9 @@ pub fn build_shard<P: AsRef<Path>>(
     let mut header = [0u8; HEADER_BYTES];
     header[0..4].copy_from_slice(&MAGIC.to_le_bytes());
     header[4..6].copy_from_slice(&VERSION.to_le_bytes());
+    // v3: country code (1=BE, 2=FR, ...). See `CountryId::to_u8`.
+    header[6] = country.to_u8();
+    // header[7] is _pad — kept zero.
     let count_u32: u32 = addrs.len().try_into().expect("record count fits in u32");
     header[8..12].copy_from_slice(&count_u32.to_le_bytes());
     header[16..24].copy_from_slice(&strings_off.to_le_bytes());
@@ -179,6 +191,7 @@ pub fn build_shard<P: AsRef<Path>>(
         index_bytes: index_bytes.len() as u64,
         unique_postcodes: by_postcode.len() as u32,
         unique_streets: by_street.len() as u32,
+        country,
     })
 }
 
@@ -281,8 +294,9 @@ mod tests {
             rec("Rue Wayez", "124", "1070", "Anderlecht", 50.834, 4.315),
             rec("Grote Markt", "1", "2000", "Antwerpen", 51.221, 4.401),
         ];
-        let stats = build_shard(&path, addrs).unwrap();
+        let stats = build_shard(&path, CountryId::BE, addrs).unwrap();
         assert_eq!(stats.record_count, 3);
+        assert_eq!(stats.country, CountryId::BE);
         assert!(stats.unique_postcodes >= 2);
         assert!(stats.unique_streets >= 2);
 
@@ -297,7 +311,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("shard.bfgs");
         let addrs = vec![rec("Rue Wayez", "122", "1070", "Anderlecht", 50.834, 4.314)];
-        build_shard(&path, addrs).unwrap();
+        build_shard(&path, CountryId::BE, addrs).unwrap();
 
         let mut buf = std::fs::read(&path).unwrap();
         // Flip a byte in the body (after header, before footer).
@@ -311,11 +325,31 @@ mod tests {
     }
 
     #[test]
+    fn country_code_round_trips_through_header() {
+        let dir = tempfile::tempdir().unwrap();
+        for country in [
+            CountryId::BE,
+            CountryId::FR,
+            CountryId::NL,
+            CountryId::LU,
+            CountryId::DE,
+            CountryId::AT,
+            CountryId::CH,
+        ] {
+            let path = dir.path().join(format!("{}.bfgs", country.iso2()));
+            let addrs = vec![rec("X Street", "1", "1000", "Town", 50.0, 4.0)];
+            build_shard(&path, country, addrs).unwrap();
+            let s = Shard::open(&path).unwrap();
+            assert_eq!(s.country(), country, "header country mismatch");
+        }
+    }
+
+    #[test]
     fn corrupted_header_fails_file_crc() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("shard.bfgs");
         let addrs = vec![rec("Rue Wayez", "122", "1070", "Anderlecht", 50.834, 4.314)];
-        build_shard(&path, addrs).unwrap();
+        build_shard(&path, CountryId::BE, addrs).unwrap();
 
         let mut buf = std::fs::read(&path).unwrap();
         // Flip a reserved/_pad byte in the header that doesn't break

--- a/geocode/src/shard/mod.rs
+++ b/geocode/src/shard/mod.rs
@@ -1,6 +1,6 @@
 //! Per-country address shard.
 //!
-//! ## Format (`BFGS` v2)
+//! ## Format (`BFGS` v3)
 //!
 //! Single binary file, mmap-friendly, little-endian. Designed for
 //! zero-copy reads: every section is 4-byte aligned, every fixed-size
@@ -13,11 +13,21 @@
 //! - **file_crc** = CRC over header + body bytes (everything except
 //!   the footer)
 //!
+//! ## Multi-country (#96)
+//!
+//! v3 is single-country (one shard per country, see #96 §"Per-Country
+//! Shard Contents") with the [`crate::routing::CountryId`] code stored
+//! in the header at byte 6. v2 is implicitly Belgium-only and treated
+//! as a v3 shard with `CountryId::BE` for one release as a
+//! backwards-compat path — operators rebuild Belgium at v3 alongside
+//! any new country shard they want to deploy.
+//!
 //! ```text
 //!   Header (64 bytes):
 //!     magic            "BFGS"        u32   (= 0x53464642)
-//!     version          u16           (= 2)
-//!     _pad             u16
+//!     version          u16           (= 3)
+//!     country_code     u8            (CountryId::to_u8 — 1=BE, 2=FR, ...)
+//!     _pad             u8
 //!     record_count     u32
 //!     _pad             u32
 //!     strings_off      u64
@@ -58,15 +68,19 @@
 //!     u64 file_crc64
 //! ```
 //!
-//! Old `BFGS v1` shards (with the broken duplicate CRC) fail to load
-//! against the v2 reader (version mismatch). They must be rebuilt.
+//! Old `BFGS v1` and `BFGS v2` shards fail to load against the v3
+//! reader (version mismatch). They must be rebuilt — Belgium MVP
+//! shards must be re-run via `build-shard --country BE`.
 
 pub mod builder;
 pub mod mmap;
 pub mod reader;
 
 pub const MAGIC: u32 = u32::from_le_bytes(*b"BFGS");
-pub const VERSION: u16 = 2;
+/// Current on-disk version. v3 introduces the per-shard country code
+/// (#96 multi-country shards). v2 was the single-country (Belgium)
+/// MVP layout.
+pub const VERSION: u16 = 3;
 pub const HEADER_BYTES: usize = 64;
 pub const RECORD_BYTES: usize = 32;
 pub const FOOTER_BYTES: usize = 16;

--- a/geocode/src/shard/reader.rs
+++ b/geocode/src/shard/reader.rs
@@ -36,6 +36,7 @@ use super::mmap::map_readonly;
 use super::{FOOTER_BYTES, HEADER_BYTES, MAGIC, RECORD_BYTES, VERSION};
 use crate::geocoder::cost::ShardStats;
 use crate::parser::normalize::normalize;
+use crate::routing::CountryId;
 
 const CRC_ENGINE: Crc<u64> = Crc::<u64>::new(&CRC_64_XZ);
 
@@ -111,6 +112,7 @@ struct SubIndex {
 #[derive(Debug)]
 pub struct Shard {
     mmap: Arc<Mmap>,
+    country: CountryId,
     record_count: usize,
     records_off: usize,
     by_postcode: SubIndex,
@@ -174,6 +176,16 @@ impl Shard {
         if version != VERSION {
             bail!("unsupported shard version: {version} (expected {VERSION}). Rebuild the shard.");
         }
+        let country_code = header_bytes[6];
+        let country = CountryId::from_u8(country_code).ok_or_else(|| {
+            anyhow!(
+                "unknown country code {country_code} in shard header at {} \
+                 (expected one of {:?}). Was the shard built with a newer geocode \
+                 version that introduced a country this build does not know?",
+                path.display(),
+                CountryId::ALL.iter().map(|c| c.iso2()).collect::<Vec<_>>(),
+            )
+        })?;
         let record_count =
             u32::from_le_bytes(header_bytes[8..12].try_into().expect("4 bytes")) as usize;
         let strings_off =
@@ -269,6 +281,7 @@ impl Shard {
 
         Ok(Self {
             mmap,
+            country,
             record_count,
             records_off,
             by_postcode,
@@ -279,6 +292,14 @@ impl Shard {
             interned,
             empty_str,
         })
+    }
+
+    /// The country this shard was built for. Read from the BFGS v3
+    /// header at open time.
+    #[inline]
+    #[must_use]
+    pub fn country(&self) -> CountryId {
+        self.country
     }
 
     fn intern(&self, off: u32, len: u16) -> Arc<str> {

--- a/geocode/src/types.rs
+++ b/geocode/src/types.rs
@@ -122,6 +122,15 @@ impl RetrievalPolicy {
         ])
     }
 
+    /// Default policy for European postcode-anchored countries
+    /// (BE / FR / NL / LU / DE / AT / CH). Same shape as
+    /// [`Self::belgium_default`] — postcode is the strongest evidence
+    /// anchor across the whole cluster #1 + #2 set. US-style profiles
+    /// (street as blocker) will diverge in a follow-up country pack.
+    pub fn european_postcode_anchor() -> Self {
+        Self::belgium_default()
+    }
+
     #[must_use]
     pub fn role(&self, ch: Channel) -> Option<ChannelRole> {
         self.roles[ch.index()]

--- a/geocode/tests/axum_e2e.rs
+++ b/geocode/tests/axum_e2e.rs
@@ -127,7 +127,8 @@ fn fixture_addresses() -> Vec<AddressRecord> {
 fn make_fixture_shard() -> (TempDir, Shard) {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("fixture.bfgs");
-    build_shard(&path, fixture_addresses()).expect("build fixture shard");
+    build_shard(&path, butterfly_geocode::CountryId::BE, fixture_addresses())
+        .expect("build fixture shard");
     let s = Shard::open(&path).expect("open fixture shard");
     (dir, s)
 }

--- a/geocode/tests/clean_query_allocs.rs
+++ b/geocode/tests/clean_query_allocs.rs
@@ -79,7 +79,7 @@ fn make_shard_with_n_postcode_records(n: usize) -> (tempfile::TempDir, Shard) {
             lon: 4.3680 + (i as f64) * 1e-5,
         });
     }
-    build_shard(&path, addrs).expect("build shard");
+    build_shard(&path, butterfly_geocode::CountryId::BE, addrs).expect("build shard");
     let s = Shard::open(&path).expect("open shard");
     (dir, s)
 }

--- a/geocode/tests/control_fanout.rs
+++ b/geocode/tests/control_fanout.rs
@@ -34,7 +34,7 @@ fn small_shard() -> (tempfile::TempDir, Shard) {
             lon: 4.314 + (i as f64) * 1e-5,
         });
     }
-    build_shard(&path, addrs).unwrap();
+    build_shard(&path, butterfly_geocode::CountryId::BE, addrs).unwrap();
     let s = Shard::open(&path).unwrap();
     (dir, s)
 }

--- a/geocode/tests/multi_country_e2e.rs
+++ b/geocode/tests/multi_country_e2e.rs
@@ -1,0 +1,241 @@
+//! End-to-end tests against multi-country shards.
+//!
+//! These tests are `#[ignore]` by default because they require:
+//!
+//! 1. Built shards at `regions/multi/<iso2>.bfgs` for at least
+//!    `be.bfgs` and one of `nl.bfgs` / `lu.bfgs`.
+//! 2. The PBFs to have been downloaded via `butterfly-dl` or curl.
+//!
+//! Run with:
+//!
+//! ```text
+//! cargo test -p butterfly-geocode --release --test multi_country_e2e -- --ignored
+//! ```
+
+use std::path::PathBuf;
+
+use butterfly_geocode::server::ServerState;
+use butterfly_geocode::{
+    CountryId, classify_country, execute, execute_across_shards, parse_heuristic,
+    parse_with_classifier,
+};
+
+fn shards_dir() -> PathBuf {
+    PathBuf::from("regions/multi")
+}
+
+fn open_state() -> ServerState {
+    ServerState::load_from_dir(shards_dir()).unwrap_or_else(|e| {
+        panic!(
+            "could not load shards from {}: {e}\n\
+             Build them first: cargo run --release -p butterfly-geocode -- build-shard \\\n\
+                            --pbf data/<country>.pbf --out geocode/regions/multi/<iso2>.bfgs --country <ISO2>",
+            shards_dir().display()
+        );
+    })
+}
+
+#[test]
+#[ignore]
+fn loads_multiple_country_shards() {
+    let state = open_state();
+    let countries = state.loaded_countries();
+    assert!(
+        countries.contains(&"BE"),
+        "expected BE shard loaded, got {countries:?}"
+    );
+    assert!(
+        countries.len() >= 2,
+        "expected ≥2 country shards for the multi-country e2e (got {countries:?}). \
+         Build LU and/or NL shards into regions/multi/."
+    );
+    assert!(state.total_record_count() > 0);
+}
+
+#[test]
+#[ignore]
+fn pinned_belgium_query_returns_belgium_results() {
+    let state = open_state();
+    let q = parse_heuristic("Rue Wayez 122 1070 Anderlecht", CountryId::BE);
+    let results = execute_across_shards(&q, &state.shards, 5);
+    assert!(!results.is_empty(), "BE pinned query produced no hits");
+    let top = &results[0];
+    assert_eq!(top.country, Some("BE"));
+    assert!(
+        (50.5..51.0).contains(&top.lat) && (4.1..4.5).contains(&top.lon),
+        "top hit not in Brussels area: {top:?}"
+    );
+}
+
+#[test]
+#[ignore]
+fn pinned_luxembourg_query_returns_lu_results_when_loaded() {
+    let state = open_state();
+    if !state.shards.contains_key(&CountryId::LU) {
+        eprintln!("skipping (no LU shard loaded)");
+        return;
+    }
+    let q = parse_heuristic("rue de la Gare Luxembourg", CountryId::LU);
+    let results = execute_across_shards(&q, &state.shards, 5);
+    if results.is_empty() {
+        let q2 = parse_heuristic("L-1611", CountryId::LU);
+        let r2 = execute_across_shards(&q2, &state.shards, 5);
+        assert!(!r2.is_empty(), "no LU hits for either canonical query");
+        for r in &r2 {
+            assert_eq!(
+                r.country,
+                Some("LU"),
+                "LU pin returned non-LU result {:?}",
+                r
+            );
+        }
+        return;
+    }
+    let top = &results[0];
+    assert_eq!(top.country, Some("LU"));
+    assert!(
+        (49.4..50.3).contains(&top.lat),
+        "top hit not in Luxembourg lat band: {top:?}"
+    );
+}
+
+#[test]
+#[ignore]
+fn pinned_netherlands_query_returns_nl_results_when_loaded() {
+    let state = open_state();
+    if !state.shards.contains_key(&CountryId::NL) {
+        eprintln!("skipping (no NL shard loaded)");
+        return;
+    }
+    let q = parse_heuristic("Damrak 1 1012 LP Amsterdam", CountryId::NL);
+    let results = execute_across_shards(&q, &state.shards, 5);
+    assert!(!results.is_empty(), "NL pinned query produced no hits");
+    let top = &results[0];
+    assert_eq!(top.country, Some("NL"));
+    assert!(
+        (52.0..53.0).contains(&top.lat) && (4.5..5.5).contains(&top.lon),
+        "top NL hit not in Amsterdam area: {top:?}"
+    );
+}
+
+#[test]
+#[ignore]
+fn cross_country_classifier_routes_correctly() {
+    let state = open_state();
+    if !state.shards.contains_key(&CountryId::NL) {
+        eprintln!("skipping (no NL shard loaded)");
+        return;
+    }
+
+    // BE-flavored input → classifier picks BE → BE shard hit.
+    let q_be = parse_with_classifier("Rue Wayez 122 1070 Anderlecht");
+    assert_eq!(q_be.country_candidates[0].0, CountryId::BE);
+    let r_be = execute_across_shards(&q_be, &state.shards, 5);
+    assert!(!r_be.is_empty());
+    assert_eq!(r_be[0].country, Some("BE"));
+
+    // NL-flavored input → classifier picks NL → NL shard hit.
+    let q_nl = parse_with_classifier("Damrak 1 1012 LP Amsterdam");
+    assert_eq!(q_nl.country_candidates[0].0, CountryId::NL);
+    let r_nl = execute_across_shards(&q_nl, &state.shards, 5);
+    assert!(!r_nl.is_empty());
+    assert_eq!(r_nl[0].country, Some("NL"));
+}
+
+#[test]
+#[ignore]
+fn ambiguous_query_returns_ranked_posterior_across_shards() {
+    let state = open_state();
+    let _other = if state.shards.contains_key(&CountryId::LU) {
+        CountryId::LU
+    } else if state.shards.contains_key(&CountryId::AT) {
+        CountryId::AT
+    } else if state.shards.contains_key(&CountryId::CH) {
+        CountryId::CH
+    } else if state.shards.contains_key(&CountryId::NL) {
+        CountryId::NL
+    } else {
+        eprintln!("skipping (no second-country shard loaded)");
+        return;
+    };
+
+    // Use a generic 4-digit postcode that exists across countries.
+    let posterior = classify_country("1070");
+    let be_mass = posterior
+        .iter()
+        .find(|(c, _)| *c == CountryId::BE)
+        .map(|(_, w)| *w)
+        .unwrap_or(0.0);
+    assert!(be_mass > 0.0, "BE expected in posterior for '1070'");
+
+    // Run the executor with max_countries=4 so the executor walks
+    // multiple shards from the classifier posterior.
+    let mut q = parse_with_classifier("1070");
+    q.execution_budget.max_countries = 4;
+    let results = execute_across_shards(&q, &state.shards, 50);
+    if results.is_empty() {
+        eprintln!("no results for ambiguous '1070' — sparse OSM postcode coverage");
+        return;
+    }
+    let countries: std::collections::HashSet<_> =
+        results.iter().filter_map(|r| r.country).collect();
+    assert!(
+        !countries.is_empty(),
+        "no country tagged on ambiguous results"
+    );
+}
+
+#[test]
+#[ignore]
+fn reverse_geocode_routes_via_bbox() {
+    let state = open_state();
+    {
+        let shard = state.shards.get(&CountryId::BE).expect("BE shard");
+        let hits = shard.nearest_within(50.8467, 4.3525, 80.0, 1);
+        assert!(!hits.is_empty(), "expected BE hit at Grand-Place");
+    }
+    if state.shards.contains_key(&CountryId::LU) {
+        use butterfly_geocode::country_for_point;
+        assert_eq!(country_for_point(49.6116, 6.1319), Some(CountryId::LU));
+    }
+    if state.shards.contains_key(&CountryId::NL) {
+        use butterfly_geocode::country_for_point;
+        assert_eq!(country_for_point(52.3791, 4.9003), Some(CountryId::NL));
+    }
+}
+
+#[test]
+#[ignore]
+fn missing_pinned_country_returns_empty_in_executor() {
+    let state = open_state();
+    if state.shards.contains_key(&CountryId::DE) {
+        eprintln!("skipping (DE shard happens to be loaded)");
+        return;
+    }
+    let mut q = parse_heuristic("Friedrichstraße 100 10117 Berlin", CountryId::DE);
+    q.execution_budget.max_countries = 1;
+    let results = execute_across_shards(&q, &state.shards, 5);
+    assert!(
+        results.is_empty(),
+        "expected empty when DE shard is not loaded; got {:?}",
+        results
+    );
+}
+
+/// Assert the per-shard `execute()` and the multi-shard
+/// `execute_across_shards()` produce the same top result on a clean
+/// pinned query — the multi-shard layer must not regress single-shard
+/// quality.
+#[test]
+#[ignore]
+fn execute_across_shards_matches_single_shard_on_clean_query() {
+    let state = open_state();
+    let shard = state.shards.get(&CountryId::BE).expect("BE shard");
+    let q = parse_heuristic("Rue Wayez 122 1070 Anderlecht", CountryId::BE);
+    let single = execute(&q, shard, 5);
+    let multi = execute_across_shards(&q, &state.shards, 5);
+    assert!(!single.is_empty() && !multi.is_empty());
+    assert_eq!(single[0].lat, multi[0].lat);
+    assert_eq!(single[0].lon, multi[0].lon);
+    assert_eq!(single[0].housenumber, multi[0].housenumber);
+}


### PR DESCRIPTION
## Summary

Extends butterfly-geocode from the Belgium-only MVP to **per-country shards** for cluster #1 (BE / FR / NL / LU / DE) and cluster #2 (AT / DE / CH) per #96 §Per-Country Shard Contents.

- BFGS shard format bumped to v3 with a country-code byte in the header. Belgium MVP shards must be rebuilt via \`build-shard --country BE\`.
- \`CountryId\` extended from BE-only to all 7 countries with ISO2 round-trip and stable on-disk u8 codes.
- Cheap deterministic country classifier returns a softmaxed \`(country, weight)\` posterior over the 7 countries from postcode-shape, lexical, and script signals.
- \`ServerState\` holds N shards keyed by \`CountryId\`; \`load_from_dir\` scans a directory for \`*.bfgs\` files and infers each shard's country from the v3 header.
- \`execute_across_shards\` walks the country posterior, runs the per-shard executor, and **multiplies each result's score by the country posterior weight** before merging — see executor doc-comment for the cross-shard score normalization rationale (multiplicative posterior preserves reason-code semantics; min-max and z-score were rejected).
- Forward HTTP handler picks dispatch country from pin or classifier top-1, validates the shard is loaded (503 if not), runs control-plane + GBDT pipeline against it, tags results with country.
- Reverse HTTP handler dispatches by country bbox (or pin); falls back to all loaded shards if the point is outside every known bbox.
- CLI: \`build-shard --country <ISO2>\`, \`build-shards-all\`, \`serve --shard-dir <dir>\` (mutually exclusive with \`--shard\`).
- Per-country postcode regex in the heuristic parser: 4-digit BE/LU/AT/CH, 5-digit FR/DE, 4-digit + alpha NL, L-prefixed LU. Plus \`parse_with_classifier()\` for unpinned multi-country queries.
- \`/health\` surfaces loaded countries; \`/geocode\` and \`/geocode/reverse\` accept any of BE/FR/NL/LU/DE/AT/CH.

## Verified live (3-shard server with BE/LU/NL)

| Query | Pin | Top result |
|---|---|---|
| Rue Wayez 122 1070 Anderlecht | BE | BE — Rue Wayez 50.69, 4.37 |
| Damrak 1 1012 LP Amsterdam | NL | NL — Dam 1, postcode 1012LP |
| L-1611 Luxembourg | LU | LU — Avenue de la Gare 1, 1611 Luxembourg |
| Damrak 1 1012 LP Amsterdam | (auto) | NL — Dam (classifier picked NL) |
| Reverse 50.8467, 4.3525 | (bbox) | BE — Grand-Place |
| Reverse 52.3791, 4.9003 | (bbox) | NL — Stationsplein, Amsterdam |
| Reverse 49.6116, 6.1319 | (bbox) | LU — Rue du Fossé, Luxembourg |

Server RSS for 3 shards (BE 162 MB + LU 8 MB + NL 480 MB on disk): ~1.85 GB VmRSS, mostly mmap-resident.

## Out of scope

- **Authoritative-source ingestion** (BOSA / BAN / BAG / BD-Adresses / BEV / swisstopo) — \`geocode-data/SOURCES.md\` has URLs + field mappings ready; OSM \`addr:*\` is the source for all countries in this release.
- **Cross-border shard co-location** (one shard per cluster) — separate per-country shards instead. Layout-merge is a future optimization for the BE-FR-NL-LU-DE cluster.
- **Adapter layers (LoRA per region)** — needs trained models.
- **DE shard build verification** (~5 GB PBF; defer to operator).
- **AT shard via BEV CSV** (URL access path needs research; OSM fallback works).

## Test plan

- [x] Unit tests: 171 lib (CountryId round-trip, classifier per-country signals, country-bbox dispatch, multi-country shard build/load, parser per-country regex, executor score normalization)
- [x] Integration tests: 9 axum_e2e + 2 clean_query_allocs + 2 control_clean_query_alloc + 6 control_fanout
- [x] Belgium e2e regression: 14 ignored tests pass against the rebuilt v3 BE shard
- [x] Multi-country e2e: 9 ignored tests against BE+LU+NL shards (forward/reverse/dispatch/normalization/missing-shard/clean-query parity)
- [x] Live curl: BE/NL/LU pinned + auto-routed + 3 reverse queries all return correct country results
- [x] \`cargo fmt\` + \`cargo clippy --workspace --all-targets\` clean
- [x] No \`unsafe_code\`; no placeholders/TODOs

## Total: 214 tests passing.