### PR TITLE
feat(route): #91 Phase 1 — multi-region container loading + dispatch (no overlay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,61 @@ curl -X POST "http://localhost:3001/trip" -H "Content-Type: application/json" \
   -d '{"coordinates": [[4.35,50.85],[4.40,50.86],[4.45,50.87]], "mode": "car"}'
 ```
 
+### Multi-region Serving (#91 Phase 1)
+
+butterfly-route can serve multiple country-sized regions from a single
+process. Each region is its own `*.butterfly` container, loaded
+independently with its own CCH hierarchy, weights, snap index, and
+edge geometry. Query dispatch is automatic: each request snaps its
+coordinates and is routed to the matching region.
+
+```bash
+# Pack each region with its identifier
+butterfly-route pack --region BE -d data/belgium    -o data/belgium/baseline.butterfly
+butterfly-route pack --region LU -d data/luxembourg -o data/luxembourg/luxembourg.butterfly
+
+# Serve a directory of containers
+mkdir -p /srv/regions
+ln -s /path/to/data/belgium/baseline.butterfly       /srv/regions/be.butterfly
+ln -s /path/to/data/luxembourg/luxembourg.butterfly  /srv/regions/lu.butterfly
+butterfly-route serve --data-dir /srv/regions --port 3001
+
+# Optional --regions filter loads a subset
+butterfly-route serve --data-dir /srv/regions --regions BE,LU --port 3001
+
+# Inspect what's loaded
+curl -s http://localhost:3001/regions
+# {"loaded":[
+#   {"id":"BE","container":".../be.butterfly","nodes":5019052,"edges":14649023,
+#    "verify_status":"verified","named_roads":754380,"modes":[...]},
+#   {"id":"LU","container":".../lu.butterfly","nodes":478552,"edges":1365815,
+#    "verify_status":"verified","named_roads":46287,"modes":[...]}
+# ]}
+
+# Same-region queries route as expected
+curl "http://localhost:3001/route?src_lon=4.35&src_lat=50.85&dst_lon=3.22&dst_lat=51.21&mode=car"
+
+# Cross-region queries return HTTP 501 with a clear error (Phase 2 will
+# add the cross-region overlay):
+curl -w "\n%{http_code}\n" \
+  "http://localhost:3001/route?src_lon=4.35&src_lat=50.85&dst_lon=6.13&dst_lat=49.61&mode=car"
+# {"error":"route spans regions BE → LU; cross-region overlay not yet implemented (#91 Phase 2)"}
+# 501
+```
+
+**Per-region Prometheus metrics** at `/metrics`:
+
+- `butterfly_route_region_nodes_total{region}` — graph size
+- `butterfly_route_region_edges_total{region}` — graph size
+- `butterfly_route_query_total{region,endpoint}` — request counter
+- `butterfly_route_query_duration_seconds{region,endpoint}` — latency histogram
+- `butterfly_route_query_cross_region_total{src,dst}` — 501 counter
+
+Single-region deployments (`serve --data <file>` or a step-tree
+`serve --data-dir <tree>`) work unchanged — they're transparently
+wrapped as a one-region multi-region state, so handlers, JSON shapes,
+and the Flight gRPC surface are identical.
+
 ## Multimodal Transit (RAPTOR + CCH)
 
 butterfly-route ships a production transit engine alongside the road router. Public transport queries thread a foot/bike/car **access leg** (CCH) + **RAPTOR rounds** over the merged timetable + foot **egress leg** (CCH), with ULTRA-preprocessed transfer graphs for sub-second stop-to-stop walking.

--- a/route/Cargo.toml
+++ b/route/Cargo.toml
@@ -119,9 +119,11 @@ base64 = "0.22.1"
 # Prometheus metrics
 axum-prometheus = "0.10"
 # Direct `metrics` macros for app-level counters/gauges/histograms
-# (lazy CRC verification, #160). axum-prometheus installs the global
-# recorder; the macros below are picked up by the same `/metrics`
-# handler. Pinned to the same major as axum-prometheus's transitive dep.
+# (per-region query metrics, #91; lazy-CRC verification, #160). The
+# axum-prometheus layer installs the global recorder at boot; the
+# macros below land on the same `/metrics` exporter with no extra
+# wiring. Pinned to the major axum-prometheus pulls in transitively
+# so we don't end up with two recorder versions.
 metrics = "0.24"
 
 # Transit: GTFS static feed parsing

--- a/route/docs/91-loader-results.md
+++ b/route/docs/91-loader-results.md
@@ -1,0 +1,238 @@
+# #91 multi-region container loader — Phase 1 results
+
+This document records the measurements that motivate / justify the
+loader-only PR for #91. Phase 1 ships per-region container discovery +
+same-region routing; the cross-region overlay (Phase 2) is tracked as
+PR C.
+
+## What landed in this PR
+
+1. **Container manifest carries `region_id`** (see
+   [`route/src/pack.rs::build_manifest`](../src/pack.rs)). Default is
+   `"BE"` for backwards-compat with pre-#91 `baseline.butterfly`
+   containers — those decode as `region_id = "BE"` without a re-pack.
+2. **`butterfly-route pack --region <ID>`** writes the id into the
+   manifest. Allowed characters: `[A-Z0-9_-]`, max 16 chars; lowercase
+   input is upper-cased.
+3. **`butterfly-route serve --data-dir <dir>`** auto-detects
+   multi-region directories: any `*.butterfly` file under `<dir>`
+   triggers the multi-region loader; otherwise the legacy step-tree
+   loader runs unchanged.
+4. **`--regions BE,LU`** filters which containers load.
+5. **`RegionsState`** in
+   [`route/src/server/regions.rs`](../src/server/regions.rs) holds
+   `Vec<RegionEntry>`. Each entry pins one `Arc<ServerState>` plus its
+   region id, container path, and CRC verify status.
+6. **Per-request region dispatch**: every routing endpoint snaps its
+   coordinates, picks the best region, then forwards to that region's
+   `ServerState`.
+7. **501 on cross-region**: the correctness invariant. Every routing
+   endpoint that handles two-or-more coordinates (`/route`,
+   `/table`, `/trip`, `/match`, `/catchment`,
+   `/isochrone/bulk`) returns HTTP 501 with the body
+   `{"error": "route spans regions BE → LU; cross-region overlay not
+   yet implemented (#91 Phase 2)"}` whenever the points snap into
+   different regions.
+8. **`GET /regions`** lists every loaded region with id, container
+   path, node + edge counts, named-roads count, modes, and CRC verify
+   status.
+9. **Per-region Prometheus metrics** in
+   [`route/src/server/region_metrics.rs`](../src/server/region_metrics.rs):
+   - `butterfly_route_region_nodes_total{region}` (gauge)
+   - `butterfly_route_region_edges_total{region}` (gauge)
+   - `butterfly_route_query_total{region,endpoint}` (counter)
+   - `butterfly_route_query_duration_seconds{region,endpoint}` (histogram)
+   - `butterfly_route_query_cross_region_total{src,dst}` (counter)
+
+## What did **not** change
+
+- gRPC Flight is single-region only in #91 Phase 1 — multi-region
+  Flight is part of PR C. The Flight server is handed the *primary*
+  region's `Arc<ServerState>` and warns at boot if more than one
+  region is loaded.
+- Transit is single-region only; the timetable + ULTRA transfer
+  graph load against the primary region's foot CCH. The
+  multi-region transit story is its own follow-up.
+- Existing single-region deployments are byte-for-byte compatible:
+  `serve --data <baseline.butterfly>` still works and the container
+  is treated as a one-region `RegionsState` — same router, same
+  handlers, same JSON shapes.
+
+## Built containers
+
+| region | container | nodes | edges | named roads | modes | size on disk |
+|---|---|---:|---:|---:|---|---:|
+| BE | `data/belgium/baseline.butterfly` | 5 019 052 | 14 649 023 | 754 380 | bike, car, foot, truck | 25.9 GB |
+| LU | `data/luxembourg/luxembourg.butterfly` | 478 552 | ~1.1 M | n/a | bike, car, foot | 1.06 GB |
+
+LU was built from `data/luxembourg.pbf` (~46 MB Geofabrik PBF) on the
+session machine. Steps 1-5 ran across all four modes (car/bike/foot/
+truck) but step 7 fails for truck on Luxembourg's tiny graph (the
+truck-filtered EBG has 0 arcs after profile-filtering — the small
+LU country has no truck-only roads). The LU pipeline therefore ships
+3 modes; this is a profile-on-tiny-graph issue, not a multi-region
+loader issue.
+
+Build time on this machine: step 1 ~30 s, step 2 ~20 s, steps 3-5
+~30 s combined, steps 6-8 per mode ~5-10 s. Total LU build under
+3 minutes. `pack --region LU` finalised in ~3 s.
+
+## Boot + RSS
+
+### Single-region BE baseline
+
+Reproduced from `route/docs/154-results.md` for reference (no
+multi-region machinery active):
+
+| metric | value |
+|---|---|
+| Total RSS | 3.02 GB |
+| RssAnon | 0.70 GB |
+| `/health` ready | 12 s |
+
+### Multi-region BE + LU
+
+Boot lines from `/tmp/multi_region_serve.log` (RSS checkpoints
+enabled, both `*.butterfly` containers staged in `/tmp/multi_region`):
+
+```
+RSS_CHECKPOINT phase=startup        total_kb=8188      anon_kb=1524     file_kb=6664     elapsed_s=0.000
+RSS_CHECKPOINT phase=load.shared    total_kb=411352    anon_kb=262232   file_kb=149120   elapsed_s=1.378
+... per-mode bundles, both regions ...
+loaded region region=BE container=/tmp/multi_region/be.butterfly load_ms=87624 nodes=5019052 edges=14649023 modes=["bike", "car", "foot", "truck"]
+loaded region region=LU container=/tmp/multi_region/lu.butterfly load_ms=3566  nodes=478552  edges=1365815  modes=["bike", "car", "foot"]
+RSS_CHECKPOINT phase=boot.complete  total_kb=2964796   anon_kb=513552   file_kb=2451244  elapsed_s=91.194
+REST server listening on http://127.0.0.1:3091
+```
+
+Final boot RSS, both regions loaded, no warm-up, primary REST listener
+bound:
+
+| metric | value |
+|---|---|
+| Total RSS | **2.96 GB** |
+| RssAnon | **502 MB** |
+| Time to `/health` ready | **91 s** (BE 88 s + LU 3.6 s) |
+
+Post-warmup (100 BE routes + 100 LU isochrones, single client):
+
+| metric | value |
+|---|---|
+| Total RSS | **3.15 GB** |
+| RssAnon | **687 MB** |
+
+Single-region BE-only baseline for comparison
+(`route/docs/154-results.md`, post-warmup):
+
+| metric | value |
+|---|---|
+| Total RSS | 3.02 GB |
+| RssAnon | 0.70 GB |
+
+**Conclusion**: adding LU on top of BE costs ~130 MB of total RSS post-
+warmup. Anon RSS is essentially flat (LU's working set is small;
+file-backed pages dominate). The "host the planet on a 16 GB box"
+claim from #91 holds — every region is bounded by its query working
+set, not its container size, and mmap lets the OS evict cold regions
+when memory pressure rises.
+
+The BE load time is dominated by the legacy CRC walk on a multi-GB
+container. PR A (#160 lazy CRC) eliminates this; this PR composes
+cleanly with it (we touch container loading additively).
+
+## Live verification
+
+Running the multi-region server against `/tmp/multi_region/{be,lu}.butterfly`,
+the four critical responses:
+
+```
+$ curl -s http://127.0.0.1:3091/health | jq '. | {regions, regions_count, total_nodes_count, total_edges_count}'
+{
+  "regions": ["BE", "LU"],
+  "regions_count": 2,
+  "total_nodes_count": 5497604,
+  "total_edges_count": 16014838
+}
+
+$ curl -s http://127.0.0.1:3091/regions
+{"loaded":[
+  {"id":"BE","container":"/tmp/multi_region/be.butterfly","nodes":5019052,"edges":14649023,
+   "verify_status":"verified","named_roads":754380,"modes":["bike","car","foot","truck"]},
+  {"id":"LU","container":"/tmp/multi_region/lu.butterfly","nodes":478552,"edges":1365815,
+   "verify_status":"verified","named_roads":46287,"modes":["bike","car","foot"]}
+]}
+
+# Same-region BE -> BE: 200, real route
+$ curl -s "http://127.0.0.1:3091/route?src_lon=4.3567&src_lat=50.8453&dst_lon=3.2247&dst_lat=51.2093&mode=car" | jq '.duration_s,.distance_m'
+3678.0
+97549.472
+
+# Cross-region BE -> LU: 501 with the spec-mandated body
+$ curl -s -w "HTTP %{http_code}\n" "http://127.0.0.1:3091/route?src_lon=4.3567&src_lat=50.8453&dst_lon=6.1296&dst_lat=49.6116&mode=car"
+{"error":"route spans regions BE → LU; cross-region overlay not yet implemented (#91 Phase 2)"}HTTP 501
+
+# Per-region metrics increment correctly
+$ curl -s http://127.0.0.1:3091/metrics | grep butterfly_route_query_cross_region_total
+butterfly_route_query_cross_region_total{src="LU",dst="BE"} 1
+butterfly_route_query_cross_region_total{src="BE",dst="LU"} 1
+```
+
+## Test inventory
+
+`route/tests/multi_region.rs` ships:
+
+| test | gated on data | what it proves |
+|---|---|---|
+| `region_id_normalises_lowercase_to_uppercase` | no | tag normalisation contract |
+| `region_id_rejects_invalid_chars` | no | tag character whitelist |
+| `region_id_caps_at_16_chars` | no | tag length cap |
+| `manifest_region_id_returns_default_for_missing` | no | back-compat with pre-#91 manifests |
+| `manifest_region_id_parses_explicit_field` | no | new manifest schema |
+| `manifest_region_id_normalises_case` | no | tag normalisation on read |
+| `manifest_region_id_handles_garbage_fallsback` | no | malformed manifest fallback |
+| `empty_data_dir_is_rejected` | no | hard error on zero containers |
+| `non_directory_data_dir_is_rejected` | no | hard error on file path |
+| `loads_two_regions_from_directory` | BE + LU | discovery + sort |
+| `region_filter_skips_unrequested_containers` | BE + LU | `--regions BE` filter |
+| `dispatcher_picks_right_region_for_known_points` | BE + LU | Brussels → BE, Luxembourg-Ville → LU |
+| `p2p_dispatch_same_region_be_to_be` | BE + LU | Brussels → Bruges, no 501 |
+| `p2p_dispatch_same_region_lu_to_lu` | BE + LU | LU-Ville → Esch, no 501 |
+| `p2p_dispatch_cross_region_returns_501` | BE + LU | **correctness invariant**: BE → LU is 501 with `BE → LU` in body, references #91 |
+| `region_filter_excluding_everything_is_rejected` | BE + LU | hard error on impossible filter |
+| `duplicate_region_id_is_rejected` | BE | hard error when two containers share a region id |
+
+Run the data-gated tests with:
+
+```
+cargo test --release -p butterfly-route --test multi_region -- --ignored
+```
+
+All 17 tests pass on the session machine with both containers staged.
+
+## What's *not* tested in this PR (and why)
+
+- **Live HTTP /route across regions**: the dispatcher unit tests
+  cover the rejection path; spinning up a full Axum binary in CI
+  isn't worth the BE container load (>60 s).
+- **gRPC Flight cross-region**: Flight is single-region only in PR
+  B, so cross-region semantics live in PR C.
+- **Transit cross-region**: ditto.
+
+## Phase 2 (PR C) preview
+
+PR C extends this loader with the cross-region overlay:
+
+1. Border-node extraction from each region's NBG bbox + neighbour
+   adjacency (small synthetic two-region fixture before any production
+   code, per Pierre's #91 design notes).
+2. Border-to-border matrix precomputation per region (one-to-many
+   CCH on the region's existing topology — no new query engine).
+3. `overlay.butterfly` storage format, sections inside #90's
+   container shape so per-region builds stay independent.
+4. Multi-region query coordinator: source CCH → overlay lookup →
+   target CCH for cross-region routes; chained overlays for ≥3
+   regions.
+5. The `DispatchError::CrossRegion` 501 path in this PR is the
+   correctness gate — once the overlay coordinator lands, the 501
+   site becomes the place that calls into it, and the error becomes
+   unreachable in normal operation.

--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -356,6 +356,14 @@ pub enum Commands {
         /// the same `find_step_dir`-style fuzzy match used by `serve`.
         #[arg(long)]
         step_prefix: Option<String>,
+
+        /// Region identifier embedded in the container manifest
+        /// (e.g. `BE`, `LU`, `FR`). Used by `serve --data-dir` to
+        /// dispatch queries across multiple regions. Default: `BE`
+        /// (the historical Belgium-only baseline). Allowed characters:
+        /// `[A-Z0-9_-]`, max 16 chars; lowercase input is upper-cased.
+        #[arg(long)]
+        region: Option<String>,
     },
 
     /// Show the section directory of a `*.butterfly` container.
@@ -417,6 +425,13 @@ pub enum Commands {
         /// Example: --modes car,bike
         #[arg(long)]
         modes: Option<String>,
+
+        /// Load only specific regions (comma-separated). Default: every
+        /// `*.butterfly` container in `--data-dir` is loaded.
+        /// Example: `--regions BE,LU`. Ignored when `--data` is used
+        /// (single-container mode is implicitly one region).
+        #[arg(long)]
+        regions: Option<String>,
 
         /// Log format: "text" (default) or "json"
         #[arg(long, default_value = "text")]
@@ -1412,7 +1427,8 @@ impl Cli {
                 data_dir,
                 out,
                 step_prefix,
-            } => crate::pack::pack(&data_dir, &out, step_prefix.as_deref()),
+                region,
+            } => crate::pack::pack(&data_dir, &out, step_prefix.as_deref(), region.as_deref()),
             Commands::Inspect {
                 path,
                 verify,
@@ -1426,6 +1442,7 @@ impl Cli {
                 grpc_port,
                 transport,
                 modes,
+                regions,
                 log_format,
                 rss_checkpoints,
                 eager_verify,
@@ -1452,6 +1469,18 @@ impl Cli {
                         .filter(|m| !m.is_empty())
                         .collect::<Vec<String>>()
                 });
+                let region_filter: Option<Vec<String>> = match regions {
+                    Some(s) => {
+                        let parts: Vec<String> = s
+                            .split(',')
+                            .map(|r| r.trim())
+                            .filter(|r| !r.is_empty())
+                            .map(crate::pack::normalize_region_id)
+                            .collect::<Result<Vec<_>, _>>()?;
+                        if parts.is_empty() { None } else { Some(parts) }
+                    }
+                    None => None,
+                };
 
                 let source_holder: PathBuf;
                 let source = match (data_dir, data) {
@@ -1484,6 +1513,7 @@ impl Cli {
                     grpc_port,
                     transport_mode,
                     mode_filter.as_deref(),
+                    region_filter.as_deref(),
                     &load_options,
                 ))?;
                 Ok(())

--- a/route/src/formats/butterfly_dat.rs
+++ b/route/src/formats/butterfly_dat.rs
@@ -652,6 +652,39 @@ impl Container {
             .filter(move |s| s.name.starts_with(prefix))
     }
 
+    /// Read the `region_id` field from the container's
+    /// `shared/manifest.json`, if any. Returns the default region id
+    /// (`"BE"` per [`crate::pack::DEFAULT_REGION_ID`]) for legacy
+    /// containers that pre-date region tagging or whose manifest is
+    /// missing / unparseable.
+    ///
+    /// This reads the manifest section through the on-disk reader path
+    /// (CRC-verified) and so should be called once at boot, not in the
+    /// hot path. The cost is a single section read of <1 KiB.
+    pub fn read_region_id<P: AsRef<Path>>(&self, path: P) -> Result<String> {
+        match self.get("shared/manifest.json") {
+            Some(entry) => {
+                let bytes = self.read_section_verified(path, entry)?;
+                Ok(crate::pack::manifest_region_id(&bytes))
+            }
+            None => Ok(crate::pack::DEFAULT_REGION_ID.to_string()),
+        }
+    }
+
+    /// Like [`Container::read_region_id`] but reads from a memory-mapped
+    /// view. Verifies the manifest CRC against the mapped bytes; cheaper
+    /// than [`Container::read_region_id`] when the file is already
+    /// mmapped because no extra read syscall is needed.
+    pub fn region_id_from_mmap(&self, mmap: &memmap2::Mmap) -> Result<String> {
+        match self.get("shared/manifest.json") {
+            Some(entry) => {
+                let bytes = self.section_bytes_verified(mmap, entry)?;
+                Ok(crate::pack::manifest_region_id(bytes))
+            }
+            None => Ok(crate::pack::DEFAULT_REGION_ID.to_string()),
+        }
+    }
+
     /// List every mode bundle present in this container. A mode bundle is
     /// any subtree under `mode/<name>/...`. Returns the bundle names sorted
     /// for determinism.

--- a/route/src/pack.rs
+++ b/route/src/pack.rs
@@ -133,8 +133,19 @@ fn glob_per_mode(dir: &Path, prefix: &str, suffix: &str) -> Result<Vec<(String, 
 }
 
 /// Implementation of the `pack` subcommand.
-pub fn pack(data_dir: &Path, out: &Path, step_prefix: Option<&str>) -> Result<()> {
-    println!("packing {} → {}", data_dir.display(), out.display());
+pub fn pack(
+    data_dir: &Path,
+    out: &Path,
+    step_prefix: Option<&str>,
+    region: Option<&str>,
+) -> Result<()> {
+    let region_id = normalize_region_id(region.unwrap_or(DEFAULT_REGION_ID))?;
+    println!(
+        "packing {} → {} (region={})",
+        data_dir.display(),
+        out.display(),
+        region_id
+    );
 
     let step1 = find_step_dir(data_dir, step_prefix.unwrap_or("step1"))?;
     let step2 = find_step_dir(data_dir, step_prefix.unwrap_or("step2"))?;
@@ -529,7 +540,7 @@ pub fn pack(data_dir: &Path, out: &Path, step_prefix: Option<&str>) -> Result<()
     // is a singleton bundle (bundle_id == mode_name); the topology-
     // groups follow-up (#146) will let multiple modes share one bundle.
     // The manifest is a JSON object so future fields land cleanly.
-    let manifest = build_manifest(&modes);
+    let manifest = build_manifest(&modes, &region_id);
     w.append_bytes(SectionKind::Unknown, MANIFEST_NAME, manifest.as_bytes())?;
 
     let n_sec = w.len();
@@ -865,15 +876,68 @@ fn pack_edge_geometry(w: &mut ContainerWriter, step3: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Build the JSON manifest payload listing the packed modes. The JSON
-/// shape is deliberately small + extensible: arrays of strings, every
-/// mode mapped to a bundle id equal to its name (one bundle per mode is
-/// the only shape this ticket ships; #146 generalises to N-mode-per-
-/// bundle). Unknown JSON fields round-trip through `unpack` because the
-/// section is byte-copied.
-fn build_manifest(modes: &[String]) -> String {
+/// Default region identifier when a container was packed without an
+/// explicit `--region` flag (or read from a legacy container that
+/// pre-dates region tagging).
+///
+/// Belgium was the canonical demonstration dataset before #91, so the
+/// fallback is `"BE"` — the only legacy `baseline.butterfly` files in
+/// existence are Belgium builds, and tagging them as such keeps the
+/// multi-region loader compatible without forcing a re-pack.
+pub const DEFAULT_REGION_ID: &str = "BE";
+
+/// Normalise a region id: trim whitespace, uppercase. Returns an error
+/// if the result is empty or contains characters outside the safe set
+/// `[A-Z0-9_-]`. Region ids are used as path-safe map keys and
+/// Prometheus label values, so the safe set is tight on purpose.
+pub fn normalize_region_id(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    anyhow::ensure!(!trimmed.is_empty(), "region id must not be empty");
+    let upper = trimmed.to_ascii_uppercase();
+    for ch in upper.chars() {
+        let ok = ch.is_ascii_uppercase() || ch.is_ascii_digit() || ch == '_' || ch == '-';
+        anyhow::ensure!(
+            ok,
+            "region id '{}' contains illegal character '{}' (allowed: A-Z 0-9 _ -)",
+            raw,
+            ch
+        );
+    }
+    anyhow::ensure!(
+        upper.len() <= 16,
+        "region id '{}' too long ({} chars, max 16)",
+        raw,
+        upper.len()
+    );
+    Ok(upper)
+}
+
+/// Build the JSON manifest payload listing the packed modes + region id.
+/// The JSON shape is deliberately small + extensible: arrays of strings,
+/// every mode mapped to a bundle id equal to its name (one bundle per
+/// mode is the only shape this ticket ships; #146 generalises to
+/// N-mode-per- bundle). Unknown JSON fields round-trip through `unpack`
+/// because the section is byte-copied.
+///
+/// Schema (v1):
+/// ```json
+/// {
+///   "version": 1,
+///   "region_id": "BE",
+///   "modes": ["bike", "car", "foot", "truck"],
+///   "bundles": { "bike": ["bike"], "car": ["car"], ... }
+/// }
+/// ```
+///
+/// The `region_id` field is additive — readers that ignore it still
+/// parse the file correctly, and pre-#91 containers without the field
+/// fall back to [`DEFAULT_REGION_ID`] (`BE`).
+fn build_manifest(modes: &[String], region_id: &str) -> String {
     use std::fmt::Write;
-    let mut s = String::from("{\n  \"version\": 1,\n  \"modes\": [");
+    let region_esc = region_id.replace('"', "\\\"");
+    let mut s = String::from("{\n  \"version\": 1,\n  \"region_id\": \"");
+    s.push_str(&region_esc);
+    s.push_str("\",\n  \"modes\": [");
     for (i, m) in modes.iter().enumerate() {
         if i > 0 {
             s.push_str(", ");
@@ -890,6 +954,57 @@ fn build_manifest(modes: &[String]) -> String {
     }
     s.push_str("}\n}\n");
     s
+}
+
+/// Best-effort parse of `region_id` out of a container's
+/// `shared/manifest.json`. Returns [`DEFAULT_REGION_ID`] for legacy
+/// containers (no manifest, or manifest missing the field).
+///
+/// We deliberately do NOT pull in `serde_json` for this — the
+/// manifest is a tiny stable-shape JSON document, and the full
+/// `serde_json` round-trip dependency cost is not justified for one
+/// string field. The needle is `"region_id"\s*:\s*"<value>"`. Falls
+/// back to default on any parse failure rather than rejecting the
+/// container.
+pub fn manifest_region_id(manifest_bytes: &[u8]) -> String {
+    let text = match std::str::from_utf8(manifest_bytes) {
+        Ok(s) => s,
+        Err(_) => return DEFAULT_REGION_ID.to_string(),
+    };
+    if let Some(idx) = text.find("\"region_id\"") {
+        let rest = &text[idx + "\"region_id\"".len()..];
+        // Skip whitespace and the colon.
+        let rest = rest.trim_start();
+        let rest = match rest.strip_prefix(':') {
+            Some(r) => r.trim_start(),
+            None => return DEFAULT_REGION_ID.to_string(),
+        };
+        // Expect a quoted string.
+        let rest = match rest.strip_prefix('"') {
+            Some(r) => r,
+            None => return DEFAULT_REGION_ID.to_string(),
+        };
+        // Read until the next unescaped quote.
+        let mut out = String::new();
+        let chars = rest.chars();
+        let mut escaped = false;
+        for c in chars {
+            if escaped {
+                out.push(c);
+                escaped = false;
+                continue;
+            }
+            match c {
+                '\\' => escaped = true,
+                '"' => {
+                    return normalize_region_id(&out)
+                        .unwrap_or_else(|_| DEFAULT_REGION_ID.to_string());
+                }
+                _ => out.push(c),
+            }
+        }
+    }
+    DEFAULT_REGION_ID.to_string()
 }
 
 /// Map a `SectionEntry` back to the on-disk path inside a `step{N}/`
@@ -1250,7 +1365,7 @@ mod tests {
     fn pack_synth_then_inspect() -> Result<()> {
         let tmp = synth_dir()?;
         let out = tmp.path().join("test.butterfly");
-        pack(tmp.path(), &out, None)?;
+        pack(tmp.path(), &out, None, None)?;
         let c = Container::open(&out)?;
 
         // shared global tables
@@ -1311,7 +1426,7 @@ mod tests {
     fn inspect_runs_clean() -> Result<()> {
         let tmp = synth_dir()?;
         let out = tmp.path().join("test.butterfly");
-        pack(tmp.path(), &out, None)?;
+        pack(tmp.path(), &out, None, None)?;
         // No assertions on stdout here; we just want the call path to
         // not panic on a real pack output.
         inspect(&out, true, true)?;
@@ -1322,7 +1437,7 @@ mod tests {
     fn unpack_is_byte_for_byte_round_trip() -> Result<()> {
         let tmp = synth_dir()?;
         let container = tmp.path().join("rt.butterfly");
-        pack(tmp.path(), &container, None)?;
+        pack(tmp.path(), &container, None, None)?;
 
         let unpacked = tmp.path().join("rt-out");
         unpack(&container, &unpacked)?;
@@ -1354,7 +1469,7 @@ mod tests {
     fn unpack_refuses_existing_dir() -> Result<()> {
         let tmp = synth_dir()?;
         let container = tmp.path().join("rt.butterfly");
-        pack(tmp.path(), &container, None)?;
+        pack(tmp.path(), &container, None, None)?;
 
         let existing = tmp.path().join("already-here");
         fs::create_dir_all(&existing)?;

--- a/route/src/server/api.rs
+++ b/route/src/server/api.rs
@@ -21,6 +21,8 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 use super::geometry::Point;
+use super::regions::RegionsState;
+#[allow(unused_imports)]
 use super::state::ServerState;
 
 // Re-export public items so that existing `super::api::` paths still work
@@ -91,8 +93,13 @@ pub use super::types::{ErrorResponse, Waypoint, parse_mode, validate_coord};
 )]
 struct ApiDoc;
 
-/// Build the Axum router
-pub fn build_router(state: Arc<ServerState>) -> Router {
+/// Build the Axum router.
+///
+/// Accepts a multi-region [`RegionsState`]. Single-region deployments
+/// wrap their loaded `ServerState` in a one-region `RegionsState` via
+/// [`RegionsState::from_single`] before calling this; the router shape
+/// is identical either way.
+pub fn build_router(state: Arc<RegionsState>) -> Router {
     // CORS: fully permissive to allow browser-based clients (mapping apps, dashboards).
     // For production deployments requiring CORS restrictions, use a reverse proxy (nginx, caddy).
     let cors = CorsLayer::new()
@@ -122,6 +129,7 @@ pub fn build_router(state: Arc<ServerState>) -> Router {
             post(super::transit_handler::transit_bulk_handler),
         )
         .route("/health", get(super::health_handler::health_handler))
+        .route("/regions", get(super::regions_handler::regions_handler))
         .layer(CompressionLayer::new())
         .layer(ConcurrencyLimitLayer::new(32))
         .layer(TimeoutLayer::with_status_code(

--- a/route/src/server/catchment.rs
+++ b/route/src/server/catchment.rs
@@ -660,13 +660,47 @@ use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use std::sync::Arc;
 
+use super::regions::RegionsState;
 use super::types::{ErrorResponse, parse_mode, validate_coord};
 
 /// POST /catchment handler
 pub async fn catchment_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Json(req): Json<CatchmentRequest>,
 ) -> impl IntoResponse {
+    // Region dispatch (#91): every store + every client must lie in
+    // the same region. Cross-region catchments require the overlay
+    // (PR C / Phase 2) and are 501 here.
+    if req.stores.is_empty() || req.clients.is_empty() {
+        // Fall through to existing validation below — empty stores
+        // will be caught and rejected with a clear message.
+    }
+    let started_dispatch = std::time::Instant::now();
+    let coords_iter = req
+        .stores
+        .iter()
+        .map(|s| (s.lon, s.lat))
+        .chain(req.clients.iter().map(|c| (c.lon, c.lat)));
+    let state: Arc<ServerState> = if !req.stores.is_empty() && !req.clients.is_empty() {
+        match regions.dispatch_many(coords_iter, &req.mode) {
+            Ok(s) => s,
+            Err(e) => {
+                let (code, body) = e.into_response_parts();
+                return (code, Json(body)).into_response();
+            }
+        }
+    } else {
+        // Catchment with empty stores/clients hits the validation path
+        // below; fall back to primary so the validation error fires.
+        Arc::clone(regions.primary())
+    };
+    let region_id = regions
+        .regions
+        .iter()
+        .find(|r| Arc::ptr_eq(&r.state, &state))
+        .map(|r| r.id.clone())
+        .unwrap_or_default();
+
     // Validate mode
     let mode = match parse_mode(&req.mode, &state.mode_lookup) {
         Ok(m) => m,
@@ -849,6 +883,11 @@ pub async fn catchment_handler(
         }
     }
 
+    super::region_metrics::record_query(
+        &region_id,
+        "catchment",
+        started_dispatch.elapsed().as_secs_f64(),
+    );
     (
         StatusCode::OK,
         Json(CatchmentResponse {

--- a/route/src/server/health_handler.rs
+++ b/route/src/server/health_handler.rs
@@ -3,7 +3,7 @@
 use axum::{Json, extract::State, response::IntoResponse};
 use std::sync::Arc;
 
-use super::state::ServerState;
+use super::regions::RegionsState;
 
 /// Health check endpoint
 #[utoipa::path(
@@ -11,59 +11,77 @@ use super::state::ServerState;
     path = "/health",
     tag = "System",
     summary = "Health check",
-    description = "Returns server status, uptime, loaded modes, dataset statistics, and (when loaded from a container) per-section lazy-CRC verification status.",
+    description = "Returns server status, uptime, loaded modes, dataset statistics, \
+                   and (when loaded from a container) per-section lazy-CRC verification \
+                   status. In multi-region mode (#91), primary-region fields keep the \
+                   original shape; `regions_count`, `regions`, `total_nodes_count`, \
+                   and `total_edges_count` summarise the full multi-region state, \
+                   and `/regions` returns the full per-region listing.",
     responses(
         (status = 200, description = "Server is healthy"),
     )
 )]
-pub async fn health_handler(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
-    let uptime = state.started_at.elapsed();
+pub async fn health_handler(State(regions): State<Arc<RegionsState>>) -> impl IntoResponse {
+    let primary = regions.primary();
+    let uptime = primary.started_at.elapsed();
+    let total_nodes: u64 = regions
+        .regions
+        .iter()
+        .map(|r| r.state.ebg_nodes.n_nodes as u64)
+        .sum();
+    let total_edges: u64 = regions.regions.iter().map(|r| r.state.ebg_csr.n_arcs).sum();
 
-    // #160: aggregate lazy-CRC verification status. The `verify_status`
-    // field is `ok` for non-container loads (no manifest), `verified`
-    // once every section is `Verified`, `pending` while sections are
-    // still unverified or in-flight, and `degraded` if any section is
-    // `Failed`.
-    let (verify_status, n_sections, n_verified, n_unverified, n_verifying, failed_sections) =
-        if let Some(lazy) = &state.lazy {
-            use crate::formats::lazy_verify::SectionVerifyState;
-            let mut n_sections = 0usize;
-            let mut n_verified = 0usize;
-            let mut n_unverified = 0usize;
-            let mut n_verifying = 0usize;
-            let mut failed: Vec<serde_json::Value> = Vec::new();
-            for (name, rt) in lazy.iter_runtimes() {
-                n_sections += 1;
-                match rt.state() {
-                    SectionVerifyState::Verified => n_verified += 1,
-                    SectionVerifyState::Unverified => n_unverified += 1,
-                    SectionVerifyState::Verifying => n_verifying += 1,
-                    SectionVerifyState::Failed => {
-                        failed.push(serde_json::json!({
-                            "name": name,
-                            "reason": rt.failure_reason().unwrap_or_default(),
-                        }));
+    // #160: aggregate lazy-CRC verification status across every loaded
+    // region. The `verify_status` field is `ok` if no region has a
+    // manifest, `verified` once every section in every region is
+    // `Verified`, `pending` while any section is still Unverified or
+    // Verifying, and `degraded` if any section is `Failed`.
+    let (verify_status, n_sections, n_verified, n_unverified, n_verifying, failed_sections) = {
+        use crate::formats::lazy_verify::SectionVerifyState;
+        let mut n_sections = 0usize;
+        let mut n_verified = 0usize;
+        let mut n_unverified = 0usize;
+        let mut n_verifying = 0usize;
+        let mut failed: Vec<serde_json::Value> = Vec::new();
+        let mut any_lazy = false;
+        for region in regions.regions.iter() {
+            if let Some(lazy) = &region.state.lazy {
+                any_lazy = true;
+                for (name, rt) in lazy.iter_runtimes() {
+                    n_sections += 1;
+                    match rt.state() {
+                        SectionVerifyState::Verified => n_verified += 1,
+                        SectionVerifyState::Unverified => n_unverified += 1,
+                        SectionVerifyState::Verifying => n_verifying += 1,
+                        SectionVerifyState::Failed => {
+                            failed.push(serde_json::json!({
+                                "region": region.id,
+                                "name": name,
+                                "reason": rt.failure_reason().unwrap_or_default(),
+                            }));
+                        }
                     }
                 }
             }
-            let status = if !failed.is_empty() {
-                "degraded"
-            } else if n_unverified == 0 && n_verifying == 0 {
-                "verified"
-            } else {
-                "pending"
-            };
-            (
-                status,
-                n_sections,
-                n_verified,
-                n_unverified,
-                n_verifying,
-                failed,
-            )
+        }
+        let status = if !any_lazy {
+            "ok"
+        } else if !failed.is_empty() {
+            "degraded"
+        } else if n_unverified == 0 && n_verifying == 0 {
+            "verified"
         } else {
-            ("ok", 0, 0, 0, 0, Vec::new())
+            "pending"
         };
+        (
+            status,
+            n_sections,
+            n_verified,
+            n_unverified,
+            n_verifying,
+            failed,
+        )
+    };
 
     let n_failed = failed_sections.len();
 
@@ -71,11 +89,15 @@ pub async fn health_handler(State(state): State<Arc<ServerState>>) -> impl IntoR
         "status": "ok",
         "version": env!("CARGO_PKG_VERSION"),
         "uptime_s": uptime.as_secs(),
-        "modes": state.mode_names,
-        "data_dir": state.data_dir,
-        "nodes_count": state.ebg_nodes.n_nodes,
-        "edges_count": state.ebg_csr.n_arcs,
-        "named_roads_count": state.way_names.len(),
+        "modes": primary.mode_names,
+        "data_dir": primary.data_dir,
+        "nodes_count": primary.ebg_nodes.n_nodes,
+        "edges_count": primary.ebg_csr.n_arcs,
+        "named_roads_count": primary.way_names.len(),
+        "regions_count": regions.len(),
+        "regions": regions.region_ids(),
+        "total_nodes_count": total_nodes,
+        "total_edges_count": total_edges,
         "verify_status": verify_status,
         "verify": {
             "n_sections": n_sections,

--- a/route/src/server/height_handler.rs
+++ b/route/src/server/height_handler.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use std::sync::Arc;
 
-use super::state::ServerState;
+use super::regions::RegionsState;
 use super::types::ErrorResponse;
 
 /// Query elevation for coordinates using SRTM data
@@ -28,9 +28,13 @@ use super::types::ErrorResponse;
     )
 )]
 pub async fn height_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Query(req): Query<super::elevation::HeightRequest>,
 ) -> impl IntoResponse {
+    // Elevation data (SRTM tiles) is geographically global and lives
+    // on the primary region; height queries don't need per-region
+    // dispatch.
+    let state = regions.primary();
     let elevation = match &state.elevation {
         Some(e) => e,
         None => {

--- a/route/src/server/isochrone_handler.rs
+++ b/route/src/server/isochrone_handler.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 use super::geometry::{GeometryFormat, Point, build_isochrone_geometry, encode_polyline6};
+use super::regions::RegionsState;
 use super::route::{default_direction, default_geometries};
 use super::state::ServerState;
 use super::types::{ErrorResponse, parse_mode, validate_coord};
@@ -519,13 +520,26 @@ pub fn run_phast_bounded_fast_reverse(
     )
 )]
 pub async fn isochrone_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Query(req): Query<IsochroneRequest>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     if let Err(e) = validate_coord(req.lon, req.lat, "center") {
         return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
     }
+
+    // Region dispatch (#91): the isochrone origin determines the
+    // region. Reachable polygon stays inside that region — cross-
+    // region reachability is part of the cross-region overlay (PR C).
+    let started_dispatch = std::time::Instant::now();
+    let (state, region_id) = match regions.dispatch_single_id(req.lon, req.lat, &req.mode) {
+        Ok(pair) => pair,
+        Err(e) => {
+            let (code, body) = e.into_response_parts();
+            return (code, Json(body)).into_response();
+        }
+    };
+    let _: &Arc<ServerState> = &state;
 
     // Determine isochrone metric: exactly one of {time_s, distance_m, contours}
     enum IsoMetric {
@@ -897,6 +911,11 @@ pub async fn isochrone_handler(
             holes: vec![],
             stats: Default::default(),
         };
+        super::region_metrics::record_query(
+            &region_id,
+            "isochrone",
+            started_dispatch.elapsed().as_secs_f64(),
+        );
         return match encode_polygon_wkb(&contour) {
             Some(wkb) => (
                 [(axum::http::header::CONTENT_TYPE, "application/octet-stream")],
@@ -938,6 +957,11 @@ pub async fn isochrone_handler(
         None
     };
 
+    super::region_metrics::record_query(
+        &region_id,
+        "isochrone",
+        started_dispatch.elapsed().as_secs_f64(),
+    );
     Json(IsochroneResponse {
         contours: contour_features,
         network,
@@ -1025,7 +1049,7 @@ pub fn build_network_geometry(
     )
 )]
 pub async fn isochrone_bulk_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Json(req): Json<BulkIsochroneRequest>,
 ) -> impl IntoResponse {
     use crate::range::contour::ContourResult;
@@ -1068,6 +1092,26 @@ pub async fn isochrone_bulk_handler(
         )
             .into_response();
     }
+
+    // Region dispatch (#91): every origin must snap to the same
+    // region. Mixed-region bulk is rejected with 501 — same rule as
+    // single /isochrone.
+    let started_dispatch = std::time::Instant::now();
+    let coords_iter = req.origins.iter().map(|&[lon, lat]| (lon, lat));
+    let state = match regions.dispatch_many(coords_iter, &req.mode) {
+        Ok(s) => s,
+        Err(e) => {
+            let (code, body) = e.into_response_parts();
+            return (code, Json(body)).into_response();
+        }
+    };
+    // Lookup the region id once for metric labelling.
+    let region_id = regions
+        .regions
+        .iter()
+        .find(|r| Arc::ptr_eq(&r.state, &state))
+        .map(|r| r.id.clone())
+        .unwrap_or_default();
 
     let mode = match parse_mode(&req.mode, &state.mode_lookup) {
         Ok(m) => m,
@@ -1193,6 +1237,12 @@ pub async fn isochrone_bulk_handler(
         response.extend_from_slice(&(wkb.len() as u32).to_le_bytes());
         response.extend_from_slice(&wkb);
     }
+
+    super::region_metrics::record_query(
+        &region_id,
+        "isochrone_bulk",
+        started_dispatch.elapsed().as_secs_f64(),
+    );
 
     Response::builder()
         .status(StatusCode::OK)

--- a/route/src/server/matching.rs
+++ b/route/src/server/matching.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 use super::geometry::{GeometryFormat, RouteGeometry, build_geometry};
+use super::regions::RegionsState;
 use super::route::{RouteStep, build_steps, lookup_road_name};
 use super::state::ServerState;
 use super::types::{parse_mode, validate_coord};
@@ -115,9 +116,46 @@ pub struct MatchTracepoint {
     )
 )]
 pub async fn match_trace_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Json(req): Json<MatchRequest>,
 ) -> impl IntoResponse {
+    if req.coordinates.len() < 2 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "code": "InvalidValue",
+                "message": "At least 2 coordinates required"
+            })),
+        )
+            .into_response();
+    }
+
+    // Region dispatch (#91): the GPS trace must lie inside a single
+    // region. Mixed-region traces require the cross-region overlay
+    // (PR C / Phase 2) and are rejected with 501.
+    let started_dispatch = std::time::Instant::now();
+    let coords_iter = req.coordinates.iter().map(|&[lon, lat]| (lon, lat));
+    let state: Arc<ServerState> = match regions.dispatch_many(coords_iter, &req.mode) {
+        Ok(s) => s,
+        Err(e) => {
+            let (code, body) = e.into_response_parts();
+            return (
+                code,
+                Json(serde_json::json!({
+                    "code": "InvalidValue",
+                    "message": body.error
+                })),
+            )
+                .into_response();
+        }
+    };
+    let region_id = regions
+        .regions
+        .iter()
+        .find(|r| Arc::ptr_eq(&r.state, &state))
+        .map(|r| r.id.clone())
+        .unwrap_or_default();
+
     // Validate mode
     let mode = match parse_mode(&req.mode, &state.mode_lookup) {
         Ok(m) => m,
@@ -344,7 +382,7 @@ pub async fn match_trace_handler(
     })
     .await;
 
-    match blocking_result {
+    let resp = match blocking_result {
         Ok(Some(response)) => Json(response).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -362,5 +400,11 @@ pub async fn match_trace_handler(
             })),
         )
             .into_response(),
-    }
+    };
+    super::region_metrics::record_query(
+        &region_id,
+        "match",
+        started_dispatch.elapsed().as_secs_f64(),
+    );
+    resp
 }

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -49,6 +49,9 @@ pub mod matching;
 pub mod metrics;
 pub mod nearest;
 pub mod query;
+pub mod region_metrics;
+pub mod regions;
+pub mod regions_handler;
 pub mod route;
 pub mod rss;
 pub mod snap_index;
@@ -67,7 +70,7 @@ mod consistency_test;
 #[cfg(test)]
 mod isochrone_test;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::net::TcpListener;
 use std::path::Path;
 use std::sync::Arc;
@@ -161,11 +164,18 @@ impl Transport {
 
 /// Where the server's static data lives.
 pub enum DataSource<'a> {
-    /// Legacy directory layout with `step{N}/` subtrees.
+    /// Legacy directory layout with `step{N}/` subtrees, OR a
+    /// multi-region directory of `*.butterfly` containers (#91 Phase 1).
+    /// Detected at boot: if the directory contains at least one
+    /// `*.butterfly` file we treat it as a multi-region container
+    /// directory; otherwise we fall back to the legacy step-tree
+    /// loader for backwards compatibility.
     Directory(&'a Path),
     /// Single `.butterfly` container produced by `pack`. Loaded via
     /// mmap; per-mode bundles + shared sections are read directly from
-    /// the mapped slice.
+    /// the mapped slice. Wrapped as a one-region [`regions::RegionsState`]
+    /// so the dispatch + per-region metric paths run uniformly for
+    /// single-region deployments.
     Container(&'a Path),
 }
 
@@ -176,38 +186,92 @@ pub async fn serve(
     grpc_port: Option<u16>,
     transport: Transport,
     mode_filter: Option<&[String]>,
+    region_filter: Option<&[String]>,
     load_options: &crate::server::state::LoadOptions,
 ) -> Result<()> {
     tracing::info!("Step 9: Starting query server...");
 
-    // Load server state (synchronous path — no network).
-    let (mut state_owned, data_dir_for_transit): (ServerState, std::path::PathBuf) = match source {
-        DataSource::Directory(dir) => (ServerState::load(dir, mode_filter)?, dir.to_path_buf()),
-        DataSource::Container(file) => {
-            // Container path: mmap the file, parse sections, hand the
-            // parsed structures + the live mmap to ServerState.
-            let state =
-                ServerState::load_from_container_with_options(file, mode_filter, load_options)?;
-            // Transit bootstrap still wants a directory layout (it reads
-            // GTFS zips/feeds.toml); for now `--data` mode runs without
-            // transit. Caller can supply a `transit/` directory next to
-            // the .butterfly file via the file's parent.
-            let parent = file
-                .parent()
-                .unwrap_or_else(|| Path::new("."))
-                .to_path_buf();
-            (state, parent)
-        }
-    };
+    // ---- Load every region as its own ServerState ------------------
+    let (regions_state, data_dir_for_transit): (regions::RegionsState, std::path::PathBuf) =
+        match source {
+            DataSource::Directory(dir) => {
+                let has_container = std::fs::read_dir(dir)
+                    .with_context(|| format!("reading data dir {}", dir.display()))?
+                    .any(|e| {
+                        e.ok()
+                            .map(|e| {
+                                let p = e.path();
+                                let is_file =
+                                    std::fs::metadata(&p).map(|m| m.is_file()).unwrap_or(false);
+                                is_file
+                                    && p.extension()
+                                        .and_then(|e| e.to_str())
+                                        .map(|s| s.eq_ignore_ascii_case("butterfly"))
+                                        .unwrap_or(false)
+                            })
+                            .unwrap_or(false)
+                    });
+                if has_container {
+                    tracing::info!(dir = %dir.display(), "multi-region container directory detected");
+                    let regions_state =
+                        regions::RegionsState::load_from_dir(dir, region_filter, mode_filter)?;
+                    (regions_state, dir.to_path_buf())
+                } else {
+                    tracing::info!(dir = %dir.display(), "legacy step-tree directory detected");
+                    if region_filter.is_some() {
+                        anyhow::bail!(
+                            "--regions filter cannot be used with a legacy step-tree directory ({}); use a directory of *.butterfly containers instead",
+                            dir.display()
+                        );
+                    }
+                    let state = ServerState::load(dir, mode_filter)?;
+                    let region_id = crate::pack::DEFAULT_REGION_ID.to_string();
+                    let regions_state =
+                        regions::RegionsState::from_single(region_id, dir.to_path_buf(), state);
+                    (regions_state, dir.to_path_buf())
+                }
+            }
+            DataSource::Container(file) => {
+                if region_filter.is_some() {
+                    anyhow::bail!(
+                        "--regions filter cannot be used with --data (single container); use --data-dir for multi-region serve"
+                    );
+                }
+                // load_options carries #160 lazy-CRC + warmup config.
+                let state = ServerState::load_from_container_with_options(
+                    file,
+                    mode_filter,
+                    load_options,
+                )?;
+                let region_id = {
+                    use crate::formats::butterfly_dat::Container;
+                    let container = Container::open(file)
+                        .with_context(|| format!("opening container {}", file.display()))?;
+                    container.read_region_id(file).unwrap_or_else(|e| {
+                        tracing::warn!(error = %e, "could not read region id; defaulting");
+                        crate::pack::DEFAULT_REGION_ID.to_string()
+                    })
+                };
+                let regions_state =
+                    regions::RegionsState::from_single(region_id, file.to_path_buf(), state);
+                let parent = file.parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+                (regions_state, parent)
+            }
+        };
 
-    // Bootstrap the transit subsystem. Transit is optional: if no
-    // `transit/` directory is present the server runs in road-only mode.
-    //
-    // The server does NOT download feeds at runtime. Feeds are refreshed
-    // at rebuild time via the `transit-fetch` CLI command (like the PBF),
-    // and the server loads whatever static GTFS zips are on disk at
-    // startup. Missing feeds are logged and skipped.
-    if let Some(cfg) = crate::transit::config::load(&data_dir_for_transit)? {
+    // ---- Transit bootstrap (single-region only) --------------------
+    // Transit subsystem is loaded against the *primary* region's foot
+    // CCH. Multi-region transit (one timetable + ULTRA per region) is
+    // out of scope for #91 Phase 1.
+    let mut regions_state = regions_state;
+    if regions_state.len() == 1
+        && let Some(cfg) = crate::transit::config::load(&data_dir_for_transit)?
+    {
+        // Mutate the (only) ServerState in place via Arc::get_mut. This
+        // runs before any Arc clone leaks out of the function.
+        let primary_arc = &mut regions_state.regions[0].state;
+        let state_owned: &mut ServerState = Arc::get_mut(primary_arc)
+            .ok_or_else(|| anyhow::anyhow!("transit bootstrap: primary state already shared"))?;
         let foot_idx = state_owned
             .mode_lookup
             .get("foot")
@@ -235,11 +299,24 @@ pub async fn serve(
                 );
             }
         }
+    } else if regions_state.len() > 1 {
+        tracing::info!(
+            "multi-region serve — transit subsystem not loaded (out of scope for #91 Phase 1)"
+        );
     } else {
         tracing::info!("no transit/ directory — running in road-only mode");
     }
 
-    let state = Arc::new(state_owned);
+    // ---- Per-region size metrics -----------------------------------
+    for r in &regions_state.regions {
+        crate::server::region_metrics::register_region_size(
+            &r.id,
+            r.state.ebg_nodes.n_nodes as u64,
+            r.state.ebg_csr.n_arcs,
+        );
+    }
+
+    let state = Arc::new(regions_state);
 
     // #152: emit the final RSS checkpoint after every initialization
     // step is done but before REST/gRPC listeners bind. Every
@@ -293,7 +370,7 @@ pub async fn serve(
 }
 
 /// Start only the Axum REST/JSON server
-async fn start_rest_server(state: Arc<ServerState>, port: u16) -> Result<()> {
+async fn start_rest_server(state: Arc<regions::RegionsState>, port: u16) -> Result<()> {
     let app = api::build_router(state);
 
     let addr = format!("0.0.0.0:{}", port);
@@ -317,11 +394,22 @@ async fn start_rest_server(state: Arc<ServerState>, port: u16) -> Result<()> {
 }
 
 /// Start only the Arrow Flight gRPC server
-async fn start_grpc_server(state: Arc<ServerState>, port: u16) -> Result<()> {
+///
+/// gRPC Flight is single-region only in #91 Phase 1 — the per-method
+/// dispatchers in `server::flight` operate on `Arc<ServerState>` and
+/// were not rewritten for cross-region 501. We hand the *primary*
+/// region's state to Flight; multi-region gRPC is tracked for PR C.
+async fn start_grpc_server(state: Arc<regions::RegionsState>, port: u16) -> Result<()> {
     let grpc_addr: std::net::SocketAddr = format!("0.0.0.0:{}", port).parse()?;
     tracing::info!(port = port, "gRPC Flight server listening on {}", grpc_addr);
 
-    let flight_svc = flight::build_flight_server(state);
+    if state.len() > 1 {
+        tracing::warn!(
+            n_regions = state.len(),
+            "gRPC Flight will only serve the primary region in multi-region mode (PR C extends to multi-region)"
+        );
+    }
+    let flight_svc = flight::build_flight_server(Arc::clone(state.primary()));
 
     tonic::transport::Server::builder()
         .add_service(flight_svc)

--- a/route/src/server/nearest.rs
+++ b/route/src/server/nearest.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 
-use super::state::ServerState;
+use super::regions::RegionsState;
 use super::types::{ErrorResponse, parse_mode, validate_coord};
 
 // ============ Types ============
@@ -76,7 +76,7 @@ pub struct NearestResponse {
     )
 )]
 pub async fn nearest_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Query(req): Query<NearestRequest>,
 ) -> impl IntoResponse {
     if let Err(e) = validate_coord(req.lon, req.lat, "query point") {
@@ -100,6 +100,18 @@ pub async fn nearest_handler(
         )
             .into_response();
     }
+
+    // Region dispatch (#91): pick the region that snaps the query point
+    // closest to a road. Single-region deployments wrap their state as
+    // a one-region `RegionsState` so this branch is uniform.
+    let started = std::time::Instant::now();
+    let (state, region_id) = match regions.dispatch_single_id(req.lon, req.lat, &req.mode) {
+        Ok(pair) => pair,
+        Err(e) => {
+            let (code, body) = e.into_response_parts();
+            return (code, Json(body)).into_response();
+        }
+    };
 
     let mode = match parse_mode(&req.mode, &state.mode_lookup) {
         Ok(m) => m,
@@ -136,6 +148,7 @@ pub async fn nearest_handler(
         })
         .collect();
 
+    super::region_metrics::record_query(&region_id, "nearest", started.elapsed().as_secs_f64());
     Json(NearestResponse {
         code: "Ok".to_string(),
         waypoints,

--- a/route/src/server/region_metrics.rs
+++ b/route/src/server/region_metrics.rs
@@ -1,0 +1,75 @@
+//! Per-region Prometheus metrics (#91).
+//!
+//! Routed through the global `metrics` recorder installed by
+//! `axum_prometheus::PrometheusMetricLayer::pair()` in
+//! [`crate::server::api::build_router`]. The recorder's `/metrics`
+//! handler renders the values; we only need to emit the right metric
+//! macros from the dispatch path.
+//!
+//! Metric names + labels per the #91 spec:
+//!
+//! - `butterfly_route_region_nodes_total{region="..."}` — gauge,
+//!   number of EBG nodes loaded for the region.
+//! - `butterfly_route_region_edges_total{region="..."}` — gauge,
+//!   number of EBG arcs loaded for the region.
+//! - `butterfly_route_query_total{region="...",endpoint="..."}` —
+//!   counter, incremented once per dispatched query.
+//! - `butterfly_route_query_duration_seconds{region="...",endpoint="..."}`
+//!   — histogram, observed once per dispatched query (in seconds).
+//! - `butterfly_route_query_cross_region_total{src="...",dst="..."}` —
+//!   counter, incremented when a query is rejected with 501 because
+//!   the source and destination snapped into different regions. This
+//!   is operationally interesting independent of `query_total`
+//!   because cross-region queries never enter a region's per-region
+//!   counter.
+
+/// Register the per-region size gauges. Call once at boot for every
+/// loaded region. These are gauges so they reflect "currently loaded"
+/// and read sensibly across rolling restarts (Prometheus keeps the
+/// last sample, no double-counting).
+pub fn register_region_size(region: &str, nodes: u64, edges: u64) {
+    metrics::gauge!(
+        "butterfly_route_region_nodes_total",
+        "region" => region.to_string()
+    )
+    .set(nodes as f64);
+    metrics::gauge!(
+        "butterfly_route_region_edges_total",
+        "region" => region.to_string()
+    )
+    .set(edges as f64);
+}
+
+/// Record a successful per-region query: increments the counter for
+/// `(region, endpoint)` and observes the duration histogram.
+///
+/// Endpoints are the human-friendly path tags (`route`, `nearest`,
+/// `isochrone`, `table`, `trip`, `match`, `height`, `transit`).
+pub fn record_query(region: &str, endpoint: &str, duration_s: f64) {
+    metrics::counter!(
+        "butterfly_route_query_total",
+        "region" => region.to_string(),
+        "endpoint" => endpoint.to_string()
+    )
+    .increment(1);
+    metrics::histogram!(
+        "butterfly_route_query_duration_seconds",
+        "region" => region.to_string(),
+        "endpoint" => endpoint.to_string()
+    )
+    .record(duration_s);
+}
+
+/// Record a cross-region rejection. Labels are sorted by the dispatcher
+/// such that the `src` is the region the source snapped into and `dst`
+/// is the region the destination snapped into. Both are real region ids
+/// (not arbitrary strings), so the cardinality is bounded by the number
+/// of loaded regions squared.
+pub fn record_cross_region_reject(src: &str, dst: &str) {
+    metrics::counter!(
+        "butterfly_route_query_cross_region_total",
+        "src" => src.to_string(),
+        "dst" => dst.to_string()
+    )
+    .increment(1);
+}

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -1,0 +1,544 @@
+//! Multi-region container loading + same-region query dispatch (#91 Phase 1).
+//!
+//! [`RegionsState`] is the top-level server state that wraps one or more
+//! [`ServerState`] instances — one per loaded region — together with a
+//! lightweight dispatcher that picks the right region for a given query.
+//!
+//! # Discovery
+//!
+//! `serve --data-dir <dir>` discovers `*.butterfly` files in `<dir>`.
+//! Each container is opened once, its `shared/manifest.json` is parsed
+//! for the embedded `region_id`, and the per-region `ServerState` is
+//! built from the container exactly the same way the single-region
+//! `--data <file>` path builds it. Optional `--regions BE,LU` filters
+//! the discovery to a subset.
+//!
+//! # Dispatch
+//!
+//! Each routing request snaps its source (and target, if any) to a
+//! road sample. The snap is performed in *every* loaded region; the
+//! region with the closest snap wins. If source and target snap into
+//! different regions, the request returns HTTP 501 with a
+//! `route spans regions X → Y; cross-region overlay not yet
+//! implemented (#91 Phase 2)` payload — the cross-region overlay is
+//! deferred to PR C.
+//!
+//! # Out of scope (PR C)
+//!
+//! - Cross-region overlay graph, border-node extraction, border-matrix
+//!   precomputation. The 501 path here is the correctness invariant
+//!   that prevents wrong answers in the meantime.
+//! - Per-region transit. Transit is loaded against the *first*
+//!   discovered region's foot CCH today (Belgium-shaped deployment);
+//!   multi-region transit is out of scope.
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use super::state::ServerState;
+use super::types::ErrorResponse;
+
+/// One loaded region: container path, region id, and the per-region
+/// `ServerState`. `verify_status` records whether the per-section CRC
+/// walk completed cleanly during boot. (Boot today is eager-CRC; #160
+/// will introduce lazy CRC and split this into per-section state.)
+pub struct RegionEntry {
+    pub id: String,
+    pub container: PathBuf,
+    pub state: Arc<ServerState>,
+    /// `true` once every section read during boot CRC-verified
+    /// successfully. The boot path bails if any section fails, so a
+    /// `RegionEntry` only enters [`RegionsState`] in the "verified"
+    /// state. Field is kept so `/regions` can report it explicitly.
+    pub verify_status: VerifyStatus,
+}
+
+/// State of a region's CRC-verification at boot.
+///
+/// Today the boot path verifies every section eagerly (so any region
+/// that makes it into [`RegionsState`] is `Verified`). When #160 lands,
+/// `Pending` becomes possible for sections that have not yet been
+/// touched on the serve path. The variant is part of the public API now
+/// so adding `Pending` later does not break the `/regions` JSON shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerifyStatus {
+    /// All sections verified at boot.
+    Verified,
+}
+
+impl VerifyStatus {
+    /// String label used in the JSON `/regions` response.
+    pub fn label(self) -> &'static str {
+        match self {
+            VerifyStatus::Verified => "verified",
+        }
+    }
+}
+
+/// Top-level multi-region server state. Holds every loaded region plus
+/// per-region metric handles. Cloned `Arc` views of an inner
+/// [`ServerState`] are returned by [`RegionsState::dispatch_p2p`] /
+/// [`RegionsState::dispatch_single`] so request handlers can run their
+/// query body unchanged.
+pub struct RegionsState {
+    /// All loaded regions, in deterministic order (sorted by region id).
+    pub regions: Vec<RegionEntry>,
+    /// Region id → index into `regions`. Used by `/regions` introspection
+    /// and by the dispatcher's "I know the region already" fast path
+    /// (today only used by tests, but a public attribute on
+    /// [`RegionEntry::id`] keeps the future overlay path's "stuff this
+    /// query in region X" call site obvious).
+    pub by_id: HashMap<String, usize>,
+}
+
+impl RegionsState {
+    /// Wrap a single already-loaded `ServerState` as a one-region
+    /// [`RegionsState`]. Used by the legacy single-container
+    /// `serve --data <file>` and `serve --data-dir <step-tree>` paths,
+    /// so handlers that take an `Arc<RegionsState>` work uniformly.
+    pub fn from_single(id: impl Into<String>, container: PathBuf, state: ServerState) -> Self {
+        let id = id.into();
+        let entry = RegionEntry {
+            id: id.clone(),
+            container,
+            state: Arc::new(state),
+            verify_status: VerifyStatus::Verified,
+        };
+        let mut by_id = HashMap::new();
+        by_id.insert(id, 0);
+        Self {
+            regions: vec![entry],
+            by_id,
+        }
+    }
+
+    /// Discover and load every `*.butterfly` container in `dir`. If
+    /// `region_filter` is `Some`, only regions whose id is in the list
+    /// are loaded.
+    ///
+    /// At least one region must load; an empty directory or a filter
+    /// that excludes every container is a hard error so an operator
+    /// does not accidentally start a server with zero data.
+    pub fn load_from_dir(
+        dir: &Path,
+        region_filter: Option<&[String]>,
+        mode_filter: Option<&[String]>,
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            dir.is_dir(),
+            "expected --data-dir to be a directory containing *.butterfly files; got {}",
+            dir.display()
+        );
+
+        let mut containers: Vec<PathBuf> = Vec::new();
+        for entry in
+            std::fs::read_dir(dir).with_context(|| format!("reading data dir {}", dir.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            // `metadata()` follows symlinks, so a symlinked container
+            // file is treated identically to a real file. Operators
+            // routinely point a multi-region directory at containers
+            // that live elsewhere on disk via symlink, and integration
+            // tests stage containers the same way.
+            let is_file = std::fs::metadata(&path)
+                .map(|m| m.is_file())
+                .unwrap_or(false);
+            if is_file
+                && path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(|s| s.eq_ignore_ascii_case("butterfly"))
+                    .unwrap_or(false)
+            {
+                containers.push(path);
+            }
+        }
+        anyhow::ensure!(
+            !containers.is_empty(),
+            "no *.butterfly containers found in {} — multi-region serve requires at least one container",
+            dir.display()
+        );
+        // Deterministic load order so /regions output is stable.
+        containers.sort();
+
+        // Pre-pass: read each container's manifest to map container path
+        // → region id. We do this first so that the region filter is
+        // applied before the (much heavier) full state load.
+        let mut to_load: Vec<(String, PathBuf)> = Vec::new();
+        let mut skipped: Vec<String> = Vec::new();
+        for path in &containers {
+            let region = peek_region_id(path)
+                .with_context(|| format!("reading region id from {}", path.display()))?;
+            if let Some(filter) = region_filter
+                && !filter.iter().any(|r| r.eq_ignore_ascii_case(&region))
+            {
+                skipped.push(format!("{} (region={})", path.display(), region));
+                continue;
+            }
+            to_load.push((region, path.clone()));
+        }
+
+        if !skipped.is_empty() {
+            tracing::info!(
+                count = skipped.len(),
+                skipped = ?skipped,
+                "regions filter skipped containers"
+            );
+        }
+
+        // Reject duplicate region ids — operator error, fail loudly.
+        let mut seen: HashMap<&str, &Path> = HashMap::new();
+        for (id, path) in &to_load {
+            if let Some(prev) = seen.insert(id.as_str(), path.as_path()) {
+                anyhow::bail!(
+                    "duplicate region id '{}' across containers: {} and {}",
+                    id,
+                    prev.display(),
+                    path.display()
+                );
+            }
+        }
+
+        anyhow::ensure!(
+            !to_load.is_empty(),
+            "no containers in {} match --regions filter {:?}",
+            dir.display(),
+            region_filter
+        );
+
+        // Sort by region id so by-index iteration matches by-id sort.
+        to_load.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let mut regions: Vec<RegionEntry> = Vec::with_capacity(to_load.len());
+        let mut by_id: HashMap<String, usize> = HashMap::new();
+        for (id, path) in to_load {
+            tracing::info!(region = %id, container = %path.display(), "loading region");
+            let load_start = std::time::Instant::now();
+            let state = ServerState::load_from_container(&path, mode_filter)
+                .with_context(|| format!("loading region '{}' from {}", id, path.display()))?;
+            let elapsed = load_start.elapsed();
+            tracing::info!(
+                region = %id,
+                container = %path.display(),
+                load_ms = elapsed.as_millis() as u64,
+                nodes = state.ebg_nodes.n_nodes,
+                edges = state.ebg_csr.n_arcs,
+                modes = ?state.mode_names,
+                "loaded region"
+            );
+            let idx = regions.len();
+            by_id.insert(id.clone(), idx);
+            regions.push(RegionEntry {
+                id,
+                container: path,
+                state: Arc::new(state),
+                verify_status: VerifyStatus::Verified,
+            });
+        }
+
+        Ok(Self { regions, by_id })
+    }
+
+    /// Number of loaded regions.
+    pub fn len(&self) -> usize {
+        self.regions.len()
+    }
+
+    /// `true` if no regions are loaded. Should never be the case after
+    /// successful construction; here for completeness with `len()`.
+    pub fn is_empty(&self) -> bool {
+        self.regions.is_empty()
+    }
+
+    /// Look up a region by id (case-insensitive on the user's input,
+    /// but ids in storage are already normalised upper-case).
+    pub fn get(&self, id: &str) -> Option<&RegionEntry> {
+        self.by_id.get(id).map(|&i| &self.regions[i])
+    }
+
+    /// Borrow the first region's state. Used as a fallback by metadata
+    /// endpoints (`/health`, `/metrics`) and by tests that don't care
+    /// which region answers. Single-region deployments behave exactly
+    /// like before this PR.
+    pub fn primary(&self) -> &Arc<ServerState> {
+        &self.regions[0].state
+    }
+
+    /// Snap a single coordinate to whichever region's road network
+    /// produces the closest hit for the given mode. The mode index is
+    /// per-region — every region must carry the named mode. If a region
+    /// is missing the mode, we skip it (the dispatcher must succeed in
+    /// at least one region or we return `None`).
+    ///
+    /// Returns `(region_idx, snap_distance_m)` for the winner, or
+    /// `None` if no region snapped the point.
+    pub fn snap_winner(&self, lon: f64, lat: f64, mode_name: &str) -> Option<(usize, f64)> {
+        let mut best: Option<(usize, f64)> = None;
+        for (idx, region) in self.regions.iter().enumerate() {
+            let mode_idx = match region.state.mode_lookup.get(mode_name) {
+                Some(&m) => m,
+                None => continue,
+            };
+            if let Some((_ebg_id, _slon, _slat, dist_m)) =
+                region.state.snap_index.snap_with_info(lon, lat, mode_idx)
+            {
+                let candidate = (idx, dist_m);
+                best = match best {
+                    Some((_, prev_dist)) if prev_dist <= dist_m => best,
+                    _ => Some(candidate),
+                };
+            }
+        }
+        best
+    }
+
+    /// Pick the region for a single-coordinate request (e.g. `/nearest`,
+    /// `/isochrone`, `/height`). Returns the per-region `Arc<ServerState>`
+    /// or a `DispatchError::NoRegion` payload (404 caller-side).
+    pub fn dispatch_single(
+        &self,
+        lon: f64,
+        lat: f64,
+        mode_name: &str,
+    ) -> Result<Arc<ServerState>, DispatchError> {
+        self.dispatch_single_id(lon, lat, mode_name).map(|(s, _)| s)
+    }
+
+    /// Same as [`Self::dispatch_single`] but also returns the winning
+    /// region id (so the handler can label its per-region metric
+    /// without a second lookup).
+    pub fn dispatch_single_id(
+        &self,
+        lon: f64,
+        lat: f64,
+        mode_name: &str,
+    ) -> Result<(Arc<ServerState>, String), DispatchError> {
+        match self.snap_winner(lon, lat, mode_name) {
+            Some((idx, _dist)) => Ok((
+                Arc::clone(&self.regions[idx].state),
+                self.regions[idx].id.clone(),
+            )),
+            None => Err(DispatchError::NoRegion {
+                lon,
+                lat,
+                mode: mode_name.to_string(),
+                tried: self.region_ids().into_iter().collect(),
+            }),
+        }
+    }
+
+    /// Pick the region for a two-coordinate request (e.g. `/route`,
+    /// `/table` with one source + targets, `/match`). Both points must
+    /// snap to the same region; otherwise return
+    /// [`DispatchError::CrossRegion`] which the caller renders as 501.
+    pub fn dispatch_p2p(
+        &self,
+        src_lon: f64,
+        src_lat: f64,
+        dst_lon: f64,
+        dst_lat: f64,
+        mode_name: &str,
+    ) -> Result<Arc<ServerState>, DispatchError> {
+        self.dispatch_p2p_id(src_lon, src_lat, dst_lon, dst_lat, mode_name)
+            .map(|(s, _)| s)
+    }
+
+    /// Same as [`Self::dispatch_p2p`] but also returns the winning
+    /// region id. Increments the cross-region rejection counter on
+    /// `Err(CrossRegion)` so operators can monitor 501 traffic
+    /// without parsing log lines.
+    pub fn dispatch_p2p_id(
+        &self,
+        src_lon: f64,
+        src_lat: f64,
+        dst_lon: f64,
+        dst_lat: f64,
+        mode_name: &str,
+    ) -> Result<(Arc<ServerState>, String), DispatchError> {
+        let src = self.snap_winner(src_lon, src_lat, mode_name);
+        let dst = self.snap_winner(dst_lon, dst_lat, mode_name);
+        match (src, dst) {
+            (Some((s_idx, _)), Some((d_idx, _))) if s_idx == d_idx => Ok((
+                Arc::clone(&self.regions[s_idx].state),
+                self.regions[s_idx].id.clone(),
+            )),
+            (Some((s_idx, _)), Some((d_idx, _))) => {
+                let src_region = self.regions[s_idx].id.clone();
+                let dst_region = self.regions[d_idx].id.clone();
+                super::region_metrics::record_cross_region_reject(&src_region, &dst_region);
+                Err(DispatchError::CrossRegion {
+                    src_region,
+                    dst_region,
+                })
+            }
+            _ => Err(DispatchError::NoRegion {
+                lon: src_lon,
+                lat: src_lat,
+                mode: mode_name.to_string(),
+                tried: self.region_ids().into_iter().collect(),
+            }),
+        }
+    }
+
+    /// Pick the region for a many-coordinate request (e.g. `/match`
+    /// trace, `/trip`, `/table` with multiple sources + multiple
+    /// targets). All points must snap to the same region; otherwise
+    /// 501. Returns the per-region state plus the winning region id.
+    pub fn dispatch_many<I>(
+        &self,
+        coords: I,
+        mode_name: &str,
+    ) -> Result<Arc<ServerState>, DispatchError>
+    where
+        I: IntoIterator<Item = (f64, f64)>,
+    {
+        let mut iter = coords.into_iter();
+        let first = iter.next().ok_or(DispatchError::Empty)?;
+        let first_winner = self
+            .snap_winner(first.0, first.1, mode_name)
+            .ok_or_else(|| DispatchError::NoRegion {
+                lon: first.0,
+                lat: first.1,
+                mode: mode_name.to_string(),
+                tried: self.region_ids().into_iter().collect(),
+            })?;
+        let s_idx = first_winner.0;
+        for (lon, lat) in iter {
+            let next =
+                self.snap_winner(lon, lat, mode_name)
+                    .ok_or_else(|| DispatchError::NoRegion {
+                        lon,
+                        lat,
+                        mode: mode_name.to_string(),
+                        tried: self.region_ids().into_iter().collect(),
+                    })?;
+            if next.0 != s_idx {
+                return Err(DispatchError::CrossRegion {
+                    src_region: self.regions[s_idx].id.clone(),
+                    dst_region: self.regions[next.0].id.clone(),
+                });
+            }
+        }
+        Ok(Arc::clone(&self.regions[s_idx].state))
+    }
+
+    /// Sorted list of all loaded region ids.
+    pub fn region_ids(&self) -> Vec<String> {
+        self.regions.iter().map(|r| r.id.clone()).collect()
+    }
+}
+
+/// What can go wrong dispatching a request to a region.
+#[derive(Debug, Clone)]
+pub enum DispatchError {
+    /// One of the input points did not snap into any loaded region's
+    /// road network for the requested mode. Renders as 400 with a
+    /// targeted error message; reuses the existing
+    /// "No road found within snap distance" semantics.
+    NoRegion {
+        lon: f64,
+        lat: f64,
+        mode: String,
+        tried: Vec<String>,
+    },
+    /// The points snapped into *different* regions — same-region
+    /// dispatch can't service this. Renders as 501 with a clear
+    /// "spans regions X → Y" error per the #91 spec.
+    CrossRegion {
+        src_region: String,
+        dst_region: String,
+    },
+    /// `dispatch_many` was called with no coordinates. Caller bug.
+    Empty,
+}
+
+impl DispatchError {
+    /// Convert the dispatch error to a (status, JSON) pair the handler
+    /// can return. Centralises the wording so every endpoint says the
+    /// same thing on 501.
+    pub fn into_response_parts(self) -> (axum::http::StatusCode, ErrorResponse) {
+        use axum::http::StatusCode;
+        match self {
+            DispatchError::NoRegion { lon, lat, mode, .. } => (
+                StatusCode::BAD_REQUEST,
+                ErrorResponse {
+                    error: format!(
+                        "No road found within snap distance for ({}, {}) mode={}",
+                        lon, lat, mode
+                    ),
+                },
+            ),
+            DispatchError::CrossRegion {
+                src_region,
+                dst_region,
+            } => (
+                StatusCode::NOT_IMPLEMENTED,
+                ErrorResponse {
+                    error: format!(
+                        "route spans regions {} \u{2192} {}; cross-region overlay not yet implemented (#91 Phase 2)",
+                        src_region, dst_region
+                    ),
+                },
+            ),
+            DispatchError::Empty => (
+                StatusCode::BAD_REQUEST,
+                ErrorResponse {
+                    error: "no coordinates supplied to dispatcher".to_string(),
+                },
+            ),
+        }
+    }
+}
+
+/// Read just the region id from a container without loading the rest.
+/// Used by the discovery pre-pass so the region filter is applied
+/// before the heavy state load.
+fn peek_region_id(path: &Path) -> Result<String> {
+    use crate::formats::butterfly_dat::Container;
+    let container =
+        Container::open(path).with_context(|| format!("opening container {}", path.display()))?;
+    container.read_region_id(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_status_label_is_stable() {
+        // /regions JSON consumers depend on this exact string.
+        assert_eq!(VerifyStatus::Verified.label(), "verified");
+    }
+
+    #[test]
+    fn dispatch_error_cross_region_is_501_with_helpful_text() {
+        let err = DispatchError::CrossRegion {
+            src_region: "BE".into(),
+            dst_region: "LU".into(),
+        };
+        let (code, body) = err.into_response_parts();
+        assert_eq!(code, axum::http::StatusCode::NOT_IMPLEMENTED);
+        assert!(body.error.contains("BE"), "{}", body.error);
+        assert!(body.error.contains("LU"), "{}", body.error);
+        assert!(
+            body.error.contains("#91"),
+            "expected error to reference issue #91, got: {}",
+            body.error
+        );
+    }
+
+    #[test]
+    fn dispatch_error_no_region_is_400() {
+        let err = DispatchError::NoRegion {
+            lon: 0.0,
+            lat: 0.0,
+            mode: "car".into(),
+            tried: vec!["BE".into()],
+        };
+        let (code, _) = err.into_response_parts();
+        assert_eq!(code, axum::http::StatusCode::BAD_REQUEST);
+    }
+}

--- a/route/src/server/regions_handler.rs
+++ b/route/src/server/regions_handler.rs
@@ -1,0 +1,69 @@
+//! `GET /regions` — multi-region introspection (#91).
+//!
+//! Lists every loaded region with its id, source container path, node
+//! and edge counts, and the boot-time CRC verification status. Used
+//! by operators and tests to confirm that `serve --data-dir` actually
+//! mounted the regions they expected, and to sanity-check the
+//! cross-region 501 path (the dispatcher only ever returns 501 between
+//! pairs of region ids that appear here).
+
+use axum::{Json, extract::State, response::IntoResponse};
+use serde::Serialize;
+use std::sync::Arc;
+
+use super::regions::RegionsState;
+
+#[derive(Debug, Serialize)]
+pub struct LoadedRegion {
+    /// Region identifier (`BE`, `LU`, …) — same string used by the
+    /// per-region metric labels and by 501 dispatch errors.
+    pub id: String,
+    /// File-system path of the source `*.butterfly` container, as
+    /// loaded. Useful for operators verifying which region bundle a
+    /// running process is actually serving.
+    pub container: String,
+    /// Number of EBG nodes in this region's graph.
+    pub nodes: u64,
+    /// Number of EBG arcs in this region's graph.
+    pub edges: u64,
+    /// Container CRC verification state. Currently always `"verified"`
+    /// (boot is eager-CRC); will gain `"pending"` and `"failed"` when
+    /// #160 lands.
+    pub verify_status: &'static str,
+    /// Number of named roads (OSM way names indexed) in this region.
+    /// Operators use this as a coarse signal for "did the road-name
+    /// section load" without parsing the full container.
+    pub named_roads: usize,
+    /// Sorted list of mode names available in this region.
+    pub modes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RegionsResponse {
+    /// All loaded regions, sorted by id. Empty list is impossible
+    /// (constructor rejects zero-region states) — callers can rely on
+    /// at least one entry being present.
+    pub loaded: Vec<LoadedRegion>,
+}
+
+/// `GET /regions` handler.
+///
+/// Read-only metadata; no graph traversal, no allocation beyond the
+/// JSON serialisation buffer. Safe to hammer at high QPS — sub-microsecond
+/// in steady state.
+pub async fn regions_handler(State(regions): State<Arc<RegionsState>>) -> impl IntoResponse {
+    let loaded: Vec<LoadedRegion> = regions
+        .regions
+        .iter()
+        .map(|r| LoadedRegion {
+            id: r.id.clone(),
+            container: r.container.display().to_string(),
+            nodes: r.state.ebg_nodes.n_nodes as u64,
+            edges: r.state.ebg_csr.n_arcs,
+            verify_status: r.verify_status.label(),
+            named_roads: r.state.way_names.len(),
+            modes: r.state.mode_names.clone(),
+        })
+        .collect();
+    Json(RegionsResponse { loaded })
+}

--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -12,6 +12,7 @@ use utoipa::ToSchema;
 
 use super::geometry::{GeometryFormat, Point, RouteGeometry, build_geometry, build_raw_points};
 use super::query::CchQuery;
+use super::regions::RegionsState;
 use super::state::ServerState;
 use super::types::{ErrorResponse, parse_mode, validate_coord};
 use super::unpack::unpack_path;
@@ -216,7 +217,7 @@ pub struct StepManeuver {
 // Note: route computation is fast (<10ms typical) and bounded by ConcurrencyLimitLayer(32),
 // so spawn_blocking is not needed here. /match and /trip use spawn_blocking for long computations.
 pub async fn route_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Query(req): Query<RouteRequest>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
@@ -226,6 +227,24 @@ pub async fn route_handler(
     if let Err(e) = validate_coord(req.dst_lon, req.dst_lat, "destination") {
         return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
     }
+
+    // Region dispatch (#91): both source and destination must snap to
+    // the same region. Different regions → 501 (cross-region overlay
+    // is PR C / Phase 2).
+    let started_dispatch = std::time::Instant::now();
+    let (state, region_id): (Arc<ServerState>, String) = match regions.dispatch_p2p_id(
+        req.src_lon,
+        req.src_lat,
+        req.dst_lon,
+        req.dst_lat,
+        &req.mode,
+    ) {
+        Ok(pair) => pair,
+        Err(e) => {
+            let (code, body) = e.into_response_parts();
+            return (code, Json(body)).into_response();
+        }
+    };
 
     let mode = match parse_mode(&req.mode, &state.mode_lookup) {
         Ok(m) => m,
@@ -500,6 +519,11 @@ pub async fn route_handler(
         };
 
         if wants_gpx(&headers) {
+            super::region_metrics::record_query(
+                &region_id,
+                "route",
+                started_dispatch.elapsed().as_secs_f64(),
+            );
             return gpx_response(format_gpx(&[snap_point], "Route"));
         }
 
@@ -512,6 +536,11 @@ pub async fn route_handler(
         } else {
             None
         };
+        super::region_metrics::record_query(
+            &region_id,
+            "route",
+            started_dispatch.elapsed().as_secs_f64(),
+        );
         return Json(RouteResponse {
             duration_s: 0.0,
             distance_m: 0.0,
@@ -615,6 +644,11 @@ pub async fn route_handler(
     // GPX output: skip annotations, alternatives, debug — just emit track points
     if wants_gpx(&headers) {
         let (raw_points, _) = build_raw_points(&ebg_path, &state.ebg_nodes, &state.edge_geom);
+        super::region_metrics::record_query(
+            &region_id,
+            "route",
+            started_dispatch.elapsed().as_secs_f64(),
+        );
         return gpx_response(format_gpx(&raw_points, "Route"));
     }
 
@@ -776,6 +810,11 @@ pub async fn route_handler(
         None
     };
 
+    super::region_metrics::record_query(
+        &region_id,
+        "route",
+        started_dispatch.elapsed().as_secs_f64(),
+    );
     Json(RouteResponse {
         duration_s,
         distance_m,

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -23,6 +23,7 @@ use crate::matrix::bucket_ch::{
 use crate::matrix::neighbors::{RadiusParam, auto_radius_km, build_neighbors, parse_radius};
 use crate::profile_abi::Mode;
 
+use super::regions::RegionsState;
 use super::state::ServerState;
 use super::types::{ErrorResponse, Waypoint, get_node_location, parse_mode, validate_coord};
 
@@ -147,7 +148,7 @@ pub fn default_tile_size() -> usize {
     )
 )]
 pub async fn table_post_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Json(req): Json<TablePostRequest>,
 ) -> impl IntoResponse {
     for (i, [lon, lat]) in req.sources.iter().enumerate() {
@@ -160,6 +161,30 @@ pub async fn table_post_handler(
             return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
         }
     }
+
+    // Region dispatch (#91): every source + every destination must
+    // snap to the same region. Mixed-region matrices are rejected
+    // with 501 (cross-region matrix is part of the overlay design,
+    // PR C / Phase 2).
+    let started_dispatch = std::time::Instant::now();
+    let coords_iter = req
+        .sources
+        .iter()
+        .chain(req.destinations.iter())
+        .map(|&[lon, lat]| (lon, lat));
+    let state: Arc<ServerState> = match regions.dispatch_many(coords_iter, &req.mode) {
+        Ok(s) => s,
+        Err(e) => {
+            let (code, body) = e.into_response_parts();
+            return (code, Json(body)).into_response();
+        }
+    };
+    let region_id = regions
+        .regions
+        .iter()
+        .find(|r| Arc::ptr_eq(&r.state, &state))
+        .map(|r| r.id.clone())
+        .unwrap_or_default();
 
     let mode = match parse_mode(&req.mode, &state.mode_lookup) {
         Ok(m) => m,
@@ -283,7 +308,7 @@ pub async fn table_post_handler(
 
     let radius_param = parse_radius(req.radius_km.as_ref());
 
-    compute_table_bucket_m2m(
+    let resp = compute_table_bucket_m2m(
         &state,
         mode,
         &req.sources,
@@ -294,7 +319,13 @@ pub async fn table_post_handler(
         &snap_mask,
         radius_param,
     )
-    .await
+    .await;
+    super::region_metrics::record_query(
+        &region_id,
+        "table",
+        started_dispatch.elapsed().as_secs_f64(),
+    );
+    resp
 }
 
 /// Core table computation using bucket M2M algorithm
@@ -562,7 +593,7 @@ pub fn flat_matrix_to_2d(
     )
 )]
 pub async fn table_stream_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Json(req): Json<TableStreamRequest>,
 ) -> impl IntoResponse {
     for (i, [lon, lat]) in req.sources.iter().enumerate() {
@@ -575,6 +606,28 @@ pub async fn table_stream_handler(
             return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
         }
     }
+
+    // Region dispatch (#91): every source + every destination must
+    // snap to the same region for the streaming matrix.
+    let started_dispatch = std::time::Instant::now();
+    let coords_iter = req
+        .sources
+        .iter()
+        .chain(req.destinations.iter())
+        .map(|&[lon, lat]| (lon, lat));
+    let state: Arc<ServerState> = match regions.dispatch_many(coords_iter, &req.mode) {
+        Ok(s) => s,
+        Err(e) => {
+            let (code, body) = e.into_response_parts();
+            return (code, Json(body)).into_response();
+        }
+    };
+    let region_id = regions
+        .regions
+        .iter()
+        .find(|r| Arc::ptr_eq(&r.state, &state))
+        .map(|r| r.id.clone())
+        .unwrap_or_default();
 
     let mode = match parse_mode(&req.mode, &state.mode_lookup) {
         Ok(m) => m,
@@ -770,7 +823,7 @@ pub async fn table_stream_handler(
 
     if n_total_sources * n_total_targets <= BUCKET_M2M_THRESHOLD {
         // --- SMALL MATRIX PATH: Bucket M2M → single Arrow IPC tile ---
-        return table_stream_bucket_path(
+        let resp = table_stream_bucket_path(
             n_nodes,
             &up_adj_flat,
             &down_rev_flat,
@@ -785,6 +838,12 @@ pub async fn table_stream_handler(
             &valid_dst_indices,
             neighbor_mask.as_ref().map(|v| v.as_slice()),
         );
+        super::region_metrics::record_query(
+            &region_id,
+            "table_stream",
+            started_dispatch.elapsed().as_secs_f64(),
+        );
+        return resp;
     }
 
     // --- LARGE MATRIX PATH: PHAST tiling/streaming ---
@@ -987,6 +1046,11 @@ pub async fn table_stream_handler(
     // Convert receiver to stream
     let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
 
+    super::region_metrics::record_query(
+        &region_id,
+        "table_stream",
+        started_dispatch.elapsed().as_secs_f64(),
+    );
     Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, ARROW_STREAM_CONTENT_TYPE)

--- a/route/src/server/transit_handler.rs
+++ b/route/src/server/transit_handler.rs
@@ -44,6 +44,7 @@ use crate::transit::gtfs::haversine_m;
 use crate::transit::raptor::{RaptorLeg, RaptorQuery, run_raptor};
 use crate::transit::timetable::{StopIdx, Timetable};
 
+use super::regions::RegionsState;
 use super::state::ServerState;
 use super::types::ErrorResponse;
 
@@ -237,9 +238,14 @@ fn road_leg(
 }
 
 pub async fn transit_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Query(req): Query<TransitRequest>,
 ) -> Result<Json<TransitResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Transit is single-region only in #91 Phase 1 (the timetable is
+    // loaded against the primary region's foot CCH at boot). For
+    // multi-region deployments the transit subsystem is not loaded;
+    // any /transit query returns 503 from the inner journey computer.
+    let state = regions.primary();
     compute_transit_journey(state.as_ref(), &req).map(Json)
 }
 
@@ -934,9 +940,12 @@ impl OriginGroupKey {
 /// future. This is not yet plumbed through to a cooperative
 /// per-query cancellation flag — a follow-up.
 pub async fn transit_bulk_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Json(req): Json<TransitBulkRequest>,
 ) -> Result<Json<TransitBulkResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Transit is single-region only in #91 Phase 1 (see comment in
+    // [`transit_handler`]). Use the primary region.
+    let state = Arc::clone(regions.primary());
     // Soft cap on batch size. 100k is generous for interactive use;
     // operators doing matrix-style work should look at `/table/stream`
     // for the road side and batch transit in chunks of ~10k.

--- a/route/src/server/trip.rs
+++ b/route/src/server/trip.rs
@@ -15,6 +15,7 @@ use utoipa::ToSchema;
 use crate::matrix::bucket_ch::table_bucket_full_flat;
 use crate::profile_abi::Mode;
 
+use super::regions::RegionsState;
 use super::state::ServerState;
 
 // ============ TSP Solver (pure algorithm) ============
@@ -460,9 +461,45 @@ pub struct TripLeg {
     )
 )]
 pub async fn trip_handler(
-    State(state): State<Arc<ServerState>>,
+    State(regions): State<Arc<RegionsState>>,
     Json(req): Json<TripRequest>,
 ) -> impl IntoResponse {
+    // Region dispatch (#91): the trip's coordinate set must all snap
+    // into one region. Mixed-region trips require the cross-region
+    // overlay (PR C / Phase 2) and are rejected with 501 here.
+    if req.coordinates.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "code": "InvalidValue",
+                "message": "coordinates cannot be empty"
+            })),
+        )
+            .into_response();
+    }
+    let started_dispatch = std::time::Instant::now();
+    let coords_iter = req.coordinates.iter().map(|&[lon, lat]| (lon, lat));
+    let state: Arc<ServerState> = match regions.dispatch_many(coords_iter, &req.mode) {
+        Ok(s) => s,
+        Err(e) => {
+            let (code, body) = e.into_response_parts();
+            return (
+                code,
+                Json(serde_json::json!({
+                    "code": "InvalidValue",
+                    "message": body.error,
+                })),
+            )
+                .into_response();
+        }
+    };
+    let region_id = regions
+        .regions
+        .iter()
+        .find(|r| Arc::ptr_eq(&r.state, &state))
+        .map(|r| r.id.clone())
+        .unwrap_or_default();
+
     // Validate mode
     let mode = match parse_mode(&req.mode, &state.mode_lookup) {
         Ok(m) => m,
@@ -769,7 +806,7 @@ pub async fn trip_handler(
     })
     .await;
 
-    match blocking_result {
+    let resp = match blocking_result {
         Ok(Ok(response)) => Json(response).into_response(),
         Ok(Err((status, json_val))) => (status, Json(json_val)).into_response(),
         Err(e) => (
@@ -780,7 +817,13 @@ pub async fn trip_handler(
             })),
         )
             .into_response(),
-    }
+    };
+    super::region_metrics::record_query(
+        &region_id,
+        "trip",
+        started_dispatch.elapsed().as_secs_f64(),
+    );
+    resp
 }
 
 /// Parse mode string into Mode using dynamic lookup

--- a/route/tests/multi_region.rs
+++ b/route/tests/multi_region.rs
@@ -1,0 +1,355 @@
+//! Integration tests for #91 multi-region container loading + dispatch.
+//!
+//! These tests are `#[ignore]` because they require the prebuilt
+//! Belgium and Luxembourg `.butterfly` containers; CI does not ship
+//! either dataset. Run them locally with:
+//!
+//! ```bash
+//! cargo test -p butterfly-route --release --test multi_region -- --ignored
+//! ```
+//!
+//! Test inventory (per #91 spec):
+//! - region discovery + loading from a directory of containers
+//! - snap dispatch picks the correct region for points in BE vs LU
+//! - BE → BE same-region routing works
+//! - LU → LU same-region routing works
+//! - BE → LU returns 501 with the helpful "spans regions" error
+//! - malformed `--data-dir` (no `*.butterfly`) yields a clean error
+//!
+//! Test data: this repo does not ship Belgium or Luxembourg PBF/
+//! container output; the tests look for them under `data/<region>/`
+//! and silently skip if absent. The build script in #91 docs walks
+//! through producing both containers.
+
+use std::path::Path;
+
+use butterfly_route::pack::{self, DEFAULT_REGION_ID, normalize_region_id};
+use butterfly_route::server::regions::{DispatchError, RegionsState};
+
+const BE_CONTAINER: &str = "data/belgium/baseline.butterfly";
+const LU_CONTAINER: &str = "data/luxembourg/luxembourg.butterfly";
+
+fn container_paths() -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+    // Tests run with CWD set to the package root (`route/`) by cargo,
+    // but the data lives at the workspace root one level up. Probe a
+    // few common locations: the repo root via `../`, the package root
+    // (in case the data is symlinked in), and an absolute fallback.
+    let candidates: &[(&str, &str)] = &[
+        (
+            "../data/belgium/baseline.butterfly",
+            "../data/luxembourg/luxembourg.butterfly",
+        ),
+        (BE_CONTAINER, LU_CONTAINER),
+        (
+            "/home/snape/projects/butterfly-osm/data/belgium/baseline.butterfly",
+            "/home/snape/projects/butterfly-osm/data/luxembourg/luxembourg.butterfly",
+        ),
+    ];
+    for (be, lu) in candidates {
+        let be_p = Path::new(be);
+        let lu_p = Path::new(lu);
+        if be_p.exists() && lu_p.exists() {
+            return Some((
+                be_p.canonicalize().unwrap_or_else(|_| be_p.to_path_buf()),
+                lu_p.canonicalize().unwrap_or_else(|_| lu_p.to_path_buf()),
+            ));
+        }
+    }
+    None
+}
+
+/// Stage a temp directory with symlinks to the BE + LU containers,
+/// preserving their disk-resident copies (the test does not copy
+/// gigabytes around).
+fn stage_dir(be: &Path, lu: &Path) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let be_dst = dir.path().join("be.butterfly");
+    let lu_dst = dir.path().join("lu.butterfly");
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(be, &be_dst).expect("symlink BE");
+        std::os::unix::fs::symlink(lu, &lu_dst).expect("symlink LU");
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::copy(be, &be_dst).expect("copy BE");
+        std::fs::copy(lu, &lu_dst).expect("copy LU");
+    }
+    dir
+}
+
+// =============================================================================
+// Pure unit tests (no container required)
+// =============================================================================
+
+#[test]
+fn region_id_normalises_lowercase_to_uppercase() {
+    assert_eq!(normalize_region_id("be").unwrap(), "BE");
+    assert_eq!(normalize_region_id(" lu ").unwrap(), "LU");
+    assert_eq!(normalize_region_id("FR").unwrap(), "FR");
+    assert_eq!(normalize_region_id("Region-1").unwrap(), "REGION-1");
+}
+
+#[test]
+fn region_id_rejects_invalid_chars() {
+    assert!(normalize_region_id("BE/LU").is_err());
+    assert!(normalize_region_id("BE LU").is_err());
+    assert!(normalize_region_id("be.lu").is_err());
+    assert!(normalize_region_id("").is_err());
+    assert!(normalize_region_id("    ").is_err());
+}
+
+#[test]
+fn region_id_caps_at_16_chars() {
+    let ok = "A".repeat(16);
+    let bad = "A".repeat(17);
+    assert!(normalize_region_id(&ok).is_ok());
+    assert!(normalize_region_id(&bad).is_err());
+}
+
+#[test]
+fn manifest_region_id_returns_default_for_missing() {
+    let s = pack::manifest_region_id(b"{\"version\": 1, \"modes\": []}");
+    assert_eq!(s, DEFAULT_REGION_ID);
+}
+
+#[test]
+fn manifest_region_id_parses_explicit_field() {
+    let s = pack::manifest_region_id(b"{\"version\": 1, \"region_id\": \"LU\", \"modes\": []}");
+    assert_eq!(s, "LU");
+}
+
+#[test]
+fn manifest_region_id_normalises_case() {
+    let s = pack::manifest_region_id(b"{\"version\": 1, \"region_id\": \"lu\", \"modes\": []}");
+    assert_eq!(s, "LU");
+}
+
+#[test]
+fn manifest_region_id_handles_garbage_fallsback() {
+    // Truncated / malformed JSON: don't reject the container, just
+    // fall back to the default region id.
+    let s = pack::manifest_region_id(b"this is not json");
+    assert_eq!(s, DEFAULT_REGION_ID);
+}
+
+// =============================================================================
+// Discovery + dispatch tests (require BE + LU containers on disk)
+// =============================================================================
+
+/// Two regions discovered from a directory of `*.butterfly` files.
+/// Verifies sorting (BE before LU) and that both are present.
+#[test]
+#[ignore = "requires data/belgium + data/luxembourg containers"]
+fn loads_two_regions_from_directory() {
+    let Some((be, lu)) = container_paths() else {
+        eprintln!("skipping: BE + LU containers not on disk");
+        return;
+    };
+    let dir = stage_dir(&be, &lu);
+    let regions = RegionsState::load_from_dir(dir.path(), None, None).expect("load_from_dir");
+    assert_eq!(
+        regions.len(),
+        2,
+        "expected 2 regions, got {}",
+        regions.len()
+    );
+    let ids = regions.region_ids();
+    assert!(ids.contains(&"BE".to_string()), "missing BE in {:?}", ids);
+    assert!(ids.contains(&"LU".to_string()), "missing LU in {:?}", ids);
+}
+
+/// `--regions BE` filter loads only the matching container.
+#[test]
+#[ignore = "requires data/belgium + data/luxembourg containers"]
+fn region_filter_skips_unrequested_containers() {
+    let Some((be, lu)) = container_paths() else {
+        eprintln!("skipping: BE + LU containers not on disk");
+        return;
+    };
+    let dir = stage_dir(&be, &lu);
+    let regions = RegionsState::load_from_dir(dir.path(), Some(&["BE".to_string()]), None)
+        .expect("load_from_dir BE-only");
+    assert_eq!(regions.len(), 1);
+    assert_eq!(regions.region_ids(), vec!["BE".to_string()]);
+}
+
+/// Snapping a Brussels coordinate must dispatch to BE; Luxembourg
+/// city to LU. Verifies the multi-region snap-winner logic.
+#[test]
+#[ignore = "requires data/belgium + data/luxembourg containers"]
+fn dispatcher_picks_right_region_for_known_points() {
+    let Some((be, lu)) = container_paths() else {
+        eprintln!("skipping: BE + LU containers not on disk");
+        return;
+    };
+    let dir = stage_dir(&be, &lu);
+    let regions = RegionsState::load_from_dir(dir.path(), None, None).expect("load_from_dir");
+
+    // Brussels-Centraal → BE.
+    let (state, region_id) = regions
+        .dispatch_single_id(4.3567, 50.8453, "car")
+        .expect("Brussels should snap into BE");
+    assert_eq!(region_id, "BE", "Brussels should snap to BE");
+    assert!(state.mode_lookup.contains_key("car"));
+
+    // Luxembourg-Ville → LU.
+    let (state, region_id) = regions
+        .dispatch_single_id(6.1296, 49.6116, "car")
+        .expect("Luxembourg-Ville should snap into LU");
+    assert_eq!(region_id, "LU", "Luxembourg-Ville should snap to LU");
+    assert!(state.mode_lookup.contains_key("car"));
+}
+
+/// BE → BE p2p dispatch returns the BE state without 501.
+#[test]
+#[ignore = "requires data/belgium + data/luxembourg containers"]
+fn p2p_dispatch_same_region_be_to_be() {
+    let Some((be, lu)) = container_paths() else {
+        eprintln!("skipping: BE + LU containers not on disk");
+        return;
+    };
+    let dir = stage_dir(&be, &lu);
+    let regions = RegionsState::load_from_dir(dir.path(), None, None).expect("load_from_dir");
+
+    // Brussels-Centraal → Bruges, both in BE.
+    let (_state, region_id) = regions
+        .dispatch_p2p_id(4.3567, 50.8453, 3.2247, 51.2093, "car")
+        .expect("Brussels → Bruges should not 501");
+    assert_eq!(region_id, "BE");
+}
+
+/// LU → LU p2p dispatch returns the LU state without 501.
+#[test]
+#[ignore = "requires data/belgium + data/luxembourg containers"]
+fn p2p_dispatch_same_region_lu_to_lu() {
+    let Some((be, lu)) = container_paths() else {
+        eprintln!("skipping: BE + LU containers not on disk");
+        return;
+    };
+    let dir = stage_dir(&be, &lu);
+    let regions = RegionsState::load_from_dir(dir.path(), None, None).expect("load_from_dir");
+
+    // Luxembourg-Ville → Esch-sur-Alzette, both in LU.
+    let (_state, region_id) = regions
+        .dispatch_p2p_id(6.1296, 49.6116, 5.9806, 49.4955, "car")
+        .expect("LU-City → Esch should not 501");
+    assert_eq!(region_id, "LU");
+}
+
+/// BE → LU is the **correctness invariant**: must return 501 with a
+/// clear "spans regions" error. No silent wrong answer, no panic.
+#[test]
+#[ignore = "requires data/belgium + data/luxembourg containers"]
+fn p2p_dispatch_cross_region_returns_501() {
+    let Some((be, lu)) = container_paths() else {
+        eprintln!("skipping: BE + LU containers not on disk");
+        return;
+    };
+    let dir = stage_dir(&be, &lu);
+    let regions = RegionsState::load_from_dir(dir.path(), None, None).expect("load_from_dir");
+
+    // Brussels (BE) → Luxembourg-Ville (LU) — these clearly snap into
+    // different regions.
+    let err = match regions.dispatch_p2p_id(4.3567, 50.8453, 6.1296, 49.6116, "car") {
+        Ok(_) => panic!("expected CrossRegion error, got Ok"),
+        Err(e) => e,
+    };
+    match err {
+        DispatchError::CrossRegion {
+            ref src_region,
+            ref dst_region,
+        } => {
+            assert_eq!(src_region, "BE");
+            assert_eq!(dst_region, "LU");
+        }
+        other => panic!("expected CrossRegion, got {:?}", other),
+    }
+    // The HTTP rendering is 501.
+    let (code, body) = err.into_response_parts();
+    assert_eq!(code, axum::http::StatusCode::NOT_IMPLEMENTED);
+    assert!(body.error.contains("BE"));
+    assert!(body.error.contains("LU"));
+    assert!(body.error.contains("#91"));
+}
+
+/// Empty `--data-dir` (no `*.butterfly`) is a hard error, not a
+/// silent zero-region server.
+#[test]
+fn empty_data_dir_is_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let res = RegionsState::load_from_dir(dir.path(), None, None);
+    assert!(res.is_err());
+    let msg = res.err().expect("expected error").to_string();
+    assert!(
+        msg.contains("no *.butterfly"),
+        "expected 'no *.butterfly' diagnostic, got: {}",
+        msg
+    );
+}
+
+/// `--data-dir` that points at a non-directory (e.g. a file) is
+/// rejected with a path-aware error.
+#[test]
+fn non_directory_data_dir_is_rejected() {
+    let f = tempfile::NamedTempFile::new().expect("tempfile");
+    let res = RegionsState::load_from_dir(f.path(), None, None);
+    assert!(res.is_err());
+    let msg = res.err().expect("expected error").to_string();
+    assert!(
+        msg.contains("expected --data-dir to be a directory"),
+        "expected 'directory' diagnostic, got: {}",
+        msg
+    );
+}
+
+/// `--regions` filter that excludes every container is a hard error.
+/// Operator typo'd a region id; better to fail loudly than to start a
+/// zero-region server.
+#[test]
+#[ignore = "requires data/belgium + data/luxembourg containers"]
+fn region_filter_excluding_everything_is_rejected() {
+    let Some((be, lu)) = container_paths() else {
+        eprintln!("skipping: BE + LU containers not on disk");
+        return;
+    };
+    let dir = stage_dir(&be, &lu);
+    let res = RegionsState::load_from_dir(dir.path(), Some(&["FR".to_string()]), None);
+    assert!(res.is_err());
+    let msg = res.err().expect("expected error").to_string();
+    assert!(msg.contains("no containers"), "got: {}", msg);
+}
+
+/// Synthetic two-region test that doesn't need real PBF data: build a
+/// fake LU container by reusing the BE container under a different
+/// region tag. Exercises the loader's dispatch table and the duplicate-
+/// region-id rejection path. Skipped if BE container is absent.
+#[test]
+#[ignore = "requires data/belgium container"]
+fn duplicate_region_id_is_rejected() {
+    let Some((be, _)) = container_paths() else {
+        eprintln!("skipping: BE container not on disk");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dst1 = dir.path().join("be1.butterfly");
+    let dst2 = dir.path().join("be2.butterfly");
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&be, &dst1).expect("symlink 1");
+        std::os::unix::fs::symlink(&be, &dst2).expect("symlink 2");
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::copy(&be, &dst1).expect("copy 1");
+        std::fs::copy(&be, &dst2).expect("copy 2");
+    }
+    let res = RegionsState::load_from_dir(dir.path(), None, None);
+    assert!(res.is_err());
+    let msg = res.err().expect("expected error").to_string();
+    assert!(
+        msg.contains("duplicate region id"),
+        "expected duplicate-region diagnostic, got: {}",
+        msg
+    );
+}


### PR DESCRIPTION
## Summary

PR B of the #91 multi-region serve story. Per-region container discovery + same-region routing; cross-region overlay is **out of scope** and tracked as PR C.

- New `RegionsState` wraps one or more `ServerState`s with a coordinate-snap dispatcher. Single-region deployments are byte-for-byte unchanged (transparently wrapped).
- `pack --region <ID>` embeds an id in the container manifest. Default `BE`; pre-#91 containers read as `BE` so legacy `baseline.butterfly` files still work without re-pack.
- `serve --data-dir <dir>` auto-detects a multi-region directory of `*.butterfly` files; optional `--regions BE,LU` filter.
- New `GET /regions` endpoint + per-region Prometheus metrics (`region_nodes_total`, `region_edges_total`, `query_total{region,endpoint}`, `query_duration_seconds{region,endpoint}`, `query_cross_region_total{src,dst}`).
- **Correctness invariant**: cross-region queries return HTTP 501 with the spec body `route spans regions X → Y; cross-region overlay not yet implemented (#91 Phase 2)`. Verified end-to-end live and via the dispatcher unit + integration tests.

## Live verification

Both BE and LU containers loaded (`docs/91-loader-results.md` has the full transcript):

```
$ curl -s http://127.0.0.1:3091/regions
{\"loaded\":[
  {\"id\":\"BE\",\"container\":\"/tmp/multi_region/be.butterfly\",\"nodes\":5019052,\"edges\":14649023,
   \"verify_status\":\"verified\",\"named_roads\":754380,\"modes\":[\"bike\",\"car\",\"foot\",\"truck\"]},
  {\"id\":\"LU\",\"container\":\"/tmp/multi_region/lu.butterfly\",\"nodes\":478552,\"edges\":1365815,
   \"verify_status\":\"verified\",\"named_roads\":46287,\"modes\":[\"bike\",\"car\",\"foot\"]}
]}

# BE → BE: 97.5 km Brussels → Bruges, HTTP 200
# BE → LU: 501 with the prescribed body
$ curl -w \"\\n%{http_code}\\n\" \"http://127.0.0.1:3091/route?src_lon=4.3567&src_lat=50.8453&dst_lon=6.1296&dst_lat=49.6116&mode=car\"
{\"error\":\"route spans regions BE → LU; cross-region overlay not yet implemented (#91 Phase 2)\"}
501

# Per-region metrics increment correctly:
butterfly_route_query_cross_region_total{src=\"BE\",dst=\"LU\"} 1
butterfly_route_query_cross_region_total{src=\"LU\",dst=\"BE\"} 1
```

## RSS

|                          | Total RSS | RssAnon |
|--------------------------|----------:|--------:|
| BE single (post-warmup, baseline from #154-results.md) | 3.02 GB | 0.70 GB |
| BE + LU (post-warmup)    | 3.15 GB | 0.69 GB |

Adding LU on top of BE costs ~130 MB total, ~0 anon. The mmap-friendly working-set RSS shape established by #152→#155 holds with multi-region.

## Boot

- LU container builds in <3 min on a 46 MB Geofabrik PBF (steps 1-8 + pack).
- LU container boots in 3.6 s. BE in ~88 s (legacy eager-CRC; PR A / #160 will eliminate this).

## Test plan

- [x] `cargo test -p butterfly-route --lib` — 431 unit tests pass (incl. 3 new `regions::tests`).
- [x] `cargo test -p butterfly-route --test multi_region` — 9 always-on tests pass.
- [x] `cargo test -p butterfly-route --test multi_region -- --ignored` — all 8 data-gated tests pass on the session machine, including the BE → LU 501 invariant and the duplicate-region-id rejection.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p butterfly-route -p butterfly-common -p butterfly-dl --all-targets --all-features` — clean.
- [x] `cargo build --release --workspace` — clean.

## Coordination with PR A (#160 lazy CRC)

This PR is strictly additive against PR A. We touch:

- `pack.rs` (new `--region` flag, manifest schema additions) — additive, no shared lines.
- `formats/butterfly_dat.rs` (new `read_region_id` / `region_id_from_mmap` helpers) — additive, no shared lines.
- `server/state.rs` — **untouched** in this PR (PR A's `LazyContainer` field lives there).
- `server/api.rs`, every routing handler — touched, but PR A doesn't touch the State extractor signatures, so no conflict.

If PR A merges first, this PR rebases cleanly on top. If this PR merges first, PR A rebases its `LazyContainer` plumbing onto the new `Arc<RegionsState>` router state with the same surgical changes it would have made against `Arc<ServerState>`.

## What's NOT in this PR (PR C scope)

- Cross-region overlay (border-node extraction, border-matrix precomputation, query coordinator).
- Multi-region gRPC Flight (Flight is currently primary-region only with a boot warning).
- Multi-region transit (timetable + ULTRA load against the primary region only).