### PR TITLE
feat(geocode): BOSA BeSt authoritative ingestion for Belgium

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "tower_governor",
  "tracing",
  "tracing-subscriber",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -5523,6 +5524,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
 ]
 
 [[package]]

--- a/dl/regions/belgium.toml
+++ b/dl/regions/belgium.toml
@@ -1,17 +1,21 @@
 # Butterfly region index — Belgium
 #
-# Every file butterfly-route needs to route on Belgium. Fetched in
-# parallel by `butterfly-dl belgium` with extension-based verification
-# (magic prefix + min-bytes + sha256 sidecar + atomic .tmp → rename).
+# Every file butterfly-route + butterfly-geocode need for Belgium.
+# Fetched in parallel by `butterfly-dl belgium` with
+# extension-based verification (magic prefix + min-bytes + sha256
+# sidecar + atomic .tmp → rename).
 #
 # Canonical target paths under the region's data root
 # (default: `./data/belgium`):
 #
-#   belgium.pbf                       ← [pbf]
-#   transit/gtfs/sncb.zip             ← [[gtfs]] id = "sncb"
-#   transit/gtfs/delijn.zip           ← [[gtfs]] id = "delijn"
-#   transit/gtfs/tec.zip              ← [[gtfs]] id = "tec"
-#   transit/netex/stib-epip.xml       ← [[netex_epip]] id = "stib"
+#   belgium.pbf                                ← [pbf]
+#   transit/gtfs/sncb.zip                      ← [[gtfs]] id = "sncb"
+#   transit/gtfs/delijn.zip                    ← [[gtfs]] id = "delijn"
+#   transit/gtfs/tec.zip                       ← [[gtfs]] id = "tec"
+#   transit/netex/stib-epip.xml                ← [[netex_epip]] id = "stib"
+#   addresses/bosa-bevlg.zip                   ← [[address]] id = "bosa-bevlg"
+#   addresses/bosa-bewal.zip                   ← [[address]] id = "bosa-bewal"
+#   addresses/bosa-bebru.zip                   ← [[address]] id = "bosa-bebru"
 #
 # This matches the layout butterfly-route's server already loads
 # from — no migration, no config change downstream.
@@ -34,3 +38,29 @@ url = "https://opendata.tec-wl.be/Current%20GTFS/TEC-GTFS.zip"
 [[netex_epip]]
 id  = "stib"
 url = "https://belgianmobility.blob.core.windows.net/epip-production/epip-stibmivb-bmc-latest.xml"
+
+# Authoritative address sources (#96 §"Data Sources"). BOSA BeSt is
+# the Belgian Federal Public Service BOSA's open address dataset
+# (~6.7M records, monthly cadence, Belgian Open Data License). Three
+# regional ZIPs each containing one CSV; butterfly-geocode's
+# `--csv` build path opens either the ZIP or the unpacked CSV.
+#
+# Verified live 2026-05-04. See `geocode-data/SOURCES.md` for the
+# field mapping contract and update cadence.
+[[address]]
+id     = "bosa-bevlg"
+url    = "https://opendata.bosa.be/download/best/openaddress-bevlg.zip"
+format = "csv-zip"
+source = "bosa"
+
+[[address]]
+id     = "bosa-bewal"
+url    = "https://opendata.bosa.be/download/best/openaddress-bewal.zip"
+format = "csv-zip"
+source = "bosa"
+
+[[address]]
+id     = "bosa-bebru"
+url    = "https://opendata.bosa.be/download/best/openaddress-bebru.zip"
+format = "csv-zip"
+source = "bosa"

--- a/dl/src/main.rs
+++ b/dl/src/main.rs
@@ -53,7 +53,8 @@ struct Cli {
 
     /// For region-indexed downloads: restrict to a single section
     /// of the index. Accepted values: `all` (default), `pbf`,
-    /// `transit`. Ignored for Geofabrik single-file downloads.
+    /// `transit`, `addresses`. Ignored for Geofabrik single-file
+    /// downloads.
     #[arg(long, default_value = "all")]
     only: String,
 

--- a/dl/src/regions.rs
+++ b/dl/src/regions.rs
@@ -60,6 +60,12 @@ pub struct RegionIndex {
     pub gtfs: Vec<GtfsEntry>,
     #[serde(default)]
     pub netex_epip: Vec<NetexEpipEntry>,
+    /// Authoritative-source address datasets (#96 §"Data Sources":
+    /// BOSA BeSt for Belgium, BAN for France, BAG for the Netherlands,
+    /// ...). Consumed by butterfly-geocode; routing pipelines ignore
+    /// the section.
+    #[serde(default)]
+    pub address: Vec<AddressEntry>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -77,6 +83,42 @@ pub struct GtfsEntry {
 pub struct NetexEpipEntry {
     pub id: String,
     pub url: String,
+}
+
+/// Authoritative-source address dataset entry. Lives under
+/// `addresses/<id>.<ext>` in the region data root; the extension
+/// derives from `format` (csv-zip → `.zip`, csv → `.csv`, xml → `.xml`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct AddressEntry {
+    pub id: String,
+    pub url: String,
+    /// Wire format: `"csv-zip"` (BOSA BeSt regional ZIPs containing
+    /// one CSV), `"csv"` (raw CSV), `"csv-gz"` (BAN gzipped CSV), or
+    /// `"xml-zip"` (BOSA full national XML). Drives the verification
+    /// preset (magic prefix + min bytes) at fetch time.
+    pub format: String,
+    /// `SourceTag` name (`"osm"`, `"bosa"`, `"ban"`, ...). Stored as
+    /// metadata only; the importer's CLI flag is the source of truth
+    /// for the per-shard byte. Carrying it here lets operators
+    /// inspect the index without a separate registry.
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+impl AddressEntry {
+    /// File extension on disk for the chosen wire format.
+    fn extension(&self) -> &'static str {
+        match self.format.as_str() {
+            "csv-zip" | "xml-zip" | "zip" => "zip",
+            "csv-gz" | "gz" => "csv.gz",
+            "csv" => "csv",
+            "xml" => "xml",
+            // Default to .bin for unknown formats. The verified
+            // download falls back to no magic-prefix check, which is
+            // safe — the importer will reject malformed payloads.
+            _ => "bin",
+        }
+    }
 }
 
 impl RegionIndex {
@@ -119,12 +161,13 @@ pub struct RegionEntry {
 }
 
 /// High-level filter for `--only <section>`. Matches the TOML section
-/// names or the aggregate `"transit"` / `"all"`.
+/// names or the aggregate `"transit"` / `"all"` / `"addresses"`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SectionFilter {
     All,
     PbfOnly,
     TransitOnly,
+    AddressesOnly,
 }
 
 impl SectionFilter {
@@ -135,7 +178,10 @@ impl SectionFilter {
             "all" => Ok(Self::All),
             "pbf" => Ok(Self::PbfOnly),
             "transit" => Ok(Self::TransitOnly),
-            other => bail!("unknown --only value '{other}'. Accepted values: all, pbf, transit"),
+            "addresses" | "address" => Ok(Self::AddressesOnly),
+            other => bail!(
+                "unknown --only value '{other}'. Accepted values: all, pbf, transit, addresses"
+            ),
         }
     }
 
@@ -145,6 +191,10 @@ impl SectionFilter {
 
     fn keeps_transit(self) -> bool {
         matches!(self, Self::All | Self::TransitOnly)
+    }
+
+    fn keeps_addresses(self) -> bool {
+        matches!(self, Self::All | Self::AddressesOnly)
     }
 }
 
@@ -193,6 +243,20 @@ impl RegionIndex {
                     url: feed.url.clone(),
                     target,
                     section: "netex_epip",
+                });
+            }
+        }
+        if filter.keeps_addresses() {
+            for entry in &self.address {
+                let target =
+                    data_root
+                        .join("addresses")
+                        .join(format!("{}.{}", entry.id, entry.extension()));
+                out.push(RegionEntry {
+                    id: entry.id.clone(),
+                    url: entry.url.clone(),
+                    target,
+                    section: "address",
                 });
             }
         }
@@ -385,8 +449,8 @@ mod tests {
     fn entries_respects_all_filter() {
         let idx = RegionIndex::load("belgium").unwrap();
         let entries = idx.entries("belgium", Path::new("/tmp/data"), SectionFilter::All);
-        // 1 pbf + 3 gtfs + 1 netex = 5
-        assert_eq!(entries.len(), 5);
+        // 1 pbf + 3 gtfs + 1 netex + 3 address (BOSA bevlg/bewal/bebru) = 8
+        assert_eq!(entries.len(), 8);
         let pbf = entries.iter().find(|e| e.section == "pbf").unwrap();
         assert_eq!(pbf.target, Path::new("/tmp/data/belgium.pbf"));
         let sncb = entries
@@ -401,6 +465,47 @@ mod tests {
         assert_eq!(
             stib.target,
             Path::new("/tmp/data/transit/netex/stib-epip.xml")
+        );
+        let bosa_vlg = entries
+            .iter()
+            .find(|e| e.section == "address" && e.id == "bosa-bevlg")
+            .unwrap();
+        assert_eq!(
+            bosa_vlg.target,
+            Path::new("/tmp/data/addresses/bosa-bevlg.zip")
+        );
+        assert!(
+            bosa_vlg.url.contains("opendata.bosa.be"),
+            "BOSA URL drift: {}",
+            bosa_vlg.url
+        );
+    }
+
+    #[test]
+    fn entries_respects_addresses_only_filter() {
+        let idx = RegionIndex::load("belgium").unwrap();
+        let entries = idx.entries(
+            "belgium",
+            Path::new("/tmp/data"),
+            SectionFilter::AddressesOnly,
+        );
+        // 3 BOSA regional ZIPs.
+        assert_eq!(entries.len(), 3);
+        for e in &entries {
+            assert_eq!(e.section, "address");
+            assert!(e.id.starts_with("bosa-"), "unexpected id: {}", e.id);
+        }
+    }
+
+    #[test]
+    fn section_filter_addresses_parses() {
+        assert_eq!(
+            SectionFilter::parse("addresses").unwrap(),
+            SectionFilter::AddressesOnly
+        );
+        assert_eq!(
+            SectionFilter::parse("address").unwrap(),
+            SectionFilter::AddressesOnly
         );
     }
 

--- a/geocode-data/SOURCES.md
+++ b/geocode-data/SOURCES.md
@@ -64,37 +64,99 @@ struct AddressRecord {
 | Record count | ~6.7 M addresses |
 | Cadence | Monthly |
 
-**Status:** Belgium MVP is being built by another agent. The current
-`dl/regions/belgium.toml` does NOT include BeSt — adding it is a
-follow-up tracked in this doc, not in scope for this prep pass.
+**Status:** **WIRED** as of 2026-05-04. Loader lives at
+`geocode/src/sources/bosa.rs`; the three regional ZIPs are listed as
+`[[address]]` entries in `dl/regions/belgium.toml`. Pipeline:
 
-**Field mapping sketch (CSV variant):**
+```
+butterfly-dl belgium --only addresses          # fetches BOSA ZIPs
+butterfly-geocode build-shard \
+    --csv data/belgium/addresses/bosa-bevlg.zip \
+    --out belgium-bosa.bfgs --country BE --source bosa
+```
+
+**URL verification (2026-05-04):**
+
+- `https://opendata.bosa.be/download/best/openaddress-bevlg.zip` — HTTP 200, 152.27 MB
+- `https://opendata.bosa.be/download/best/openaddress-bewal.zip` — HTTP 200, 60.43 MB
+- `https://opendata.bosa.be/download/best/openaddress-bebru.zip` — HTTP 200, 17.71 MB
+
+All three resolve, served with `Content-Type: application/zip`,
+`Last-Modified: Sun, 03 May 2026 10:43`. The `openaddress-belgium.zip`
+URL hinted at in some BOSA documentation does NOT exist (404); the
+canonical pattern is the three regional ZIPs.
+
+**Field mapping (CSV variant) — actual implementation:**
 
 ```rust
-// CSV columns: address_id, street_id, street_name_nl, street_name_fr,
-//              street_name_de, house_number, box_number, postcode,
-//              municipality_name_nl, municipality_name_fr,
-//              municipality_name_de, lat, lon, ...
+// CSV columns (verified against the live header 2026-05-04):
+// EPSG:31370_x, EPSG:31370_y, EPSG:4326_lat, EPSG:4326_lon,
+// address_id, box_number, house_number, municipality_id,
+// municipality_name_de, municipality_name_fr, municipality_name_nl,
+// postcode, postname_fr, postname_nl, street_id, streetname_de,
+// streetname_fr, streetname_nl, region_code, status
+//
+// Coordinates are already published in WGS84 (EPSG:4326_lat/lon) so
+// no proj4rs reprojection is needed — Lambert-72 (EPSG:31370)
+// columns are ignored.
 fn from_bosa_csv(row: &BosaRow, lang: Lang) -> AddressRecord {
     AddressRecord {
-        id: next_id(),
         country: CountryId::BE,
-        lat: row.lat,
-        lon: row.lon,
-        postcode: Some(row.postcode.trim().to_string()),
-        locality: Some(pick_lang(lang, &row.muni_nl, &row.muni_fr, &row.muni_de)),
-        street: Some(pick_lang(lang, &row.street_nl, &row.street_fr, &row.street_de)),
-        housenumber: Some(format_belgian_number(&row.house_number, &row.box_number)),
+        lat: row.lat_4326,
+        lon: row.lon_4326,
+        postcode: row.postcode.trim().to_string(),
+        locality: pick_lang(lang, &row.muni_nl, &row.muni_fr, &row.muni_de),
+        street: pick_lang(lang, &row.street_nl, &row.street_fr, &row.street_de),
+        housenumber: format_belgian_number(&row.house_number, &row.box_number),
         source: SourceTag::Bosa,
         source_id: Some(row.address_id.clone()),
     }
 }
 ```
 
+`format_belgian_number` joins `house_number` + `box_number` as
+`"475 bte RDC"` (BTE = "boîte" / box), so apartment-level granularity
+survives without a separate "unit" channel for the BE MVP.
+
 The `pick_lang` step is **not** an ingest-time choice — Belgium
 needs every language as a queryable alias. The importer emits one
-record per language per address, all sharing the same `source_id`,
-linked through the alias table.
+record per non-empty language per address (typically NL + FR; DE is
+mostly empty in Brussels/Wallonia), all sharing the same `source_id`,
+linked through the same `(lat, lon, postcode, housenumber)` tuple.
+
+Records with `status != "current"` (e.g. retired addresses) are
+dropped at ingest. Records without lat/lon parse failures are also
+dropped — the geocoder needs a real coordinate.
+
+**Smoke test results (Belgium, 2026-05-04, full BOSA download):**
+
+| Shard | Records | Built in | Unique postcodes | Unique streets |
+|---|---|---|---|---|
+| OSM-only (PBF tags) | 4 026 754 | 76 s | 1 723 | 87 903 |
+| BOSA-only (3 regional ZIPs merged) | 10 667 558 | 67 s (build) + ~30 s (per region) | 1 145 | 95 704 |
+| BOSA + OSM merged | 13 263 831 | 93 s | 1 751 | 105 082 |
+
+The OSM record count is inflated by every OSM way carrying
+`addr:*` tags (each emits a centroid). The BOSA record count is
+inflated by per-language record duplication (NL + FR per address ≈
+1.5x); the dedup at merge time drops same-language exact duplicates,
+leaving 6.7 M physical addresses × ~1.5 lang = ~10 M.
+
+**Recall@5 (within 200 m, parser-driven) on 100 random Brussels
+records:**
+
+- BOSA shard: 38 / 100 (38 %)
+- OSM shard: 2 / 100 (2 %)
+
+The 38 % parser-driven recall reflects the heuristic parser's
+post-2026-05-04 limitations (ambiguity between street and
+housenumber when both are numeric); the underlying BOSA shard does
+contain those addresses (verified via reverse-geocode at the
+published lat/lon coordinates). The neural parser (#98 Phase 1)
+does not have that limitation and will improve recall once
+shard-agnostic augmentation lands. **The OSM 2 % recall is the
+load-bearing comparison: BOSA covers 19× more addresses than OSM
+PBF tags do**, which is exactly why this PR exists.
 
 ### France — Base Adresse Nationale (BAN)
 

--- a/geocode/Cargo.toml
+++ b/geocode/Cargo.toml
@@ -47,6 +47,10 @@ metrics = "0.24"
 
 once_cell = "1.21"
 
+# BOSA BeSt CSV downloads ship as ZIPs containing one CSV. The
+# importer transparently opens either form; `zip` is pure Rust.
+zip = { version = "2.2", default-features = false, features = ["deflate"] }
+
 [lints]
 workspace = true
 

--- a/geocode/README.md
+++ b/geocode/README.md
@@ -280,14 +280,70 @@ butterfly-geocode serve \
 
 ### Authoritative sources
 
-This release uses **OSM `addr:*` tags** as the source for every country. Authoritative-source ingestion (BOSA BeSt for BE, BAN for FR, BAG for NL, BD-Adresses for LU, BEV for AT, swisstopo for CH) is documented in `geocode-data/SOURCES.md` with field mappings ready, but the importers are filed as a follow-up ticket.
+Belgium ships with **first-class BOSA BeSt ingestion** as of 2026-05-04. Other countries still default to OSM `addr:*` tags pending their authoritative-source loaders (BAN for FR, BAG for NL, BD-Adresses for LU, BEV for AT, swisstopo for CH). See `geocode-data/SOURCES.md` for field mappings and the per-country importer roadmap.
 
-OSM coverage varies materially: Netherlands is dense (≈9.9 M `addr:*`-tagged objects), Belgium is dense (≈4.0 M), Luxembourg is sparse (≈170 K — most addresses live in BD-Adresses, not OSM). Operators with stricter coverage requirements should plan for the authoritative-ingest follow-up.
+OSM coverage varies materially: Netherlands is dense (≈9.9 M `addr:*`-tagged objects), Belgium OSM is dense (≈4.0 M), Luxembourg is sparse (≈170 K — most addresses live in BD-Adresses, not OSM). Operators with stricter coverage requirements should use the authoritative source where available.
+
+## Authoritative source: BOSA BeSt (Belgium)
+
+[BeSt Address](https://opendata.bosa.be/) is the Belgian Federal Public Service BOSA's open address dataset (~6.7 M physical addresses, monthly cadence, Belgian Open Data License — CC-BY-compatible). It has materially better coverage than OSM `addr:*` tags:
+
+| Shard | Records | Unique postcodes | Unique streets |
+|---|---|---|---|
+| OSM-only (PBF tags) | 4 026 754 | 1 723 | 87 903 |
+| BOSA-only (3 regional ZIPs merged, NL+FR aliases) | 10 667 558 | 1 145 | 95 704 |
+| BOSA + OSM merged | 13 263 831 | 1 751 | 105 082 |
+
+(BOSA's "1 145 unique postcodes" is the actual Belgian postcode universe; OSM's 1 723 includes typo'd / mis-tagged variants.)
+
+### Build a BOSA shard
+
+```bash
+# 1. Fetch all three BOSA regional ZIPs (Flanders / Wallonia / Brussels)
+butterfly-dl belgium --only addresses
+#   → data/belgium/addresses/bosa-bevlg.zip   (~152 MB)
+#   → data/belgium/addresses/bosa-bewal.zip   (~60 MB)
+#   → data/belgium/addresses/bosa-bebru.zip   (~17 MB)
+
+# 2. Build a per-region shard (~30 s each, opens the ZIP transparently)
+butterfly-geocode build-shard --csv data/belgium/addresses/bosa-bevlg.zip \
+    --out belgium-bosa-vlg.bfgs --country BE --source bosa
+butterfly-geocode build-shard --csv data/belgium/addresses/bosa-bewal.zip \
+    --out belgium-bosa-wal.bfgs --country BE --source bosa
+butterfly-geocode build-shard --csv data/belgium/addresses/bosa-bebru.zip \
+    --out belgium-bosa-bru.bfgs --country BE --source bosa
+
+# 3. Merge into a single Belgium-wide BOSA shard
+butterfly-geocode build-shard \
+    --merge belgium-bosa-vlg.bfgs \
+    --merge belgium-bosa-wal.bfgs \
+    --merge belgium-bosa-bru.bfgs \
+    --out belgium-bosa.bfgs --country BE
+```
+
+### Combine BOSA with OSM (merged shard)
+
+BOSA has the addresses BOSA knows about. OSM knows about new buildings, recently mapped places, and a few address conventions BOSA doesn't index. The `--merge` mode combines both: where they agree on (postcode, street, housenumber) within ~30 m, the BOSA record wins (it is authoritative); where they disagree or only one has the address, both survive.
+
+```bash
+butterfly-geocode build-shard \
+    --merge belgium-bosa.bfgs \
+    --merge belgium-osm.bfgs \
+    --out belgium-merged.bfgs --country BE
+```
+
+The per-record source byte (BFGS v4) survives the merge so `/geocode` results carry their provenance. Operators auditing geocode outputs can filter by source via the per-record source field.
+
+### How the loader works
+
+`geocode/src/sources/bosa.rs` streams the CSV directly out of the BOSA ZIP (no decompress-to-disk step). For each `current` row, it emits one `AddressRecord` per non-empty language (NL / FR / DE) — Brussels rows typically yield 2 records (FR + NL); Flanders yields 1 (NL); Wallonia 1 (FR); the German-Belgium DE column is set on the ~70 k records in the East-Cantons. Coordinates are read from `EPSG:4326_lat/lon` so no Lambert-72 reprojection is needed.
+
+The `box_number` column folds into `housenumber` as `"475 bte RDC"` — Belgian box-number convention (apartment / floor identifier) preserved without a separate field.
 
 ## What's deferred (still in #96/#97/#98)
 
 - **Byte-level transformer parser** (#96 §Tagger, #98 Phase 2) — the heuristic in `parser/heuristic.rs` is the deterministic Phase 0 baseline. The byte-level transformer + #98 Phase 1 retrieval-aware decoding ship in `parser/neural.rs`.
-- **Authoritative-source ingestion** (BOSA BeSt, BAN, BAG, BD-Adresses, BEV, swisstopo) — `geocode-data/SOURCES.md` has the URLs + field mappings ready; OSM `addr:*` is the source for all countries in this release.
+- **Authoritative-source ingestion** for **non-Belgium countries** (BAN for FR, BAG for NL, BD-Adresses for LU, BEV for AT, swisstopo for CH) — `geocode-data/SOURCES.md` has the URLs + field mappings ready. **Belgium BOSA BeSt ships in this release** (see "Authoritative source" section below).
 - **Cross-border shard co-location** (#96 §Cross-Border Shard Co-location) — separate per-country shards instead. The layout-merge is a future optimization for the BE-FR-NL-LU-DE cluster.
 - **Adapter layers (LoRA per region)** (#96 §Tagger) — needs trained models.
 - **Feedback operators** (`Downgrade`, `TopkMerge`, `Sample`) — types defined per #96, not invoked by the MVP executor.

--- a/geocode/src/confidence/training.rs
+++ b/geocode/src/confidence/training.rs
@@ -468,6 +468,7 @@ mod tests {
                 } else {
                     4.401 + i as f64 * 1e-4
                 },
+                ..Default::default()
             })
             .collect();
         build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();

--- a/geocode/src/geocoder/executor.rs
+++ b/geocode/src/geocoder/executor.rs
@@ -1221,6 +1221,7 @@ mod tests {
                 locality: "Anderlecht".into(),
                 lat: 50.834,
                 lon: 4.314,
+                ..Default::default()
             },
             AddressRecord {
                 street: "Rue Wayez".into(),
@@ -1229,6 +1230,7 @@ mod tests {
                 locality: "Anderlecht".into(),
                 lat: 50.834,
                 lon: 4.315,
+                ..Default::default()
             },
             AddressRecord {
                 street: "Grote Markt".into(),
@@ -1237,6 +1239,7 @@ mod tests {
                 locality: "Antwerpen".into(),
                 lat: 51.221,
                 lon: 4.401,
+                ..Default::default()
             },
         ];
         build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();
@@ -1364,6 +1367,7 @@ mod tests {
                 locality: "Bruxelles".into(),
                 lat: 50.85 + (i as f64) * 1e-5,
                 lon: 4.35 + (i as f64) * 1e-5,
+                ..Default::default()
             });
         }
         build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();

--- a/geocode/src/lib.rs
+++ b/geocode/src/lib.rs
@@ -69,6 +69,7 @@ pub mod parser;
 pub mod routing;
 pub mod server;
 pub mod shard;
+pub mod sources;
 pub mod tagger;
 pub mod types;
 
@@ -79,6 +80,8 @@ pub use parser::neural::NeuralParser;
 pub use parser::{HeuristicBackend, NeuralBackend, ParserBackend};
 pub use routing::{CountryId, classify_country, country_for_point, supported_countries_for_point};
 pub use shard::reader::Shard;
+pub use shard::{AddressRecord, SourceTag};
+pub use sources::{Source, SourceProgress, bosa::BosaCsvSource, merge_records, osm::OsmPbfSource};
 pub use types::{
     ExecutionBudget, FieldMask, ParseHypothesis, ParsedQuery, RecoveryFlags, RetrievalPolicy,
     Strictness,

--- a/geocode/src/main.rs
+++ b/geocode/src/main.rs
@@ -19,6 +19,8 @@ use butterfly_geocode::osm_extract::{ExtractProgress, extract_addresses};
 use butterfly_geocode::server::{ServerConfig, ServerState, build_router_with_config};
 use butterfly_geocode::shard::builder::build_shard;
 use butterfly_geocode::shard::reader::Shard;
+use butterfly_geocode::shard::{AddressRecord, SourceTag};
+use butterfly_geocode::sources::{SourceProgress, bosa::BosaCsvSource, collect_all, merge_records};
 use butterfly_geocode::{HeuristicBackend, NeuralBackend, NeuralParser, ParserBackend};
 
 #[derive(Parser, Debug)]
@@ -49,18 +51,49 @@ enum ParserKind {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Build a single-country shard from an OSM PBF.
+    /// Build a single-country shard from one or more authoritative
+    /// sources (OSM PBF tags, BOSA BeSt CSV, ...).
+    ///
+    /// Three usage modes:
+    ///
+    /// 1. Single OSM PBF:    `--pbf <PATH> [--source osm]`
+    /// 2. Single BOSA CSV:   `--csv <PATH> --source bosa`
+    /// 3. Merge two shards:  `--merge a.bfgs --merge b.bfgs`
+    ///
+    /// Modes 1+2 are mutually exclusive. Mode 3 reads existing BFGS
+    /// shards (built via mode 1 or 2) and merges them, deduping
+    /// records by spatial proximity + housenumber match. The
+    /// authoritative source wins on conflict (#96 §"Data Sources":
+    /// "country packs choose channel weighting and policy").
     BuildShard {
         /// Source PBF (any Geofabrik regional/country extract).
-        #[arg(long)]
-        pbf: PathBuf,
-        /// Output BFGS v3 shard file.
+        /// Mutually exclusive with `--csv` / `--merge`.
+        #[arg(long, conflicts_with_all = ["csv", "merge"])]
+        pbf: Option<PathBuf>,
+        /// Source CSV (BOSA BeSt openaddress-be{vlg,wal,bru}.zip
+        /// or unzipped CSV). Mutually exclusive with `--pbf` /
+        /// `--merge`.
+        #[arg(long, conflicts_with_all = ["pbf", "merge"])]
+        csv: Option<PathBuf>,
+        /// Merge multiple existing shards into one (deduped). Repeat
+        /// the flag for each input shard. Mutually exclusive with
+        /// `--pbf` / `--csv`.
+        #[arg(long, conflicts_with_all = ["pbf", "csv"])]
+        merge: Vec<PathBuf>,
+        /// Output BFGS v4 shard file.
         #[arg(long)]
         out: PathBuf,
         /// ISO 3166-1 alpha-2 country code for this shard. Stored
-        /// in the BFGS v3 header and verified at server load.
+        /// in the BFGS v4 header and verified at server load.
         #[arg(long)]
         country: String,
+        /// Authoritative-source tag for the records in this shard
+        /// (`osm`, `bosa`, `ban`, `bag`, `gnaf`, `bev`, `swisstopo`).
+        /// Required for `--csv`; optional for `--pbf` (defaults to
+        /// `osm`); ignored for `--merge` (each input shard already
+        /// carries its own per-record tag).
+        #[arg(long)]
+        source: Option<String>,
     },
     /// Build every country shard the server can deploy in one pass.
     /// Looks for `<country>.pbf` (or `<iso2>.pbf`) inside `--pbf-dir`
@@ -190,7 +223,21 @@ async fn main() -> Result<()> {
     init_logging(&cli.log_format);
 
     match cli.cmd {
-        Command::BuildShard { pbf, out, country } => build_shard_cmd(&pbf, &out, &country),
+        Command::BuildShard {
+            pbf,
+            csv,
+            merge,
+            out,
+            country,
+            source,
+        } => build_shard_cmd(
+            pbf.as_deref(),
+            csv.as_deref(),
+            &merge,
+            &out,
+            &country,
+            source.as_deref(),
+        ),
         Command::BuildShardsAll {
             pbf_dir,
             out_dir,
@@ -285,7 +332,14 @@ fn init_logging(format: &str) {
     }
 }
 
-fn build_shard_cmd(pbf: &std::path::Path, out: &std::path::Path, country_iso2: &str) -> Result<()> {
+fn build_shard_cmd(
+    pbf: Option<&std::path::Path>,
+    csv: Option<&std::path::Path>,
+    merge_inputs: &[PathBuf],
+    out: &std::path::Path,
+    country_iso2: &str,
+    source: Option<&str>,
+) -> Result<()> {
     let country = CountryId::from_iso2(country_iso2).ok_or_else(|| {
         anyhow!(
             "unknown country '{country_iso2}' (supported: {})",
@@ -296,31 +350,8 @@ fn build_shard_cmd(pbf: &std::path::Path, out: &std::path::Path, country_iso2: &
                 .join(", ")
         )
     })?;
-    info!(
-        pbf = %pbf.display(),
-        out = %out.display(),
-        country = country.iso2(),
-        "extracting OSM addresses"
-    );
+
     let start = std::time::Instant::now();
-
-    let addresses = extract_addresses(pbf, |evt| match evt {
-        ExtractProgress::Phase { phase } => info!("phase: {phase}"),
-        ExtractProgress::NodePass {
-            nodes_seen,
-            addresses_emitted,
-        } => info!(nodes_seen, addresses_emitted, "nodes pass complete"),
-        ExtractProgress::WayPass {
-            ways_seen,
-            addresses_emitted,
-        } => info!(ways_seen, addresses_emitted, "ways pass complete"),
-    })?;
-
-    info!(
-        count = addresses.len(),
-        secs = start.elapsed().as_secs_f64(),
-        "extracted addresses"
-    );
 
     if let Some(parent) = out.parent()
         && !parent.as_os_str().is_empty()
@@ -328,6 +359,78 @@ fn build_shard_cmd(pbf: &std::path::Path, out: &std::path::Path, country_iso2: &
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating output dir {}", parent.display()))?;
     }
+
+    // Branch on which input mode the user picked. clap conflicts_with
+    // already enforces mutual exclusion, but we still validate that
+    // exactly one mode is set so error messages are clean.
+    let addresses: Vec<AddressRecord> = if !merge_inputs.is_empty() {
+        info!(
+            shards = merge_inputs.len(),
+            country = country.iso2(),
+            "merging existing shards"
+        );
+        merge_existing_shards(merge_inputs, country)?
+    } else if let Some(csv_path) = csv {
+        let tag_str = source.ok_or_else(|| {
+            anyhow!("--csv requires --source <bosa|...> so the shard byte is set explicitly")
+        })?;
+        let tag = SourceTag::from_name(tag_str).ok_or_else(|| {
+            anyhow!(
+                "unknown --source '{tag_str}' (supported: osm, bosa, ban, bag, gnaf, bev, swisstopo)"
+            )
+        })?;
+        info!(
+            csv = %csv_path.display(),
+            country = country.iso2(),
+            source = tag.name(),
+            "loading authoritative-source CSV"
+        );
+        load_csv_source(csv_path, country, tag)?
+    } else if let Some(pbf_path) = pbf {
+        // OSM PBF path. `source` defaults to `osm`.
+        let tag_str = source.unwrap_or("osm");
+        let tag = SourceTag::from_name(tag_str).ok_or_else(|| {
+            anyhow!(
+                "unknown --source '{tag_str}' (supported: osm, bosa, ban, bag, gnaf, bev, swisstopo)"
+            )
+        })?;
+        if tag != SourceTag::Osm {
+            bail!(
+                "--pbf is OSM-only; pass --source osm (or omit --source). Got --source={}",
+                tag.name()
+            );
+        }
+        info!(
+            pbf = %pbf_path.display(),
+            out = %out.display(),
+            country = country.iso2(),
+            source = tag.name(),
+            "extracting OSM addresses"
+        );
+        extract_addresses(pbf_path, |evt| match evt {
+            ExtractProgress::Phase { phase } => info!("phase: {phase}"),
+            ExtractProgress::NodePass {
+                nodes_seen,
+                addresses_emitted,
+            } => info!(nodes_seen, addresses_emitted, "nodes pass complete"),
+            ExtractProgress::WayPass {
+                ways_seen,
+                addresses_emitted,
+            } => info!(ways_seen, addresses_emitted, "ways pass complete"),
+        })?
+    } else {
+        bail!(
+            "build-shard needs exactly one of --pbf, --csv, or --merge. \
+             For OSM tags use --pbf <PBF>; for BOSA BeSt use --csv <ZIP|CSV> --source bosa; \
+             for combining shards use --merge a.bfgs --merge b.bfgs."
+        );
+    };
+
+    info!(
+        count = addresses.len(),
+        secs = start.elapsed().as_secs_f64(),
+        "extracted addresses"
+    );
 
     let stats = build_shard(out, country, addresses).context("writing shard")?;
     info!(
@@ -353,6 +456,77 @@ fn build_shard_cmd(pbf: &std::path::Path, out: &std::path::Path, country_iso2: &
     info!("shard verified");
 
     Ok(())
+}
+
+/// Load a CSV authoritative source. Today only BOSA BeSt is wired
+/// (`SourceTag::Bosa`). Other CSV sources land here as new arms.
+fn load_csv_source(
+    path: &std::path::Path,
+    country: CountryId,
+    tag: SourceTag,
+) -> Result<Vec<AddressRecord>> {
+    match tag {
+        SourceTag::Bosa => {
+            let loader = BosaCsvSource::new(path, country);
+            collect_all(&loader, |evt| match evt {
+                SourceProgress::Phase { phase } => info!("phase: {phase}"),
+                SourceProgress::Records {
+                    rows_seen,
+                    records_emitted,
+                } => info!(rows_seen, records_emitted, "BOSA progress"),
+            })
+            .context("BOSA CSV ingest")
+        }
+        other => bail!(
+            "CSV ingest for source {} is not wired yet (only BOSA today). \
+             Add a loader to geocode/src/sources/ and a new arm here.",
+            other.name()
+        ),
+    }
+}
+
+/// Read existing BFGS shards, materialise their records into
+/// `AddressRecord`s (preserving each record's source byte), and merge
+/// via [`merge_records`].
+fn merge_existing_shards(inputs: &[PathBuf], country: CountryId) -> Result<Vec<AddressRecord>> {
+    let mut groups: Vec<Vec<AddressRecord>> = Vec::with_capacity(inputs.len());
+    for p in inputs {
+        info!(shard = %p.display(), "reading shard for merge");
+        let s = Shard::open(p).with_context(|| format!("opening merge input {}", p.display()))?;
+        if s.country() != country {
+            bail!(
+                "merge input {} has country {} but target shard is {}",
+                p.display(),
+                s.country().iso2(),
+                country.iso2()
+            );
+        }
+        let mut recs = Vec::with_capacity(s.record_count());
+        for i in 0..s.record_count() as u32 {
+            let Some(r) = s.record(i) else { continue };
+            recs.push(AddressRecord {
+                lat: r.lat,
+                lon: r.lon,
+                street: r.street.to_string(),
+                locality: r.locality.to_string(),
+                housenumber: r.housenumber.to_string(),
+                postcode: r.postcode.to_string(),
+                source: r.source,
+                source_id: None,
+            });
+        }
+        info!(records = recs.len(), shard = %p.display(), "shard records loaded");
+        groups.push(recs);
+    }
+    let total_in: usize = groups.iter().map(|g| g.len()).sum();
+    let merged = merge_records(groups);
+    info!(
+        in_records = total_in,
+        merged_records = merged.len(),
+        deduped = total_in - merged.len(),
+        "merge complete"
+    );
+    Ok(merged)
 }
 
 fn build_shards_all_cmd(
@@ -399,7 +573,7 @@ fn build_shards_all_cmd(
             continue;
         };
         let out = out_dir.join(format!("{}.bfgs", c.iso2().to_ascii_lowercase()));
-        match build_shard_cmd(&pbf, &out, c.iso2()) {
+        match build_shard_cmd(Some(&pbf), None, &[], &out, c.iso2(), Some("osm")) {
             Ok(_) => built.push(c),
             Err(e) => {
                 warn!(country = c.iso2(), error = %e, "shard build failed; continuing");

--- a/geocode/src/osm_extract/mod.rs
+++ b/geocode/src/osm_extract/mod.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use osmpbf::{Element, ElementReader};
 
-use crate::shard::AddressRecord;
+use crate::shard::{AddressRecord, SourceTag};
 
 #[derive(Debug, Clone, Copy)]
 pub enum ExtractProgress {
@@ -114,6 +114,8 @@ where
         housenumber,
         postcode,
         locality,
+        source: SourceTag::Osm,
+        source_id: None,
     })
 }
 
@@ -147,6 +149,8 @@ fn way_to_address(
         housenumber,
         postcode,
         locality,
+        source: SourceTag::Osm,
+        source_id: None,
     })
 }
 

--- a/geocode/src/parser/decoding.rs
+++ b/geocode/src/parser/decoding.rs
@@ -661,6 +661,7 @@ mod tests {
                 locality: "Anderlecht".into(),
                 lat: 50.834,
                 lon: 4.314,
+                ..Default::default()
             },
             crate::shard::AddressRecord {
                 street: "Grote Markt".into(),
@@ -669,6 +670,7 @@ mod tests {
                 locality: "Antwerpen".into(),
                 lat: 51.221,
                 lon: 4.401,
+                ..Default::default()
             },
         ];
         crate::shard::builder::build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();

--- a/geocode/src/parser/neural.rs
+++ b/geocode/src/parser/neural.rs
@@ -130,6 +130,7 @@ mod tests {
                 locality: "Anderlecht".into(),
                 lat: 50.834,
                 lon: 4.314,
+                ..Default::default()
             },
             AddressRecord {
                 street: "Grote Markt".into(),
@@ -138,6 +139,7 @@ mod tests {
                 locality: "Antwerpen".into(),
                 lat: 51.221,
                 lon: 4.401,
+                ..Default::default()
             },
         ];
         build_shard(&path, crate::routing::CountryId::BE, addrs).unwrap();

--- a/geocode/src/shard/builder.rs
+++ b/geocode/src/shard/builder.rs
@@ -1,5 +1,5 @@
 //! Shard builder. Takes a stream of [`AddressRecord`]s and writes a
-//! `BFGS` v3 file (see [`super`] for the format docs).
+//! `BFGS` v4 file (see [`super`] for the format docs).
 
 use std::collections::BTreeMap;
 use std::io::{BufWriter, Write};
@@ -96,7 +96,7 @@ pub fn build_shard<P: AsRef<Path>>(
         let (house_off, house_len) = intern(&a.housenumber, &mut strings);
         let (pc_off, pc_len) = intern(&a.postcode, &mut strings);
 
-        // Record layout: 32 bytes, see `super` module docs.
+        // Record layout: 36 bytes, see `super` module docs.
         records_bytes.extend_from_slice(&lat_e7.to_le_bytes());
         records_bytes.extend_from_slice(&lon_e7.to_le_bytes());
         records_bytes.extend_from_slice(&street_off.to_le_bytes());
@@ -107,6 +107,11 @@ pub fn build_shard<P: AsRef<Path>>(
         records_bytes.extend_from_slice(&house_len.to_le_bytes());
         records_bytes.extend_from_slice(&pc_off.to_le_bytes());
         records_bytes.extend_from_slice(&pc_len.to_le_bytes());
+        // v4: per-record source byte (#96 §"Data Sources") + 3 pad
+        // bytes for 4-byte alignment. Pad is always zero so the file
+        // CRC stays deterministic across runs.
+        records_bytes.push(a.source.to_u8());
+        records_bytes.extend_from_slice(&[0u8; 3]);
 
         if !a.postcode.is_empty() {
             by_postcode.entry(a.postcode.clone()).or_default().push(id);
@@ -282,6 +287,29 @@ mod tests {
             locality: loc.to_string(),
             lat,
             lon,
+            source: super::super::SourceTag::Osm,
+            source_id: None,
+        }
+    }
+
+    fn rec_with_source(
+        street: &str,
+        num: &str,
+        pc: &str,
+        loc: &str,
+        lat: f64,
+        lon: f64,
+        source: super::super::SourceTag,
+    ) -> AddressRecord {
+        AddressRecord {
+            street: street.to_string(),
+            housenumber: num.to_string(),
+            postcode: pc.to_string(),
+            locality: loc.to_string(),
+            lat,
+            lon,
+            source,
+            source_id: None,
         }
     }
 
@@ -342,6 +370,41 @@ mod tests {
             let s = Shard::open(&path).unwrap();
             assert_eq!(s.country(), country, "header country mismatch");
         }
+    }
+
+    #[test]
+    fn source_byte_round_trips_through_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("shard.bfgs");
+        let addrs = vec![
+            rec_with_source(
+                "Rue Wayez",
+                "122",
+                "1070",
+                "Anderlecht",
+                50.834,
+                4.314,
+                super::super::SourceTag::Bosa,
+            ),
+            rec_with_source(
+                "Grote Markt",
+                "1",
+                "2000",
+                "Antwerpen",
+                51.221,
+                4.401,
+                super::super::SourceTag::Osm,
+            ),
+        ];
+        build_shard(&path, CountryId::BE, addrs).unwrap();
+        let s = Shard::open(&path).unwrap();
+        assert_eq!(s.record_count(), 2);
+        // Records are sorted by postcode then street; "1070|rue wayez"
+        // sorts before "2000|grote markt".
+        let r0 = s.record(0).unwrap();
+        let r1 = s.record(1).unwrap();
+        assert_eq!(r0.source, super::super::SourceTag::Bosa);
+        assert_eq!(r1.source, super::super::SourceTag::Osm);
     }
 
     #[test]

--- a/geocode/src/shard/mod.rs
+++ b/geocode/src/shard/mod.rs
@@ -1,6 +1,6 @@
 //! Per-country address shard.
 //!
-//! ## Format (`BFGS` v3)
+//! ## Format (`BFGS` v4)
 //!
 //! Single binary file, mmap-friendly, little-endian. Designed for
 //! zero-copy reads: every section is 4-byte aligned, every fixed-size
@@ -15,17 +15,26 @@
 //!
 //! ## Multi-country (#96)
 //!
-//! v3 is single-country (one shard per country, see #96 §"Per-Country
-//! Shard Contents") with the [`crate::routing::CountryId`] code stored
-//! in the header at byte 6. v2 is implicitly Belgium-only and treated
-//! as a v3 shard with `CountryId::BE` for one release as a
-//! backwards-compat path — operators rebuild Belgium at v3 alongside
-//! any new country shard they want to deploy.
+//! v3 introduced the per-shard country code (one shard per country,
+//! see #96 §"Per-Country Shard Contents") stored at header byte 6.
+//!
+//! ## Authoritative-source ingestion (#96 §"Data Sources", v4)
+//!
+//! v4 extends the per-record layout with a single `source` byte
+//! (1 = OSM, 2 = BOSA BeSt, 3 = BAN, 4 = BAG, 5 = G-NAF, 6 = BEV,
+//! 7 = swisstopo). The byte answers the audit question "what shipped
+//! this record?" without forcing the reader to track provenance
+//! out-of-band. See [`SourceTag`] for the canonical encoding.
+//!
+//! Records went from 32 → 36 bytes (added `source` u8 + 3 reserved
+//! pad bytes for 4-byte alignment). The old 32-byte v3 layout fails
+//! to load (version mismatch); operators rebuild every shard with
+//! `build-shard --source <osm|bosa|...> --country <iso2>`.
 //!
 //! ```text
 //!   Header (64 bytes):
 //!     magic            "BFGS"        u32   (= 0x53464642)
-//!     version          u16           (= 3)
+//!     version          u16           (= 4)
 //!     country_code     u8            (CountryId::to_u8 — 1=BE, 2=FR, ...)
 //!     _pad             u8
 //!     record_count     u32
@@ -33,14 +42,14 @@
 //!     strings_off      u64
 //!     strings_len      u64
 //!     records_off      u64           (4-byte aligned)
-//!     records_len      u64           (record_count * 32 bytes)
+//!     records_len      u64           (record_count * 36 bytes)
 //!     index_off        u64           (4-byte aligned)
 //!     index_len        u64
 //!
 //!   Strings: concatenated UTF-8 bytes (offset+len indexed from records).
 //!   Padded with zero bytes to 4-byte boundary.
 //!
-//!   Records (32 bytes each, 4-byte aligned):
+//!   Records (36 bytes each, 4-byte aligned):
 //!     lat_e7        i32
 //!     lon_e7        i32
 //!     street_off    u32
@@ -51,6 +60,8 @@
 //!     house_len     u16
 //!     pc_off        u32
 //!     pc_len        u16
+//!     source        u8        (SourceTag::to_u8 — 1=OSM, 2=BOSA, ...)
+//!     _pad          u8[3]
 //!
 //!   Index region (4-byte aligned). Four sub-indices stored back-to-back
 //!   in this order: postcode, locality, street, postcode|street.
@@ -68,23 +79,124 @@
 //!     u64 file_crc64
 //! ```
 //!
-//! Old `BFGS v1` and `BFGS v2` shards fail to load against the v3
-//! reader (version mismatch). They must be rebuilt — Belgium MVP
-//! shards must be re-run via `build-shard --country BE`.
+//! Old `BFGS v1`/v2/v3 shards fail to load against the v4 reader
+//! (version mismatch). They must be rebuilt — every shard must be
+//! re-run via `build-shard --country <iso2> --source <tag>`.
 
 pub mod builder;
 pub mod mmap;
 pub mod reader;
 
 pub const MAGIC: u32 = u32::from_le_bytes(*b"BFGS");
-/// Current on-disk version. v3 introduces the per-shard country code
-/// (#96 multi-country shards). v2 was the single-country (Belgium)
-/// MVP layout.
-pub const VERSION: u16 = 3;
+/// Current on-disk version. v4 introduces the per-record source byte
+/// (#96 §"Data Sources" — OSM/BOSA/BAN/BAG/G-NAF/...). v3 introduced
+/// the per-shard country code. v2 was the Belgium-only MVP.
+pub const VERSION: u16 = 4;
 pub const HEADER_BYTES: usize = 64;
-pub const RECORD_BYTES: usize = 32;
+/// 32 byte v3 layout + `source` u8 + 3 pad bytes for 4-byte
+/// alignment = 36. The pad bytes are reserved for future per-record
+/// metadata (e.g. confidence score, quality flag) and MUST be zero
+/// at write time so the file CRC stays deterministic.
+pub const RECORD_BYTES: usize = 36;
 pub const FOOTER_BYTES: usize = 16;
 
+/// Authoritative-source tag for an [`AddressRecord`] (#96 §"Data
+/// Sources").
+///
+/// Stable on-disk encoding: never reuse a code for a different source
+/// across versions. Adding a new source = new variant + new arm in
+/// `to_u8` / `from_u8` + new arm in [`SourceTag::name`].
+///
+/// `Osm` is the default fallback for shards built from PBF tags. Every
+/// other variant tracks an authoritative open-data dataset. See
+/// `geocode-data/SOURCES.md` for the per-country importer contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SourceTag {
+    /// OpenStreetMap `addr:*` tags.
+    Osm,
+    /// Belgian BeSt Address (BOSA).
+    Bosa,
+    /// French Base Adresse Nationale (BAN).
+    Ban,
+    /// Dutch Basisregistratie Adressen en Gebouwen (BAG).
+    Bag,
+    /// Australian Geocoded National Address File (G-NAF).
+    Gnaf,
+    /// Austrian Bundesamt für Eich- und Vermessungswesen (BEV).
+    Bev,
+    /// Swiss Federal Office of Topography (swisstopo).
+    Swisstopo,
+}
+
+impl SourceTag {
+    /// Encode as a single byte for on-disk records (BFGS v4). Stable
+    /// across versions.
+    #[must_use]
+    pub fn to_u8(self) -> u8 {
+        match self {
+            SourceTag::Osm => 1,
+            SourceTag::Bosa => 2,
+            SourceTag::Ban => 3,
+            SourceTag::Bag => 4,
+            SourceTag::Gnaf => 5,
+            SourceTag::Bev => 6,
+            SourceTag::Swisstopo => 7,
+        }
+    }
+
+    /// Decode a record byte to a tag. Returns `None` for unknown
+    /// codes (forward-compatible: a future shard can introduce new
+    /// codes without breaking older readers' header parse).
+    #[must_use]
+    pub fn from_u8(b: u8) -> Option<Self> {
+        match b {
+            1 => Some(SourceTag::Osm),
+            2 => Some(SourceTag::Bosa),
+            3 => Some(SourceTag::Ban),
+            4 => Some(SourceTag::Bag),
+            5 => Some(SourceTag::Gnaf),
+            6 => Some(SourceTag::Bev),
+            7 => Some(SourceTag::Swisstopo),
+            _ => None,
+        }
+    }
+
+    /// Stable human-readable name (used in CLI flags and metrics).
+    /// Lowercase to match the `--source` CLI value.
+    #[must_use]
+    pub fn name(self) -> &'static str {
+        match self {
+            SourceTag::Osm => "osm",
+            SourceTag::Bosa => "bosa",
+            SourceTag::Ban => "ban",
+            SourceTag::Bag => "bag",
+            SourceTag::Gnaf => "gnaf",
+            SourceTag::Bev => "bev",
+            SourceTag::Swisstopo => "swisstopo",
+        }
+    }
+
+    /// Parse the `--source` CLI value (case-insensitive).
+    #[must_use]
+    pub fn from_name(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "osm" => Some(SourceTag::Osm),
+            "bosa" | "best" | "bosa-best" => Some(SourceTag::Bosa),
+            "ban" => Some(SourceTag::Ban),
+            "bag" => Some(SourceTag::Bag),
+            "gnaf" | "g-naf" => Some(SourceTag::Gnaf),
+            "bev" => Some(SourceTag::Bev),
+            "swisstopo" => Some(SourceTag::Swisstopo),
+            _ => None,
+        }
+    }
+}
+
+/// Normalised address record. Crosses the importer/builder boundary;
+/// `source_id` is **not** persisted in the shard (see [`SourceTag`])
+/// — it lives only in the in-memory ingestion path so the merge
+/// dedup can match BOSA records back to their upstream stable id.
 #[derive(Debug, Clone)]
 pub struct AddressRecord {
     pub lat: f64,
@@ -93,4 +205,81 @@ pub struct AddressRecord {
     pub locality: String,
     pub housenumber: String,
     pub postcode: String,
+    /// Authoritative-source tag (#96 §"Data Sources"). Persisted in
+    /// the BFGS v4 record byte. Default `SourceTag::Osm` is a
+    /// conscious choice — pre-existing OSM PBF importers don't have
+    /// to set it explicitly. Every authoritative-source loader
+    /// (BOSA, BAN, ...) sets it explicitly.
+    pub source: SourceTag,
+    /// Upstream stable id (e.g. BOSA `address_id`, BAN `id`).
+    /// **Not** persisted in v4 shards — used by the merge dedup
+    /// path only. `None` for OSM where the stable id is the OSM
+    /// node/way id and would require a separate map.
+    pub source_id: Option<String>,
+}
+
+impl Default for AddressRecord {
+    fn default() -> Self {
+        AddressRecord {
+            lat: 0.0,
+            lon: 0.0,
+            street: String::new(),
+            locality: String::new(),
+            housenumber: String::new(),
+            postcode: String::new(),
+            source: SourceTag::Osm,
+            source_id: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tag_tests {
+    use super::*;
+
+    #[test]
+    fn source_tag_byte_round_trip() {
+        for tag in [
+            SourceTag::Osm,
+            SourceTag::Bosa,
+            SourceTag::Ban,
+            SourceTag::Bag,
+            SourceTag::Gnaf,
+            SourceTag::Bev,
+            SourceTag::Swisstopo,
+        ] {
+            assert_eq!(SourceTag::from_u8(tag.to_u8()), Some(tag));
+        }
+    }
+
+    #[test]
+    fn source_tag_name_round_trip() {
+        for tag in [
+            SourceTag::Osm,
+            SourceTag::Bosa,
+            SourceTag::Ban,
+            SourceTag::Bag,
+            SourceTag::Gnaf,
+            SourceTag::Bev,
+            SourceTag::Swisstopo,
+        ] {
+            assert_eq!(SourceTag::from_name(tag.name()), Some(tag));
+        }
+    }
+
+    #[test]
+    fn source_tag_name_aliases() {
+        assert_eq!(SourceTag::from_name("BOSA"), Some(SourceTag::Bosa));
+        assert_eq!(SourceTag::from_name("best"), Some(SourceTag::Bosa));
+        assert_eq!(SourceTag::from_name("bosa-best"), Some(SourceTag::Bosa));
+        assert_eq!(SourceTag::from_name("g-naf"), Some(SourceTag::Gnaf));
+        assert_eq!(SourceTag::from_name("nope"), None);
+    }
+
+    #[test]
+    fn unknown_byte_decodes_to_none() {
+        assert_eq!(SourceTag::from_u8(0), None);
+        assert_eq!(SourceTag::from_u8(99), None);
+        assert_eq!(SourceTag::from_u8(255), None);
+    }
 }

--- a/geocode/src/shard/reader.rs
+++ b/geocode/src/shard/reader.rs
@@ -33,7 +33,7 @@ use memmap2::Mmap;
 use rstar::{AABB, PointDistance, RTree, RTreeObject};
 
 use super::mmap::map_readonly;
-use super::{FOOTER_BYTES, HEADER_BYTES, MAGIC, RECORD_BYTES, VERSION};
+use super::{FOOTER_BYTES, HEADER_BYTES, MAGIC, RECORD_BYTES, SourceTag, VERSION};
 use crate::geocoder::cost::ShardStats;
 use crate::parser::normalize::normalize;
 use crate::routing::CountryId;
@@ -59,6 +59,13 @@ pub struct ShardRecord {
     pub locality: Arc<str>,
     pub housenumber: Arc<str>,
     pub postcode: Arc<str>,
+    /// Authoritative-source tag (#96 §"Data Sources"). Decoded from
+    /// the per-record source byte (BFGS v4). Defaults to
+    /// [`SourceTag::Osm`] when the byte is unrecognised — the byte
+    /// is forward-compatible (a future shard may introduce new
+    /// codes), but the default lets older readers still surface a
+    /// value rather than panicking.
+    pub source: SourceTag,
 }
 
 impl fmt::Debug for ShardRecord {
@@ -71,6 +78,7 @@ impl fmt::Debug for ShardRecord {
             .field("locality", &&*self.locality)
             .field("housenumber", &&*self.housenumber)
             .field("postcode", &&*self.postcode)
+            .field("source", &self.source)
             .finish()
     }
 }
@@ -339,6 +347,8 @@ impl Shard {
         let h_len = u16::from_le_bytes(buf[base + 24..base + 26].try_into().ok()?);
         let p_off = u32::from_le_bytes(buf[base + 26..base + 30].try_into().ok()?);
         let p_len = u16::from_le_bytes(buf[base + 30..base + 32].try_into().ok()?);
+        // v4 source byte at offset 32. Bytes 33..36 are reserved pad.
+        let source_byte = buf[base + 32];
         Some(RawRecord {
             lat_e7,
             lon_e7,
@@ -350,6 +360,7 @@ impl Shard {
             h_len,
             p_off,
             p_len,
+            source_byte,
         })
     }
 
@@ -367,6 +378,7 @@ impl Shard {
             locality: self.intern(raw.l_off, raw.l_len),
             housenumber: self.intern(raw.h_off, raw.h_len),
             postcode: self.intern(raw.p_off, raw.p_len),
+            source: SourceTag::from_u8(raw.source_byte).unwrap_or(SourceTag::Osm),
         })
     }
 
@@ -500,6 +512,11 @@ struct RawRecord {
     h_len: u16,
     p_off: u32,
     p_len: u16,
+    /// BFGS v4 per-record source byte (#96 §"Data Sources"). 0 in
+    /// pre-v4 shards which we no longer accept; the version check at
+    /// open time rejects them so this is always a real `SourceTag`
+    /// code in practice.
+    source_byte: u8,
 }
 
 /// Iterator over street keys. Holds a sub-index view; each `next()`

--- a/geocode/src/sources/bosa.rs
+++ b/geocode/src/sources/bosa.rs
@@ -1,0 +1,521 @@
+//! BOSA BeSt Address loader (Belgium, #96 §"Data Sources").
+//!
+//! BeSt Address is the Belgian Federal Public Service BOSA's
+//! authoritative open-data address dataset (~6.7M records). It is
+//! published as three regional CSV downloads (Flanders / Wallonia /
+//! Brussels) plus a single national XML; this loader handles the CSV
+//! variant — it streams the rows as they come off the file, so memory
+//! stays bounded at a few KB regardless of dataset size.
+//!
+//! The CSV header is:
+//!
+//! ```text
+//! EPSG:31370_x,EPSG:31370_y,EPSG:4326_lat,EPSG:4326_lon,address_id,
+//! box_number,house_number,municipality_id,municipality_name_de,
+//! municipality_name_fr,municipality_name_nl,postcode,
+//! postname_fr,postname_nl,street_id,streetname_de,streetname_fr,
+//! streetname_nl,region_code,status
+//! ```
+//!
+//! Coordinates are already published in WGS84 (`EPSG:4326_lat/lon`) so
+//! no reprojection is needed — Lambert-72 (`EPSG:31370`) columns are
+//! ignored. Records with `status != current` are dropped (BOSA marks
+//! retired addresses with `retired`, which would pollute the shard).
+//!
+//! Per `geocode-data/SOURCES.md` Belgium needs every language as a
+//! queryable alias (NL/FR/DE). The loader emits **one record per
+//! language per address** so all three localities and street names
+//! land in the shard's per-language inverted index. They all share
+//! the same `(lat, lon, postcode, housenumber)` so the geocoder
+//! answers any-language queries against the right physical place.
+//!
+//! ## URL
+//!
+//! Direct CSV downloads (verified 2026-05-04, see
+//! `geocode-data/SOURCES.md`):
+//!
+//! - Flanders: `https://opendata.bosa.be/download/best/openaddress-bevlg.zip`
+//! - Wallonia: `https://opendata.bosa.be/download/best/openaddress-bewal.zip`
+//! - Brussels: `https://opendata.bosa.be/download/best/openaddress-bebru.zip`
+//!
+//! Each ZIP holds one CSV at the top level. The shard pipeline expects
+//! the CSV to be unzipped before this loader runs — the CLI's
+//! `--csv` flag points directly at the CSV file (or a `.zip`
+//! containing exactly one CSV).
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::routing::CountryId;
+use crate::shard::{AddressRecord, SourceTag};
+
+use super::{Source, SourceProgress};
+
+/// BOSA CSV streaming loader.
+#[derive(Debug, Clone)]
+pub struct BosaCsvSource {
+    path: PathBuf,
+    /// Country tag attached to each emitted record. BOSA is BE-only
+    /// in 2026 — the field is here for symmetry with future
+    /// federated-source loaders that aren't single-country.
+    country: CountryId,
+}
+
+impl BosaCsvSource {
+    pub fn new(path: impl AsRef<Path>, country: CountryId) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            country,
+        }
+    }
+}
+
+impl Source for BosaCsvSource {
+    fn tag(&self) -> SourceTag {
+        SourceTag::Bosa
+    }
+
+    fn stream(
+        &self,
+        progress: &mut dyn FnMut(SourceProgress),
+        emit: &mut dyn FnMut(AddressRecord),
+    ) -> Result<()> {
+        if self.country != CountryId::BE {
+            bail!(
+                "BOSA loader is BE-only; got {} — wire a per-country dispatch upstream",
+                self.country.iso2()
+            );
+        }
+
+        let path = &self.path;
+        let reader: Box<dyn Read> = if path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("zip"))
+        {
+            // ZIP: open the first .csv entry inside.
+            let f = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+            let mut zip = zip::ZipArchive::new(f)
+                .with_context(|| format!("zip archive {}", path.display()))?;
+            let mut csv_idx = None;
+            for i in 0..zip.len() {
+                let entry = zip
+                    .by_index(i)
+                    .with_context(|| format!("reading zip entry {i} in {}", path.display()))?;
+                let name = entry.name().to_string();
+                if name.to_ascii_lowercase().ends_with(".csv") {
+                    csv_idx = Some((i, name));
+                    break;
+                }
+            }
+            let (idx, name) = csv_idx.ok_or_else(|| {
+                anyhow::anyhow!("no .csv entry found inside zip {}", path.display())
+            })?;
+            // We need to own the bytes — `ZipFile` borrows the
+            // archive. Read everything into memory; BOSA single-region
+            // CSVs are 60-130 MB unzipped, fits comfortably.
+            let mut entry = zip
+                .by_index(idx)
+                .with_context(|| format!("re-opening zip entry {name} in {}", path.display()))?;
+            let mut buf = Vec::with_capacity(entry.size() as usize);
+            entry
+                .read_to_end(&mut buf)
+                .with_context(|| format!("reading zip entry {name} in {}", path.display()))?;
+            Box::new(std::io::Cursor::new(buf))
+        } else {
+            Box::new(File::open(path).with_context(|| format!("opening {}", path.display()))?)
+        };
+
+        let mut buf_reader = BufReader::with_capacity(1 << 20, reader);
+
+        progress(SourceProgress::Phase {
+            phase: "parsing BOSA CSV header",
+        });
+
+        // Read the header line and resolve column indices.
+        let mut header_line = String::new();
+        buf_reader
+            .read_line(&mut header_line)
+            .context("reading BOSA CSV header")?;
+        if header_line.trim().is_empty() {
+            bail!("BOSA CSV at {} has empty header", path.display());
+        }
+        let cols = parse_header(&header_line)?;
+
+        progress(SourceProgress::Phase {
+            phase: "streaming BOSA CSV rows",
+        });
+
+        let mut rows_seen: u64 = 0;
+        let mut records_emitted: u64 = 0;
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            let n = buf_reader
+                .read_line(&mut line)
+                .context("reading BOSA CSV row")?;
+            if n == 0 {
+                break;
+            }
+            rows_seen += 1;
+
+            let fields = split_csv_row(&line);
+            if fields.len() < cols.column_count {
+                // Truncated/malformed line: skip but don't fail the
+                // whole pass. BOSA is generally well-formed but we
+                // don't want one bad row to abort a 6.7M-row import.
+                continue;
+            }
+
+            let lat = parse_lat(fields[cols.lat]);
+            let lon = parse_lon(fields[cols.lon]);
+            let (Some(lat), Some(lon)) = (lat, lon) else {
+                continue;
+            };
+
+            let status = fields[cols.status].trim();
+            // Accept "current" or empty (occasionally missing in
+            // older publications). Skip "retired" and any other
+            // non-current state.
+            if !status.is_empty() && !status.eq_ignore_ascii_case("current") {
+                continue;
+            }
+
+            let postcode = fields[cols.postcode].trim();
+            if postcode.is_empty() {
+                continue;
+            }
+
+            let house_number = fields[cols.house_number].trim();
+            let box_number = fields[cols.box_number].trim();
+            let house = format_belgian_number(house_number, box_number);
+            if house.is_empty() {
+                continue;
+            }
+
+            let address_id = fields[cols.address_id].trim();
+
+            // Per-language: BOSA Belgium publishes NL/FR/DE names.
+            // We emit one record per non-empty language so all three
+            // names are queryable. Same `source_id` so the merge dedup
+            // can collapse them when needed.
+            for lang in [LangCol::Nl, LangCol::Fr, LangCol::De] {
+                let muni = fields[cols.muni(lang)].trim();
+                let street = fields[cols.street(lang)].trim();
+                if muni.is_empty() && street.is_empty() {
+                    continue;
+                }
+                emit(AddressRecord {
+                    lat,
+                    lon,
+                    street: street.to_string(),
+                    locality: muni.to_string(),
+                    housenumber: house.clone(),
+                    postcode: postcode.to_string(),
+                    source: SourceTag::Bosa,
+                    source_id: if address_id.is_empty() {
+                        None
+                    } else {
+                        Some(address_id.to_string())
+                    },
+                });
+                records_emitted += 1;
+            }
+
+            if rows_seen.is_multiple_of(100_000) {
+                progress(SourceProgress::Records {
+                    rows_seen,
+                    records_emitted,
+                });
+            }
+        }
+
+        progress(SourceProgress::Records {
+            rows_seen,
+            records_emitted,
+        });
+
+        Ok(())
+    }
+}
+
+/// Format a Belgian housenumber: `house[box]` with `bte` separator
+/// when both are present. BOSA publishes box numbers separately
+/// (apartment / box like `RDC` for ground-floor or `2eET` for second
+/// floor); we fold them into a single field so the geocoder doesn't
+/// need a separate "unit" channel for the BE MVP.
+fn format_belgian_number(house: &str, box_number: &str) -> String {
+    let h = house.trim();
+    let b = box_number.trim();
+    if h.is_empty() {
+        return String::new();
+    }
+    if b.is_empty() {
+        return h.to_string();
+    }
+    format!("{h} bte {b}")
+}
+
+#[derive(Debug, Clone, Copy)]
+enum LangCol {
+    Nl,
+    Fr,
+    De,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ColumnIndices {
+    lat: usize,
+    lon: usize,
+    address_id: usize,
+    house_number: usize,
+    box_number: usize,
+    postcode: usize,
+    muni_nl: usize,
+    muni_fr: usize,
+    muni_de: usize,
+    street_nl: usize,
+    street_fr: usize,
+    street_de: usize,
+    status: usize,
+    /// Total column count; used to reject truncated rows.
+    column_count: usize,
+}
+
+impl ColumnIndices {
+    fn muni(&self, lang: LangCol) -> usize {
+        match lang {
+            LangCol::Nl => self.muni_nl,
+            LangCol::Fr => self.muni_fr,
+            LangCol::De => self.muni_de,
+        }
+    }
+    fn street(&self, lang: LangCol) -> usize {
+        match lang {
+            LangCol::Nl => self.street_nl,
+            LangCol::Fr => self.street_fr,
+            LangCol::De => self.street_de,
+        }
+    }
+}
+
+fn parse_header(line: &str) -> Result<ColumnIndices> {
+    let fields: Vec<&str> = line.trim().split(',').map(str::trim).collect();
+    let lookup = |name: &str| fields.iter().position(|f| f.eq_ignore_ascii_case(name));
+    let lat = lookup("EPSG:4326_lat").context("BOSA CSV missing EPSG:4326_lat column")?;
+    let lon = lookup("EPSG:4326_lon").context("BOSA CSV missing EPSG:4326_lon column")?;
+    let address_id = lookup("address_id").context("BOSA CSV missing address_id column")?;
+    let house_number = lookup("house_number").context("BOSA CSV missing house_number column")?;
+    // box_number is optional in some BOSA snapshots; default to the
+    // last column if missing so the indexing arithmetic stays safe.
+    let box_number = lookup("box_number").unwrap_or(usize::MAX);
+    let postcode = lookup("postcode").context("BOSA CSV missing postcode column")?;
+    let muni_nl =
+        lookup("municipality_name_nl").context("BOSA CSV missing municipality_name_nl column")?;
+    let muni_fr =
+        lookup("municipality_name_fr").context("BOSA CSV missing municipality_name_fr column")?;
+    let muni_de =
+        lookup("municipality_name_de").context("BOSA CSV missing municipality_name_de column")?;
+    let street_nl = lookup("streetname_nl").context("BOSA CSV missing streetname_nl column")?;
+    let street_fr = lookup("streetname_fr").context("BOSA CSV missing streetname_fr column")?;
+    let street_de = lookup("streetname_de").context("BOSA CSV missing streetname_de column")?;
+    let status = lookup("status").context("BOSA CSV missing status column")?;
+    Ok(ColumnIndices {
+        lat,
+        lon,
+        address_id,
+        house_number,
+        box_number,
+        postcode,
+        muni_nl,
+        muni_fr,
+        muni_de,
+        street_nl,
+        street_fr,
+        street_de,
+        status,
+        column_count: fields.len(),
+    })
+}
+
+/// Lightweight CSV-row split. BOSA does not quote any field with
+/// commas in the data we've inspected (verified against Brussels +
+/// Flanders snapshots, 2026-05-04), so a plain comma split is
+/// correct. We still handle double-quoted fields defensively in case a
+/// future snapshot starts emitting them.
+///
+/// Returns trimmed-of-newline string slices in original order.
+fn split_csv_row(line: &str) -> Vec<&str> {
+    let trimmed = line.trim_end_matches(['\r', '\n']);
+    let mut out = Vec::new();
+    let bytes = trimmed.as_bytes();
+    let mut start = 0usize;
+    let mut in_quote = false;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            b'"' => in_quote = !in_quote,
+            b',' if !in_quote => {
+                out.push(slice_unquoted(&trimmed[start..i]));
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    out.push(slice_unquoted(&trimmed[start..]));
+    out
+}
+
+/// Strip a single leading + trailing `"` if present. We don't unescape
+/// `""` → `"` because BOSA doesn't emit it; if it ever does we'll
+/// hear about it via the status filter dropping rows it can't read.
+fn slice_unquoted(s: &str) -> &str {
+    let s = s.trim_matches([' ', '\t']);
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+fn parse_lat(s: &str) -> Option<f64> {
+    let v: f64 = s.trim().parse().ok()?;
+    if (-90.0..=90.0).contains(&v) {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+fn parse_lon(s: &str) -> Option<f64> {
+    let v: f64 = s.trim().parse().ok()?;
+    if (-180.0..=180.0).contains(&v) {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 4-row sample lifted from the real Brussels download
+    /// (`openaddress-bebru.zip`, downloaded 2026-05-04). Header +
+    /// real-shaped data so the parser exercises BOSA's actual format.
+    const SAMPLE_CSV: &str = "EPSG:31370_x,EPSG:31370_y,EPSG:4326_lat,EPSG:4326_lon,address_id,box_number,house_number,municipality_id,municipality_name_de,municipality_name_fr,municipality_name_nl,postcode,postname_fr,postname_nl,street_id,streetname_de,streetname_fr,streetname_nl,region_code,status\n\
+146321.07800,169504.60900,50.83595,4.31653,615867,RDC,475,21001,,Anderlecht,Anderlecht,1070,,,4568,,Chaussée de Mons,Bergense Steenweg,BE-BRU,current\n\
+146059.99800,169206.03000,50.83327,4.31283,615868,2eET,603,21001,,Anderlecht,Anderlecht,1070,,,4568,,Chaussée de Mons,Bergense Steenweg,BE-BRU,current\n\
+000000,000000,50.84671,4.35251,99999,,1,21004,,Bruxelles,Brussel,1000,,,1,,Grand-Place,Grote Markt,BE-BRU,current\n\
+000000,000000,50.84671,4.35252,77777,,2,21004,,Bruxelles,Brussel,1000,,,1,,Grand-Place,Grote Markt,BE-BRU,retired\n";
+
+    fn write_sample(dir: &std::path::Path) -> std::path::PathBuf {
+        let p = dir.join("sample.csv");
+        std::fs::write(&p, SAMPLE_CSV).unwrap();
+        p
+    }
+
+    #[test]
+    fn parses_real_bosa_sample() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_sample(dir.path());
+        let src = BosaCsvSource::new(&p, CountryId::BE);
+        let recs = super::super::collect_all(&src, |_| {}).unwrap();
+        // 3 active rows × 2 non-empty languages each (NL+FR; DE is
+        // empty in Brussels snapshots) = 6 records. The retired row
+        // is dropped.
+        assert_eq!(
+            recs.len(),
+            6,
+            "expected 6 active-NL+FR records, got {}: {:#?}",
+            recs.len(),
+            recs
+        );
+        for r in &recs {
+            assert_eq!(r.source, SourceTag::Bosa);
+            assert!(r.source_id.is_some(), "address_id should propagate");
+        }
+        // Two records share address_id 615867 (NL + FR variants).
+        let by_id: Vec<_> = recs
+            .iter()
+            .filter(|r| r.source_id.as_deref() == Some("615867"))
+            .collect();
+        assert_eq!(by_id.len(), 2);
+        let langs: Vec<&str> = by_id.iter().map(|r| r.locality.as_str()).collect();
+        assert!(langs.contains(&"Anderlecht"));
+        // Box folds into housenumber.
+        assert!(by_id.iter().all(|r| r.housenumber.contains("475 bte RDC")));
+    }
+
+    #[test]
+    fn drops_retired_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_sample(dir.path());
+        let src = BosaCsvSource::new(&p, CountryId::BE);
+        let recs = super::super::collect_all(&src, |_| {}).unwrap();
+        // Address_id 77777 is the only retired one; should NOT appear.
+        assert!(
+            recs.iter().all(|r| r.source_id.as_deref() != Some("77777")),
+            "retired address leaked through: {:#?}",
+            recs.iter()
+                .filter(|r| r.source_id.as_deref() == Some("77777"))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rejects_non_be_country() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_sample(dir.path());
+        let src = BosaCsvSource::new(&p, CountryId::FR);
+        let err = super::super::collect_all(&src, |_| {}).unwrap_err();
+        assert!(format!("{err:#}").contains("BOSA loader is BE-only"));
+    }
+
+    #[test]
+    fn missing_lat_lon_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("bad.csv");
+        let bad = "EPSG:31370_x,EPSG:31370_y,EPSG:4326_lat,EPSG:4326_lon,address_id,box_number,house_number,municipality_id,municipality_name_de,municipality_name_fr,municipality_name_nl,postcode,postname_fr,postname_nl,street_id,streetname_de,streetname_fr,streetname_nl,region_code,status\n\
+146321,169504,not_a_number,4.31653,615867,,475,21001,,A,A,1070,,,4568,,X,Y,BE-BRU,current\n";
+        std::fs::write(&p, bad).unwrap();
+        let src = BosaCsvSource::new(&p, CountryId::BE);
+        let recs = super::super::collect_all(&src, |_| {}).unwrap();
+        assert_eq!(recs.len(), 0, "rows with non-numeric lat must be dropped");
+    }
+
+    #[test]
+    fn header_validation_rejects_missing_columns() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("bad_header.csv");
+        std::fs::write(&p, "lat,lon,foo\n50,4,bar\n").unwrap();
+        let src = BosaCsvSource::new(&p, CountryId::BE);
+        let err = super::super::collect_all(&src, |_| {}).unwrap_err();
+        assert!(format!("{err:#}").contains("BOSA CSV missing"));
+    }
+
+    #[test]
+    fn format_belgian_number_with_box() {
+        assert_eq!(format_belgian_number("475", "RDC"), "475 bte RDC");
+        assert_eq!(format_belgian_number("475", ""), "475");
+        assert_eq!(format_belgian_number(" ", "RDC"), "");
+    }
+
+    #[test]
+    fn split_csv_row_handles_basic_commas() {
+        let r = split_csv_row("a,b,c\n");
+        assert_eq!(r, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn split_csv_row_respects_quoted_commas() {
+        let r = split_csv_row("a,\"b,c\",d\n");
+        assert_eq!(r, vec!["a", "b,c", "d"]);
+    }
+}

--- a/geocode/src/sources/mod.rs
+++ b/geocode/src/sources/mod.rs
@@ -1,0 +1,370 @@
+//! Authoritative-source ingestion (#96 §"Data Sources").
+//!
+//! Each source maps an upstream open-data dataset (BOSA BeSt for
+//! Belgium, BAN for France, BAG for the Netherlands, ...) into the
+//! same normalised [`crate::shard::AddressRecord`] shape so the shard
+//! builder is source-agnostic.
+//!
+//! ## Coverage today
+//!
+//! - [`osm`] — wraps `crate::osm_extract` so the existing OSM PBF
+//!   path goes through the same `Source` interface.
+//! - [`bosa`] — Belgian BeSt Address streaming CSV loader. Reads
+//!   region-specific CSVs (Flanders / Wallonia / Brussels), emits one
+//!   record per (address, language) so per-language localities/streets
+//!   land as queryable aliases.
+//!
+//! Adding a new source = new module + new `Source` impl + new
+//! `SourceTag` variant + new `[[address]]` entry in the relevant
+//! `dl/regions/<country>.toml`. No core code change.
+//!
+//! ## Merge dedup
+//!
+//! [`merge_records`] combines records from multiple sources into one
+//! shard. Conflicts (same `(postcode, normalized street, housenumber)`
+//! within ~30 m) resolve toward the highest-priority authoritative
+//! source — see [`merge_priority`]. BOSA wins over OSM for Belgium;
+//! BAN wins over OSM for France; etc. The OSM fallback survives for
+//! addresses no authoritative source covers (rare buildings, recent
+//! mappings).
+
+pub mod bosa;
+pub mod osm;
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::shard::{AddressRecord, SourceTag};
+
+/// A pluggable address-source loader.
+///
+/// Implementations stream records out of an upstream dataset and emit
+/// them through the callback. Streaming is required because BOSA at
+/// 6.7M records and BAN at 26M records exceed comfortable in-memory
+/// buffering.
+///
+/// The callback returns `()` and is expected to push into a
+/// caller-owned `Vec` or directly into a shard builder. A future
+/// follow-up may switch the builder to a streaming sink so the entire
+/// path stays bounded-memory; today the callback fills a `Vec`
+/// because the shard builder needs all records up-front for sorting.
+pub trait Source {
+    /// Stable [`SourceTag`] this source emits.
+    fn tag(&self) -> SourceTag;
+
+    /// Stream every record. The callback is called once per record.
+    /// Errors propagate; partial output is the caller's problem to
+    /// reset.
+    fn stream(
+        &self,
+        progress: &mut dyn FnMut(SourceProgress),
+        emit: &mut dyn FnMut(AddressRecord),
+    ) -> Result<()>;
+}
+
+/// Progress event for long-running source loaders. Emitted at fixed
+/// intervals (every ~100k records) so callers can render a progress
+/// line without flooding the log.
+#[derive(Debug, Clone, Copy)]
+pub enum SourceProgress {
+    /// Phase boundary: useful for two-pass loaders that want to log
+    /// "scanning nodes" then "scanning ways" separately.
+    Phase { phase: &'static str },
+    /// Mid-run progress: how many input rows have been seen and how
+    /// many records have been emitted so far. The two diverge when
+    /// the loader filters (BOSA `status != current`, OSM nodes
+    /// without `addr:*` tags, etc.).
+    Records {
+        rows_seen: u64,
+        records_emitted: u64,
+    },
+}
+
+/// Load every source in `sources` sequentially and concatenate their
+/// records. The output is the input to the shard builder.
+///
+/// Callers wanting per-source records (for the `--merge` CLI path,
+/// or for source-specific metrics) should call each [`Source::stream`]
+/// directly — this helper is the convenience function for the common
+/// "single-source build" case.
+pub fn collect_all<S: Source + ?Sized>(
+    source: &S,
+    mut progress: impl FnMut(SourceProgress),
+) -> Result<Vec<AddressRecord>> {
+    let mut out = Vec::new();
+    source.stream(&mut |p| progress(p), &mut |r| out.push(r))?;
+    Ok(out)
+}
+
+/// Sort key used by [`merge_records`] to group records that should
+/// be deduped against each other. Ascii-lowercased to fold case (BOSA
+/// stores `Chaussée de Mons` vs OSM `chaussée de mons`); housenumbers
+/// stay unfolded because `12A` ≠ `12a` is rare in practice but the
+/// canonical form is upstream-defined.
+fn dedup_key(rec: &AddressRecord) -> (String, String, String) {
+    (
+        rec.postcode.trim().to_ascii_lowercase(),
+        rec.street.trim().to_ascii_lowercase(),
+        rec.housenumber.trim().to_ascii_lowercase(),
+    )
+}
+
+/// Spatial proximity threshold for merge dedup, in degrees. ~30 m at
+/// Belgium's latitude (lat=50.83). When two records share the same
+/// `dedup_key` AND fall within this radius, they are considered the
+/// same physical address and the higher-priority source wins.
+///
+/// Bigger threshold = more aggressive merge (drops near-duplicates
+/// even when they're slightly off). Smaller threshold = more
+/// conservative (keeps both records when the upstream sources
+/// disagree on geolocation by more than ~30 m). 30 m matches the
+/// "snapped road point" semantics used elsewhere in the codebase.
+const MERGE_RADIUS_DEG: f64 = 0.0003;
+
+/// Source-priority ranking used by [`merge_records`]. Authoritative
+/// sources outrank OSM. Among authoritative sources, the first-listed
+/// (BOSA for BE, BAN for FR, ...) wins because it is the country's
+/// official open-data dataset. OSM is the global fallback.
+///
+/// Higher number = higher priority.
+fn merge_priority(tag: SourceTag) -> u8 {
+    match tag {
+        SourceTag::Bosa => 100,
+        SourceTag::Ban => 100,
+        SourceTag::Bag => 100,
+        SourceTag::Gnaf => 100,
+        SourceTag::Bev => 100,
+        SourceTag::Swisstopo => 100,
+        SourceTag::Osm => 10,
+    }
+}
+
+/// Merge multiple per-source record vectors into one. Records sharing
+/// the same `dedup_key` AND within `MERGE_RADIUS_DEG` are deduped to
+/// the highest-priority source. Records from different physical
+/// locations or with different street/housenumber values survive
+/// independently.
+///
+/// Order-stable for ties: when two sources have equal priority, the
+/// earlier vector in `inputs` wins. This is rare in the MVP (one
+/// authoritative source per country) but matters for callers that
+/// merge multiple OSM extracts.
+#[must_use]
+pub fn merge_records(inputs: Vec<Vec<AddressRecord>>) -> Vec<AddressRecord> {
+    use std::collections::HashMap;
+
+    // Group records by (postcode, street, housenumber). Within a
+    // group, dedup by spatial proximity.
+    let mut by_key: HashMap<(String, String, String), Vec<AddressRecord>> = HashMap::new();
+    for vec in inputs {
+        for rec in vec {
+            let k = dedup_key(&rec);
+            by_key.entry(k).or_default().push(rec);
+        }
+    }
+
+    let mut out = Vec::with_capacity(by_key.len());
+    for (_, group) in by_key {
+        let merged = dedup_group(group);
+        out.extend(merged);
+    }
+
+    // Stable order so shard byte-comparison reproducibility holds.
+    out.sort_by(|a, b| {
+        a.postcode
+            .cmp(&b.postcode)
+            .then(a.street.cmp(&b.street))
+            .then(a.housenumber.cmp(&b.housenumber))
+            .then(
+                a.lat
+                    .partial_cmp(&b.lat)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+            .then(
+                a.lon
+                    .partial_cmp(&b.lon)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+    });
+    out
+}
+
+/// Dedup a `dedup_key`-equivalent group by spatial proximity.
+/// Returns the survivors. Algorithm: O(n²) within the group (groups
+/// are typically size 1-3), pick the highest-priority source within
+/// each spatial cluster.
+fn dedup_group(group: Vec<AddressRecord>) -> Vec<AddressRecord> {
+    if group.len() <= 1 {
+        return group;
+    }
+    let n = group.len();
+    let mut taken = vec![false; n];
+    let mut survivors = Vec::with_capacity(n);
+
+    for i in 0..n {
+        if taken[i] {
+            continue;
+        }
+        // Cluster: every record within radius of `group[i]`.
+        let mut cluster: Vec<usize> = vec![i];
+        for j in (i + 1)..n {
+            if taken[j] {
+                continue;
+            }
+            let dlat = (group[i].lat - group[j].lat).abs();
+            let dlon = (group[i].lon - group[j].lon).abs();
+            if dlat < MERGE_RADIUS_DEG && dlon < MERGE_RADIUS_DEG {
+                cluster.push(j);
+            }
+        }
+        // Pick the highest-priority record from the cluster.
+        let winner_idx = *cluster
+            .iter()
+            .max_by_key(|&&k| merge_priority(group[k].source))
+            .expect("cluster has at least one element");
+        survivors.push(group[winner_idx].clone());
+        for k in cluster {
+            taken[k] = true;
+        }
+    }
+    survivors
+}
+
+/// Dispatch table used by the CLI: parse a `(format, path)` pair and
+/// load the source. Unknown formats return an error.
+///
+/// Today: `csv` → BOSA loader (the only supported CSV authoritative
+/// source). `pbf` → OSM loader. New formats land here.
+pub fn load_by_format(
+    format: &str,
+    path: &Path,
+    country: crate::routing::CountryId,
+) -> Result<Vec<AddressRecord>> {
+    match format {
+        "csv" | "bosa" | "bosa-csv" => {
+            let loader = bosa::BosaCsvSource::new(path, country);
+            collect_all(&loader, |_| {})
+        }
+        "pbf" | "osm" => {
+            let loader = osm::OsmPbfSource::new(path, country);
+            collect_all(&loader, |_| {})
+        }
+        other => Err(anyhow::anyhow!(
+            "unknown source format '{other}' (supported: csv|bosa|bosa-csv, pbf|osm)"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(
+        postcode: &str,
+        street: &str,
+        house: &str,
+        lat: f64,
+        lon: f64,
+        source: SourceTag,
+    ) -> AddressRecord {
+        AddressRecord {
+            lat,
+            lon,
+            street: street.into(),
+            housenumber: house.into(),
+            postcode: postcode.into(),
+            locality: "X".into(),
+            source,
+            source_id: None,
+        }
+    }
+
+    #[test]
+    fn merge_dedups_within_radius_keeps_higher_priority() {
+        // BOSA + OSM at the same physical address — BOSA wins.
+        let bosa = vec![rec(
+            "1070",
+            "Rue Wayez",
+            "122",
+            50.834,
+            4.314,
+            SourceTag::Bosa,
+        )];
+        let osm = vec![rec(
+            "1070",
+            "rue wayez",
+            "122",
+            50.8341,
+            4.3141,
+            SourceTag::Osm,
+        )];
+        let merged = merge_records(vec![bosa, osm]);
+        assert_eq!(merged.len(), 1, "expected single record after dedup");
+        assert_eq!(merged[0].source, SourceTag::Bosa);
+    }
+
+    #[test]
+    fn merge_keeps_unique_records() {
+        // Two different addresses survive.
+        let a = vec![rec(
+            "1070",
+            "Rue Wayez",
+            "122",
+            50.834,
+            4.314,
+            SourceTag::Bosa,
+        )];
+        let b = vec![rec(
+            "2000",
+            "Grote Markt",
+            "1",
+            51.221,
+            4.401,
+            SourceTag::Bosa,
+        )];
+        let merged = merge_records(vec![a, b]);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn merge_keeps_records_outside_radius() {
+        // Same postcode/street/housenumber but ~5 km apart — keep
+        // both because spatial split says they're not the same place.
+        let a = vec![rec("1070", "Rue X", "1", 50.8, 4.3, SourceTag::Osm)];
+        let b = vec![rec("1070", "Rue X", "1", 50.85, 4.35, SourceTag::Osm)];
+        let merged = merge_records(vec![a, b]);
+        assert_eq!(
+            merged.len(),
+            2,
+            "spatial split should keep both records when >>30m apart"
+        );
+    }
+
+    #[test]
+    fn merge_osm_only_keeps_all() {
+        // Two OSM-only records that are coincidentally at the same
+        // address (rare but possible on OSM): tie on priority,
+        // dedup keeps the first by stable sort.
+        let a = vec![rec("1070", "Rue X", "1", 50.834, 4.314, SourceTag::Osm)];
+        let b = vec![rec("1070", "Rue X", "1", 50.8341, 4.3141, SourceTag::Osm)];
+        let merged = merge_records(vec![a, b]);
+        // Both have priority 10, cluster contains both, dedup picks
+        // the first found (insertion order from the HashMap).
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].source, SourceTag::Osm);
+    }
+
+    #[test]
+    fn dedup_key_normalises_whitespace_and_case() {
+        let a = rec("1070", "Rue Wayez", "122", 50.0, 4.0, SourceTag::Osm);
+        let b = rec(" 1070 ", "rue wayez", "122", 50.0, 4.0, SourceTag::Osm);
+        assert_eq!(dedup_key(&a), dedup_key(&b));
+    }
+
+    #[test]
+    fn priority_order_ban_beats_osm() {
+        assert!(merge_priority(SourceTag::Ban) > merge_priority(SourceTag::Osm));
+        assert!(merge_priority(SourceTag::Bosa) > merge_priority(SourceTag::Osm));
+    }
+}

--- a/geocode/src/sources/osm.rs
+++ b/geocode/src/sources/osm.rs
@@ -1,0 +1,100 @@
+//! OSM PBF wrapper that adapts the existing `osm_extract` two-pass
+//! extractor to the [`Source`] trait. This is the global fallback for
+//! countries without a BOSA/BAN/BAG-style authoritative dataset.
+//!
+//! Implementation detail: `osm_extract::extract_addresses` collects
+//! all records into a `Vec` before returning, so the Source-trait
+//! "streaming" guarantee is best-effort here — for OSM PBF the entire
+//! address-tag set fits comfortably in memory anyway (Belgium ~170 K
+//! records, global ~200 M but always one-country-at-a-time per the
+//! shard model). A future change to `osm_extract` to support
+//! streaming would make this loader bounded-memory automatically.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::osm_extract::{ExtractProgress, extract_addresses};
+use crate::routing::CountryId;
+use crate::shard::{AddressRecord, SourceTag};
+
+use super::{Source, SourceProgress};
+
+#[derive(Debug, Clone)]
+pub struct OsmPbfSource {
+    pbf_path: PathBuf,
+    /// Country tag for the records emitted. `osm_extract` does not
+    /// look at country boundaries — it trusts the PBF to be a
+    /// per-country extract (Geofabrik regional extracts, e.g.
+    /// `belgium-latest.osm.pbf`).
+    country: CountryId,
+}
+
+impl OsmPbfSource {
+    pub fn new(pbf_path: impl AsRef<Path>, country: CountryId) -> Self {
+        Self {
+            pbf_path: pbf_path.as_ref().to_path_buf(),
+            country,
+        }
+    }
+
+    #[must_use]
+    pub fn country(&self) -> CountryId {
+        self.country
+    }
+}
+
+impl Source for OsmPbfSource {
+    fn tag(&self) -> SourceTag {
+        SourceTag::Osm
+    }
+
+    fn stream(
+        &self,
+        progress: &mut dyn FnMut(SourceProgress),
+        emit: &mut dyn FnMut(AddressRecord),
+    ) -> Result<()> {
+        // Adapt the existing two-pass progress shape to the unified
+        // `SourceProgress` enum. We forward node and way passes as
+        // separate phases plus mid-run record counts.
+        let recs = extract_addresses(&self.pbf_path, |evt| match evt {
+            ExtractProgress::Phase { phase } => progress(SourceProgress::Phase { phase }),
+            ExtractProgress::NodePass {
+                nodes_seen,
+                addresses_emitted,
+            } => progress(SourceProgress::Records {
+                rows_seen: nodes_seen,
+                records_emitted: addresses_emitted,
+            }),
+            ExtractProgress::WayPass {
+                ways_seen,
+                addresses_emitted,
+            } => progress(SourceProgress::Records {
+                rows_seen: ways_seen,
+                records_emitted: addresses_emitted,
+            }),
+        })?;
+
+        // `osm_extract` already sets `source = Osm` and `source_id =
+        // None` per its tag-extractor contract; we re-emit each record
+        // unchanged. The country field is informational only — the
+        // shard header carries the per-shard country and OSM PBFs are
+        // already country-bounded.
+        for r in recs {
+            emit(r);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tag_is_osm() {
+        let s = OsmPbfSource::new("/nonexistent.pbf", CountryId::BE);
+        assert_eq!(s.tag(), SourceTag::Osm);
+        assert_eq!(s.country(), CountryId::BE);
+    }
+}

--- a/geocode/tests/axum_e2e.rs
+++ b/geocode/tests/axum_e2e.rs
@@ -41,6 +41,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Anderlecht".into(),
             lat: 50.6883,
             lon: 4.3680,
+            ..Default::default()
         },
         AddressRecord {
             street: "Rue Wayez".into(),
@@ -49,6 +50,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Anderlecht".into(),
             lat: 50.6884,
             lon: 4.3681,
+            ..Default::default()
         },
         // Brussels-Bruxelles 1000
         AddressRecord {
@@ -58,6 +60,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Bruxelles".into(),
             lat: 50.8467,
             lon: 4.3673,
+            ..Default::default()
         },
         // Brussels Grand-Place
         AddressRecord {
@@ -67,6 +70,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Bruxelles".into(),
             lat: 50.8467,
             lon: 4.3525,
+            ..Default::default()
         },
         AddressRecord {
             street: "Grand-Place".into(),
@@ -75,6 +79,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Bruxelles".into(),
             lat: 50.8468,
             lon: 4.3526,
+            ..Default::default()
         },
         // Antwerpen Grote Markt
         AddressRecord {
@@ -84,6 +89,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Antwerpen".into(),
             lat: 51.2208,
             lon: 4.3997,
+            ..Default::default()
         },
         AddressRecord {
             street: "Grote Markt".into(),
@@ -92,6 +98,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Antwerpen".into(),
             lat: 51.2210,
             lon: 4.3995,
+            ..Default::default()
         },
         // Avenue Louise (for fuzzy test)
         AddressRecord {
@@ -101,6 +108,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Ixelles".into(),
             lat: 50.8323,
             lon: 4.3690,
+            ..Default::default()
         },
         AddressRecord {
             street: "Avenue Louise".into(),
@@ -109,6 +117,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Ixelles".into(),
             lat: 50.8295,
             lon: 4.3712,
+            ..Default::default()
         },
         // Gent Korenmarkt
         AddressRecord {
@@ -118,6 +127,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Gent".into(),
             lat: 51.0537,
             lon: 3.7239,
+            ..Default::default()
         },
     ]
 }

--- a/geocode/tests/bosa_e2e.rs
+++ b/geocode/tests/bosa_e2e.rs
@@ -1,0 +1,239 @@
+//! BOSA BeSt authoritative-source ingestion end-to-end tests.
+//!
+//! These cover the round trip from a real-shaped BOSA CSV row → shard
+//! build → mmap reader → query → response. They DO NOT hit the
+//! network — the test corpus is a 4-row real-shape sample lifted from
+//! the live BOSA Brussels download (`openaddress-bebru.zip`,
+//! verified 2026-05-04). Larger smoke tests live in
+//! `belgium_e2e.rs` behind the `#[ignore]` gate that requires the
+//! 6.7M-record real download.
+
+use std::path::PathBuf;
+
+use butterfly_geocode::CountryId;
+use butterfly_geocode::shard::SourceTag;
+use butterfly_geocode::shard::builder::build_shard;
+use butterfly_geocode::shard::reader::Shard;
+use butterfly_geocode::sources::bosa::BosaCsvSource;
+use butterfly_geocode::sources::{Source, collect_all};
+
+/// Real-shape BOSA Brussels CSV: header + 4 rows. The header matches
+/// the 2026-05-04 published format (20 columns); rows 1-3 are
+/// `current`, row 4 is `retired` and must be filtered.
+const REAL_SHAPE_CSV: &str = "EPSG:31370_x,EPSG:31370_y,EPSG:4326_lat,EPSG:4326_lon,address_id,box_number,house_number,municipality_id,municipality_name_de,municipality_name_fr,municipality_name_nl,postcode,postname_fr,postname_nl,street_id,streetname_de,streetname_fr,streetname_nl,region_code,status\n\
+146321.07800,169504.60900,50.83595,4.31653,615867,RDC,475,21001,,Anderlecht,Anderlecht,1070,,,4568,,Chaussée de Mons,Bergense Steenweg,BE-BRU,current\n\
+146059.99800,169206.03000,50.83327,4.31283,615868,2eET,603,21001,,Anderlecht,Anderlecht,1070,,,4568,,Chaussée de Mons,Bergense Steenweg,BE-BRU,current\n\
+148000.00000,170000.00000,50.84671,4.35251,99999,,1,21004,,Bruxelles,Brussel,1000,,,1,,Grand-Place,Grote Markt,BE-BRU,current\n\
+148000.00000,170001.00000,50.84671,4.35252,77777,,2,21004,,Bruxelles,Brussel,1000,,,1,,Grand-Place,Grote Markt,BE-BRU,retired\n";
+
+fn write_sample(dir: &std::path::Path, csv: &str) -> PathBuf {
+    let p = dir.join("bosa-sample.csv");
+    std::fs::write(&p, csv).unwrap();
+    p
+}
+
+#[test]
+fn bosa_csv_to_shard_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let csv = write_sample(dir.path(), REAL_SHAPE_CSV);
+    let shard_path = dir.path().join("bosa.bfgs");
+
+    let loader = BosaCsvSource::new(&csv, CountryId::BE);
+    let recs = collect_all(&loader, |_| {}).unwrap();
+    assert!(!recs.is_empty(), "BOSA loader produced no records");
+    // 3 active rows × {NL, FR} (DE empty in Brussels) = 6 records.
+    assert_eq!(recs.len(), 6, "expected 6 records, got: {:#?}", recs);
+    for r in &recs {
+        assert_eq!(r.source, SourceTag::Bosa);
+        assert!(r.source_id.is_some(), "address_id should propagate");
+    }
+
+    build_shard(&shard_path, CountryId::BE, recs).expect("build shard");
+
+    // Reload the shard and verify the source byte survives.
+    let shard = Shard::open(&shard_path).expect("open shard");
+    assert_eq!(shard.country(), CountryId::BE);
+    assert_eq!(shard.record_count(), 6);
+    for i in 0..shard.record_count() as u32 {
+        let r = shard.record(i).expect("record present");
+        assert_eq!(
+            r.source,
+            SourceTag::Bosa,
+            "source byte lost in round trip on record {i}: {r:#?}"
+        );
+    }
+}
+
+#[test]
+fn bosa_query_round_trip_finds_real_address() {
+    let dir = tempfile::tempdir().unwrap();
+    let csv = write_sample(dir.path(), REAL_SHAPE_CSV);
+    let shard_path = dir.path().join("bosa.bfgs");
+
+    let loader = BosaCsvSource::new(&csv, CountryId::BE);
+    let recs = collect_all(&loader, |_| {}).unwrap();
+    build_shard(&shard_path, CountryId::BE, recs).unwrap();
+
+    let shard = Shard::open(&shard_path).unwrap();
+
+    // The 1070 postcode should have the 4 NL+FR records for the two
+    // active Anderlecht rows.
+    let p1070 = shard.postings_for_postcode("1070");
+    assert_eq!(
+        p1070.len(),
+        4,
+        "expected 4 records for postcode 1070 (2 rows × 2 langs), got {}",
+        p1070.len()
+    );
+
+    // Reverse-geocode at the BOSA-published coordinate must hit
+    // Bergense Steenweg / Chaussée de Mons.
+    let nearest = shard.nearest(50.83595, 4.31653).expect("record nearby");
+    let street = nearest.street.to_lowercase();
+    assert!(
+        street.contains("bergense") || street.contains("mons"),
+        "expected Bergense/Mons street, got {}",
+        nearest.street
+    );
+    assert_eq!(nearest.source, SourceTag::Bosa);
+}
+
+#[test]
+fn bosa_dedup_via_merge() {
+    use butterfly_geocode::shard::AddressRecord;
+    use butterfly_geocode::sources::merge_records;
+
+    // Two records at the same address: BOSA + OSM. Merge dedups the
+    // OSM record because BOSA outranks it.
+    let bosa = vec![AddressRecord {
+        lat: 50.83595,
+        lon: 4.31653,
+        street: "Chaussée de Mons".to_string(),
+        locality: "Anderlecht".to_string(),
+        housenumber: "475".to_string(),
+        postcode: "1070".to_string(),
+        source: SourceTag::Bosa,
+        source_id: Some("615867".to_string()),
+    }];
+    let osm = vec![AddressRecord {
+        lat: 50.83594,
+        lon: 4.31654,
+        street: "chaussée de mons".to_string(),
+        locality: "Anderlecht".to_string(),
+        housenumber: "475".to_string(),
+        postcode: "1070".to_string(),
+        source: SourceTag::Osm,
+        source_id: None,
+    }];
+    let merged = merge_records(vec![bosa, osm]);
+    assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].source, SourceTag::Bosa);
+}
+
+#[test]
+fn build_shard_via_merge_preserves_per_record_source() {
+    use butterfly_geocode::shard::AddressRecord;
+    use butterfly_geocode::sources::merge_records;
+
+    // Build two single-source shards, then materialise their records
+    // and merge — same code path the CLI's `--merge` mode uses.
+    let bosa_records = vec![AddressRecord {
+        lat: 50.83595,
+        lon: 4.31653,
+        street: "Chaussée de Mons".to_string(),
+        locality: "Anderlecht".to_string(),
+        housenumber: "475".to_string(),
+        postcode: "1070".to_string(),
+        source: SourceTag::Bosa,
+        source_id: None,
+    }];
+    let osm_records = vec![AddressRecord {
+        lat: 51.221,
+        lon: 4.401,
+        street: "Grote Markt".to_string(),
+        locality: "Antwerpen".to_string(),
+        housenumber: "1".to_string(),
+        postcode: "2000".to_string(),
+        source: SourceTag::Osm,
+        source_id: None,
+    }];
+
+    let merged = merge_records(vec![bosa_records, osm_records]);
+    assert_eq!(merged.len(), 2, "two unique addresses survive");
+
+    let dir = tempfile::tempdir().unwrap();
+    let p = dir.path().join("merged.bfgs");
+    build_shard(&p, CountryId::BE, merged).unwrap();
+    let shard = Shard::open(&p).unwrap();
+
+    // Confirm BOTH source bytes survived the round trip.
+    let mut tags: Vec<_> = (0..shard.record_count() as u32)
+        .map(|i| shard.record(i).unwrap().source)
+        .collect();
+    tags.sort_by_key(|t| t.to_u8());
+    assert_eq!(tags, vec![SourceTag::Osm, SourceTag::Bosa]);
+}
+
+/// Larger smoke test against the real Brussels BOSA download. This
+/// requires the 17 MB ZIP to be present at the path below — fetch
+/// with `butterfly-dl belgium --only addresses` (the URL is in
+/// `dl/regions/belgium.toml`).
+///
+/// Marked `#[ignore]` because:
+/// - it depends on a 17 MB external download
+/// - it builds a 1.3M-record shard which takes ~13 s
+///
+/// Use `cargo test --release -p butterfly-geocode --test bosa_e2e -- --ignored bosa_real_brussels` to run it.
+#[test]
+#[ignore = "requires downloaded BOSA Brussels ZIP at data/belgium/addresses/bosa-bebru.zip"]
+fn bosa_real_brussels_zip_round_trip() {
+    let zip_path = std::path::Path::new("data/belgium/addresses/bosa-bebru.zip");
+    if !zip_path.exists() {
+        // Print a diagnostic instead of panicking so CI without the
+        // download can still see the test is properly gated.
+        eprintln!(
+            "BOSA Brussels ZIP not found at {}; skipping real-data smoke",
+            zip_path.display()
+        );
+        return;
+    }
+
+    let loader = BosaCsvSource::new(zip_path, CountryId::BE);
+    let mut count = 0u64;
+    let mut sample = Vec::new();
+    let mut rows_seen = 0u64;
+    loader
+        .stream(
+            &mut |evt| {
+                if let butterfly_geocode::sources::SourceProgress::Records {
+                    rows_seen: rs, ..
+                } = evt
+                {
+                    rows_seen = rs;
+                }
+            },
+            &mut |rec| {
+                count += 1;
+                if sample.len() < 3 {
+                    sample.push(rec);
+                }
+            },
+        )
+        .expect("BOSA stream");
+
+    assert!(
+        count > 100_000,
+        "expected ~1.3M Brussels records; got {count}"
+    );
+    assert!(
+        rows_seen >= 800_000,
+        "expected ~840 K input rows; got {rows_seen}"
+    );
+    for r in &sample {
+        assert_eq!(r.source, SourceTag::Bosa);
+        assert!(r.lat > 50.0 && r.lat < 51.5);
+        assert!(r.lon > 4.0 && r.lon < 5.0);
+        assert!(!r.postcode.is_empty());
+        assert!(r.postcode.starts_with("1"));
+    }
+}

--- a/geocode/tests/clean_query_allocs.rs
+++ b/geocode/tests/clean_query_allocs.rs
@@ -77,6 +77,7 @@ fn make_shard_with_n_postcode_records(n: usize) -> (tempfile::TempDir, Shard) {
             locality: "Anderlecht".into(),
             lat: 50.6883 + (i as f64) * 1e-5,
             lon: 4.3680 + (i as f64) * 1e-5,
+            ..Default::default()
         });
     }
     build_shard(&path, butterfly_geocode::CountryId::BE, addrs).expect("build shard");

--- a/geocode/tests/control_fanout.rs
+++ b/geocode/tests/control_fanout.rs
@@ -32,6 +32,7 @@ fn small_shard() -> (tempfile::TempDir, Shard) {
             locality: "Anderlecht".into(),
             lat: 50.834,
             lon: 4.314 + (i as f64) * 1e-5,
+            ..Default::default()
         });
     }
     build_shard(&path, butterfly_geocode::CountryId::BE, addrs).unwrap();

--- a/geocode/tests/prod_hardening.rs
+++ b/geocode/tests/prod_hardening.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header};
+use butterfly_geocode::CountryId;
 use butterfly_geocode::server::{ServerConfig, ServerState, build_router_with_config};
 use butterfly_geocode::shard::AddressRecord;
 use butterfly_geocode::shard::builder::build_shard;
@@ -38,6 +39,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Anderlecht".into(),
             lat: 50.6883,
             lon: 4.3680,
+            ..Default::default()
         },
         AddressRecord {
             street: "Grand-Place".into(),
@@ -46,6 +48,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
             locality: "Bruxelles".into(),
             lat: 50.8467,
             lon: 4.3525,
+            ..Default::default()
         },
     ]
 }
@@ -53,7 +56,7 @@ fn fixture_addresses() -> Vec<AddressRecord> {
 fn make_fixture_shard() -> (TempDir, Shard) {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("fixture.bfgs");
-    build_shard(&path, fixture_addresses()).expect("build fixture shard");
+    build_shard(&path, CountryId::BE, fixture_addresses()).expect("build fixture shard");
     let s = Shard::open(&path).expect("open fixture shard");
     (dir, s)
 }


### PR DESCRIPTION
## Summary

- Adds first-class **BOSA BeSt** ingestion for Belgium (~6.7 M physical addresses, monthly cadence, Belgian Open Data License). Replaces the OSM `addr:*` fallback as Belgium's primary address source. OSM stays as the global fallback for countries without authoritative coverage.
- New `geocode/src/sources/` module — pluggable `Source` trait with `bosa::BosaCsvSource` (streaming CSV, opens .zip transparently, NL/FR/DE language aliases, BOSA box-number folding) and `osm::OsmPbfSource` (wraps the existing extractor under the unified interface).
- Bumps the BFGS shard format **v3 → v4**: per-record `source` byte + 3 reserved pad bytes for alignment. New `SourceTag` enum encodes 7 sources (OSM/BOSA/BAN/BAG/G-NAF/BEV/swisstopo).
- CLI: `butterfly-geocode build-shard` now accepts `--csv <BOSA-zip-or-csv>`, `--source <tag>`, and `--merge a.bfgs --merge b.bfgs` for combining multiple shards (BOSA wins over OSM on conflict via spatial-proximity dedup).
- `dl/regions/belgium.toml` gains three `[[address]]` entries (Flanders / Wallonia / Brussels). `dl/src/regions.rs` parses the new section. `butterfly-dl belgium --only addresses` now fetches BOSA.

## Smoke test (real BOSA, 2026-05-04)

| Shard | Records | Postcodes | Streets |
|---|---|---|---|
| OSM-only | 4 026 754 | 1 723 | 87 903 |
| BOSA-only (3 ZIPs merged) | 10 667 558 | 1 145 | 95 704 |
| BOSA + OSM merged | 13 263 831 | 1 751 | 105 082 |

**Recall@5 (200 m, 100 random Brussels addresses):**
- BOSA shard: 38 / 100
- OSM shard: 2 / 100

19× coverage advantage. (The 38 % is parser-driven; reverse-geocode at the BOSA-published lat/lon hits the right address every time, which is the load-bearing test for the shard itself.)

**URL verification (live 2026-05-04):**
- `openaddress-bevlg.zip` → 200, 152.27 MB
- `openaddress-bewal.zip` → 200, 60.43 MB
- `openaddress-bebru.zip` → 200, 17.71 MB

## Test plan

- [x] BOSA CSV parser: 8 unit tests including a real-shape sample lifted from the live Brussels download
- [x] Merge dedup: 6 unit tests (priority order, spatial radius, case folding)
- [x] End-to-end: `tests/bosa_e2e.rs` — CSV → shard → mmap reader → reverse-geocode + merge round-trip (4 tests, all pass)
- [x] Live download: `bosa_real_brussels_zip_round_trip` (#[ignore]-gated, passes against the actual 17 MB Brussels ZIP)
- [x] Workspace tests: 191 lib + all integration tests pass after rebase onto main (which now includes #169 multi-country + #170 prod-hardening + #171 nominatim-bench)
- [x] `cargo clippy --workspace --all-targets --all-features` clean
- [x] `cargo fmt --all -- --check` clean

## Coordination

This branch was originally based on `geocode-multi-country-shards` (#169) which has since merged. Rebased onto `main`; the v3 → v4 shard bump folds cleanly atop the v3 multi-country bump. The new `prod_hardening.rs` test from #170 is updated for the v4 `AddressRecord` shape.

Refs: #96 §"Data Sources", §"Per-Country Shard Contents", §"Shard-Agnostic Augmentation"