### PR TITLE
fix(geocode): address Copilot reviews on PRs #162/#166/#169/#170/#173/#176 (shard/sources/server)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "wiremock",
 ]
 
@@ -597,6 +597,7 @@ dependencies = [
  "axum",
  "axum-prometheus",
  "butterfly-common",
+ "butterfly-dl",
  "bytemuck",
  "bytes",
  "candle-core",
@@ -624,7 +625,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "toml 0.8.23",
+ "toml",
  "tonic",
  "tower",
  "tower-http",
@@ -680,7 +681,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "tonic",
  "tower",
  "tower-http",
@@ -4009,15 +4010,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4478,38 +4470,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -4522,33 +4493,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5353,15 +5304,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ env_logger = "0.11.10"
 indicatif = "0.18"
 strsim = "0.11.1"
 tempfile = "3.27"
+# `toml` is API-stable across 0.8 → 1.x for our schema-parsing
+# workload (TOML region indexes + country packs). Pinning workspace-
+# wide so dl/route/geocode all link the same crate version.
+toml = "1.1"
 # Dev dependencies
 wiremock = "0.6.5"
 ctor = "0.10"

--- a/dl/src/regions.rs
+++ b/dl/src/regions.rs
@@ -458,6 +458,54 @@ mod tests {
     }
 
     #[test]
+    fn every_loadable_region_appears_in_shipped_regions() {
+        // Inverse of the test above: every name in `shipped_regions()`
+        // must round-trip through `RegionIndex::load`. Without this,
+        // a new arm in `RegionIndex::load` without a corresponding
+        // entry in `shipped_regions()` would slip past CI — the CLI's
+        // "unknown region X; known regions are [...]" error would lie
+        // about the actual supported set.
+        //
+        // The list of known good aliases this test enumerates must
+        // stay synchronised with `RegionIndex::load`. When you add a
+        // region, drop a new line below.
+        let known: &[&str] = &[
+            "belgium",
+            "france",
+            "netherlands",
+            "luxembourg",
+            "germany",
+            "austria",
+            "switzerland",
+            "united-states",
+            "us",
+            "japan",
+            "brazil",
+            "india",
+            "australia",
+        ];
+        for name in known {
+            assert!(
+                RegionIndex::load(name).is_ok(),
+                "region '{name}' should load via RegionIndex::load"
+            );
+        }
+        // The `shipped_regions()` alias set must be a subset of the
+        // load-arm set above. Any name in `shipped_regions()` that
+        // doesn't load is a bug — same direction as the test above
+        // but verified explicitly without depending on iteration.
+        let shipped: std::collections::HashSet<&str> = shipped_regions().iter().copied().collect();
+        let known_set: std::collections::HashSet<&str> = known.iter().copied().collect();
+        for name in &shipped {
+            assert!(
+                known_set.contains(name),
+                "shipped_regions() lists '{name}' but the inverse test doesn't \
+                 enumerate it — add it to the `known` array in this test"
+            );
+        }
+    }
+
+    #[test]
     fn unknown_region_errors() {
         let err = RegionIndex::load("atlantis").expect_err("should reject");
         let msg = format!("{err:#}");

--- a/geocode-data/CLUSTERS.md
+++ b/geocode-data/CLUSTERS.md
@@ -223,6 +223,29 @@ back-to-back in the on-disk file so:
   average, which is small enough to fit in L3 for hot fragments
   and page-fault cheaply for cold ones.
 
+### Postcode-less records
+
+Authoritative datasets sometimes ship records without a postcode
+(Germany OSM fallback in particular has `addr:postcode` Optional —
+rural addresses, some POIs, parts of older imports). The fragment
+key MUST partition every record, so postcode-less records land in a
+sentinel bucket with the literal two-byte string `"00"` as the
+`pc2` value:
+
+```
+key = (cluster_id, country, "00")  ← sentinel for missing postcode
+```
+
+`"00"` was chosen because no real-world postcode begins with two
+literal zeros: BE/LU/NL postcodes start at `1xxx`, German postcodes
+start at `01xxx` (so `pc2 = "01"`), French postcodes start at
+`01xxx` to `9xxxx`. The sentinel collides with no legitimate `pc2`.
+
+The query path treats `"00"` specially: a query with a confirmed
+postcode skips this fragment entirely; a query with NO postcode
+hits both the sentinel and (if locality narrows further) the
+postcode-bearing fragments.
+
 ### Why `pc2` and not country alone?
 
 Without `pc2`-level partitioning, a single-country query against
@@ -245,10 +268,22 @@ records.
 ```
 geocode-{cluster_id}.shard
 ├── header                        — magic, version, cluster id, table of contents
+├── strings table                 — concatenated UTF-8 bytes (street, locality, housenumber, postcode)
 ├── alias_table                   — multilingual locality + street aliases (cluster-wide)
 ├── per-country sections (sorted by ISO code)
-│   └── per-pc2 fragments (sorted by postcode prefix)
-│       ├── records slab          — [AddressRecord; n], packed, fixed stride
+│   └── per-pc2 fragments (sorted by postcode prefix; sentinel "00" first)
+│       ├── records slab          — fixed-stride per-record metadata (32-40 bytes per record)
+│       │                           NOT `[AddressRecord; n]` — `AddressRecord` has
+│       │                           `String` fields and is not mmap-safe. Each on-disk
+│       │                           record holds (lat_e7 i32, lon_e7 i32) + offsets
+│       │                           into the strings table:
+│       │                             street_off u32, street_len u16,
+│       │                             loc_off u32, loc_len u16,
+│       │                             house_off u32, house_len u16,
+│       │                             pc_off u32, pc_len u16,
+│       │                             source u8, _pad [u8; 3]
+│       │                           Strings are owned by the strings-table region, not
+│       │                           by the record row.
 │       ├── postcode index        — sparse FST or sorted-key array
 │       ├── locality index        — alias-id → record-offset adjacency
 │       ├── street trie           — fst::Map of canonical street name → offset list

--- a/geocode-data/SOURCES.md
+++ b/geocode-data/SOURCES.md
@@ -42,8 +42,25 @@ struct AddressRecord {
 - Postcodes are stored as published, **without** country prefix. The
   parser knows postcode format per country at query time.
 - Multilingual aliases (e.g. Brussels = Bruxelles = Brussel = Brüssel)
-  are handled at the **alias-table** layer (one record per (canonical
-  locality, alias)), not by duplicating `AddressRecord`s.
+  are handled at the **alias-table** layer: one record per
+  `(canonical locality, alias)` pair. The canonical locality is the
+  `(country, postcode_first_two, locality_canonical_id)` tuple; each
+  alias adds one row pointing back to that canonical id. Worked
+  example for Brussels:
+  ```
+  canonical_locality: (BE, "10", id=42 → "Bruxelles")
+  alias:              (BE, "10", id=42, alias="Brussel",  lang="nl")
+  alias:              (BE, "10", id=42, alias="Brussels", lang="en")
+  alias:              (BE, "10", id=42, alias="Brüssel",  lang="de")
+  ```
+  Because BOSA publishes each address once with every-language
+  street + locality columns populated, the importer projects each
+  language column into one alias row, NOT one full `AddressRecord`
+  per language. The shard's per-language inverted-index lookups
+  resolve through this alias table, then materialise the canonical
+  record exactly once. (PR #166 originally said "one record per
+  language per address"; that contradicted the alias-table model
+  and is corrected here.)
 - House numbers stay strings. Numeric coercion is wrong — alphanumeric
   ("12A"), hyphenated ("10-12"), bis/ter/quater suffixes are all
   semantically real.
@@ -119,10 +136,15 @@ fn from_bosa_csv(row: &BosaRow, lang: Lang) -> AddressRecord {
 survives without a separate "unit" channel for the BE MVP.
 
 The `pick_lang` step is **not** an ingest-time choice — Belgium
-needs every language as a queryable alias. The importer emits one
-record per non-empty language per address (typically NL + FR; DE is
-mostly empty in Brussels/Wallonia), all sharing the same `source_id`,
-linked through the same `(lat, lon, postcode, housenumber)` tuple.
+needs every language as a queryable alias. The importer projects
+each non-empty language column (NL/FR/DE) into a separate row in
+the alias table per the model documented in §"Normalized record
+schema": one canonical `AddressRecord` per address, plus one alias
+row per non-empty language pointing at that canonical id. (The
+2026-05-04 BOSA loader currently emits one `AddressRecord` per
+language as a stopgap until the alias-table layer lands; the
+follow-up to switch to the alias-table model is filed as part of
+the geocode shard format work in `geocode-data/CLUSTERS.md`.)
 
 Records with `status != "current"` (e.g. retired addresses) are
 dropped at ingest. Records without lat/lon parse failures are also

--- a/geocode/Cargo.toml
+++ b/geocode/Cargo.toml
@@ -11,6 +11,10 @@ categories = ["api-bindings"]
 
 [dependencies]
 butterfly-common = { path = "../butterfly-common" }
+# `butterfly-dl::regions` provides the per-region TOML index that
+# `build-shards-all` consults to discover authoritative-source files
+# (BOSA BeSt for BE, etc.).
+butterfly-dl = { path = "../dl" }
 clap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -60,7 +64,7 @@ bytes = "1.11.1"
 tokio-stream = "0.1.18"
 rayon = "1.11"
 
-toml = "0.8"
+toml = { workspace = true }
 tempfile = { workspace = true }
 
 # BOSA BeSt CSV downloads ship as ZIPs containing one CSV. The

--- a/geocode/README.md
+++ b/geocode/README.md
@@ -383,7 +383,7 @@ butterfly-geocode build-shard \
     --out belgium-merged.bfgs --country BE
 ```
 
-The per-record source byte (BFGS v4) survives the merge so `/geocode` results carry their provenance. Operators auditing geocode outputs can filter by source via the per-record source field.
+The per-record source byte (BFGS v4) is persisted at build time and survives the merge. The byte is stored on every record in the shard, lets the merger pick the higher-priority source on conflict, and is available to anyone reading the shard directly. Surfacing it on the `/geocode` JSON envelope is a follow-up tracked against `geocoder/executor.rs::GeocodedResult` (the result type lives outside this layer's territory).
 
 ### How the loader works
 

--- a/geocode/data/packs/README.md
+++ b/geocode/data/packs/README.md
@@ -124,4 +124,23 @@ packs all pass these checks (`PackRegistry::shipped()` is unit-tested).
 Same parser butterfly-route uses for region indexes (`dl/regions/`).
 Comment-friendly. Hand-editable. Operators can ship a country pack
 override without recompiling the binary by mounting a directory and
-running `serve --pack-dir /etc/geocode/packs`.
+running `butterfly-geocode serve --pack-dir /etc/geocode/packs`.
+
+### `--pack-dir` semantics
+
+The flag is additive over the shipped registry: every embedded pack
+loads first; then every `*.toml` under `<pack-dir>` overlays the
+matching ISO2. Files in `<pack-dir>` win on conflict. Missing files
+leave the embedded pack untouched.
+
+Example: to hot-patch BE's postcode regex without rebuilding:
+```bash
+mkdir -p /etc/geocode/packs
+cp my-be-override.toml /etc/geocode/packs/be.toml
+butterfly-geocode serve --shard-dir /data/shards --pack-dir /etc/geocode/packs
+```
+Bring the override TOML through the same validation gate as the
+shipped packs (see "Validation" above) — a malformed override
+**fails the boot** rather than silently degrading to the embedded
+pack. Operators can keep partial coverage in the override directory
+(only the countries they want to patch); the rest stay shipped.

--- a/geocode/src/main.rs
+++ b/geocode/src/main.rs
@@ -15,7 +15,7 @@ use butterfly_geocode::confidence::{
     GbdtModel, TrainConfig, build_training_groups, build_training_rows, dump_training_rows,
     evaluate, load_corpus, synthesise_corpus_from_shard, train_pointwise,
 };
-use butterfly_geocode::osm_extract::{ExtractProgress, extract_addresses};
+use butterfly_geocode::osm_extract::{ExtractProgress, extract_addresses_with_tags};
 use butterfly_geocode::server::{
     DEFAULT_GRPC_PORT, DEFAULT_REST_PORT, ServerConfig, ServerState, Transport,
     build_router_with_config, start_grpc_server,
@@ -238,6 +238,22 @@ enum Command {
         /// future Flight endpoints will tighten this).
         #[arg(long, default_value_t = 4096)]
         max_body_bytes: usize,
+        /// Optional directory of country pack TOMLs that overlay
+        /// the shipped packs (#96 §"Country Routing"). Each TOML is
+        /// loaded after the shipped set and replaces the embedded
+        /// pack for that ISO2; missing files leave the shipped pack
+        /// in place. Useful for hot-patching a postcode regex or
+        /// adding lexical cues without rebuilding the binary.
+        #[arg(long)]
+        pack_dir: Option<PathBuf>,
+        /// Comma-separated CIDR allowlist of trusted reverse proxies.
+        /// When set, the per-IP rate limiter pulls the client IP
+        /// from `X-Forwarded-For` (rightmost non-trusted entry per
+        /// RFC 7239) for connections coming from these CIDRs.
+        /// Without it, all requests behind a reverse proxy share the
+        /// proxy IP and rate-limiting is global rather than per-client.
+        #[arg(long)]
+        trusted_proxies: Option<String>,
     },
     /// Run a batch of queries against a remote geocoder via gRPC
     /// Arrow Flight (#145). Reads JSONL queries (one per line) from
@@ -393,13 +409,34 @@ async fn main() -> Result<()> {
             request_timeout_secs,
             shutdown_timeout_secs,
             max_body_bytes,
+            pack_dir,
+            trusted_proxies,
         } => {
             let server_cfg = ServerConfig {
                 rate_limit_per_sec,
                 rate_limit_burst,
                 request_timeout: std::time::Duration::from_secs(request_timeout_secs),
                 max_request_body_bytes: max_body_bytes,
+                trusted_proxies: butterfly_geocode::server::parse_trusted_proxies(
+                    trusted_proxies.as_deref(),
+                )
+                .map_err(|e| anyhow!("parsing --trusted-proxies: {e}"))?,
             };
+            // Load + validate the pack registry. Either shipped-only
+            // (default) or shipped + override directory. Done at CLI
+            // level so a bad pack drop fails the boot loudly rather
+            // than silently degrading classifier accuracy.
+            let pack_registry = match pack_dir.as_deref() {
+                Some(d) => butterfly_geocode::routing::PackRegistry::shipped_with_overrides(d)
+                    .with_context(|| format!("loading pack overrides from {}", d.display()))?,
+                None => butterfly_geocode::routing::PackRegistry::shipped()
+                    .context("loading shipped country packs")?,
+            };
+            info!(
+                packs = pack_registry.len(),
+                pack_dir = ?pack_dir,
+                "country pack registry ready"
+            );
             // Port resolution precedence:
             // 1. explicit `--rest-port` / `--grpc-port`
             // 2. legacy `--port` aliases the REST port (default 3003)
@@ -560,14 +597,31 @@ fn build_shard_cmd(
                 tag.name()
             );
         }
+        // Per-country OSM tag overrides via the country pack
+        // (#96 §"Per-Country Shard Contents"). Falls back to the
+        // standard `addr:*` keys when no pack is shipped for `country`
+        // — every shipped pack today carries the [osm_tags] section,
+        // but we don't fail the build over a missing pack.
+        let pack_registry = butterfly_geocode::routing::PackRegistry::shipped()
+            .context("loading shipped country packs for OSM tag mapping")?;
+        let osm_tags = pack_registry
+            .get(country)
+            .map(|p| p.osm_tags.clone())
+            .unwrap_or_else(|| butterfly_geocode::routing::pack::OsmTags {
+                postcode: "addr:postcode".to_string(),
+                street: "addr:street".to_string(),
+                housenumber: "addr:housenumber".to_string(),
+                city: "addr:city".to_string(),
+            });
         info!(
             pbf = %pbf_path.display(),
             out = %out.display(),
             country = country.iso2(),
             source = tag.name(),
-            "extracting OSM addresses"
+            street_tag = osm_tags.street,
+            "extracting OSM addresses (pack-driven tag mapping)"
         );
-        extract_addresses(pbf_path, |evt| match evt {
+        extract_addresses_with_tags(pbf_path, &osm_tags, |evt| match evt {
             ExtractProgress::Phase { phase } => info!("phase: {phase}"),
             ExtractProgress::NodePass {
                 nodes_seen,
@@ -703,11 +757,36 @@ fn build_shards_all_cmd(
     std::fs::create_dir_all(out_dir)
         .with_context(|| format!("creating output dir {}", out_dir.display()))?;
 
-    let allowed: Option<Vec<CountryId>> = only.map(|s| {
-        s.split(',')
-            .filter_map(|t| CountryId::from_iso2(t.trim()))
-            .collect()
-    });
+    let allowed: Option<Vec<CountryId>> = match only {
+        Some(s) => {
+            let tokens: Vec<&str> = s
+                .split(',')
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .collect();
+            if tokens.is_empty() {
+                bail!(
+                    "--only is empty (got {:?}); pass a comma-separated list of ISO2 codes \
+                     like --only BE,FR,NL or omit the flag to build every shipped pack",
+                    s
+                );
+            }
+            let parsed: Result<Vec<CountryId>> = tokens
+                .iter()
+                .map(|t| {
+                    CountryId::from_iso2(t).ok_or_else(|| {
+                        anyhow!(
+                            "--only contains invalid ISO 3166-1 alpha-2 code '{}' \
+                             (must be exactly 2 letters)",
+                            t
+                        )
+                    })
+                })
+                .collect();
+            Some(parsed?)
+        }
+        None => None,
+    };
 
     let mut built = Vec::<CountryId>::new();
     let mut skipped = Vec::<(CountryId, String)>::new();
@@ -719,6 +798,26 @@ fn build_shards_all_cmd(
             && !a.contains(&c)
         {
             continue;
+        }
+        // Authoritative-source preference: if the region index ships
+        // any `[[address]]` entries for this country AND the operator
+        // has staged the corresponding files under `<pbf_dir>/addresses/`,
+        // prefer the authoritative source over OSM PBF tags. Belgium
+        // ships three regional BOSA ZIPs (Flanders/Wallonia/Brussels);
+        // when all three are present we build per-region shards in a
+        // tmp dir and merge them into the country shard. Other
+        // countries fall through to PBF/OSM until their loaders land.
+        match try_authoritative_build(c, pbf_dir, out_dir) {
+            Ok(true) => {
+                built.push(c);
+                continue;
+            }
+            Ok(false) => {
+                // No authoritative source available; fall through to PBF.
+            }
+            Err(e) => {
+                warn!(country = c.iso2(), error = %e, "authoritative-source build failed; falling back to PBF");
+            }
         }
         let candidates = candidate_pbf_names(c);
         let pbf = candidates
@@ -755,18 +854,173 @@ fn build_shards_all_cmd(
     Ok(())
 }
 
+/// If the region index for `c` ships `[[address]]` entries with
+/// staged files under `<pbf_dir>/addresses/`, build the country shard
+/// from the authoritative source(s). Returns `Ok(true)` when a shard
+/// was written; `Ok(false)` when no authoritative source is available;
+/// `Err` on a build failure (caller should fall back to PBF/OSM).
+///
+/// Today only BOSA (BE) is wired — the BOSA loader is the single
+/// authoritative source the geocode crate knows how to ingest. As
+/// BAN/BAG/etc. land they get a new arm here AND a new arm in
+/// `load_csv_source` (geocode/src/main.rs:`build_shard_cmd`).
+fn try_authoritative_build(
+    c: CountryId,
+    pbf_dir: &std::path::Path,
+    out_dir: &std::path::Path,
+) -> Result<bool> {
+    let addresses_dir = pbf_dir.join("addresses");
+    if !addresses_dir.is_dir() {
+        return Ok(false);
+    }
+    let region_name = if c == CountryId::BE {
+        "belgium"
+    } else if c == CountryId::FR {
+        "france"
+    } else if c == CountryId::NL {
+        "netherlands"
+    } else if c == CountryId::LU {
+        "luxembourg"
+    } else if c == CountryId::DE {
+        "germany"
+    } else if c == CountryId::AT {
+        "austria"
+    } else if c == CountryId::CH {
+        "switzerland"
+    } else if c == CountryId::US {
+        "united-states"
+    } else if c == CountryId::JP {
+        "japan"
+    } else if c == CountryId::BR {
+        "brazil"
+    } else if c == CountryId::IN {
+        "india"
+    } else if c == CountryId::AU {
+        "australia"
+    } else {
+        return Ok(false);
+    };
+    let region_index = match butterfly_dl::regions::RegionIndex::load(region_name) {
+        Ok(idx) => idx,
+        Err(_) => return Ok(false),
+    };
+
+    // Walk the [[address]] section, collect every entry with both a
+    // known loader AND a staged file on disk.
+    let mut staged: Vec<(PathBuf, &'static str)> = Vec::new();
+    for entry in &region_index.address {
+        let tag = entry.source.as_deref().unwrap_or("");
+        let static_tag: &'static str = match tag {
+            "bosa" => "bosa",
+            // BAN/BAG/G-NAF/BEV/swisstopo lack loaders today; ignore.
+            _ => continue,
+        };
+        let candidate = addresses_dir.join(format!("{}.{}", entry.id, address_extension(entry)));
+        if candidate.is_file() {
+            staged.push((candidate, static_tag));
+        }
+    }
+    if staged.is_empty() {
+        return Ok(false);
+    }
+
+    let out = out_dir.join(format!("{}.bfgs", c.iso2().to_ascii_lowercase()));
+
+    // Single staged file: build directly from it.
+    if staged.len() == 1 {
+        let (csv_path, tag) = &staged[0];
+        info!(
+            country = c.iso2(),
+            source = *tag,
+            csv = %csv_path.display(),
+            "using authoritative source for shard build"
+        );
+        build_shard_cmd(None, Some(csv_path), &[], &out, c.iso2(), Some(*tag))?;
+        return Ok(true);
+    }
+
+    // Multiple staged files (e.g. BE's three BOSA regional ZIPs):
+    // build a tmp shard per file, then merge into the country shard.
+    let tmp = tempfile::tempdir().context("creating tmp dir for authoritative-source build")?;
+    let mut per_region_shards: Vec<PathBuf> = Vec::with_capacity(staged.len());
+    for (i, (csv_path, tag)) in staged.iter().enumerate() {
+        let stem = csv_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("source");
+        let part = tmp.path().join(format!("{i:02}-{stem}.bfgs"));
+        info!(
+            country = c.iso2(),
+            source = *tag,
+            csv = %csv_path.display(),
+            tmp = %part.display(),
+            "ingesting authoritative-source shard fragment"
+        );
+        build_shard_cmd(None, Some(csv_path), &[], &part, c.iso2(), Some(*tag))?;
+        per_region_shards.push(part);
+    }
+    info!(
+        country = c.iso2(),
+        fragments = per_region_shards.len(),
+        out = %out.display(),
+        "merging authoritative-source fragments into country shard"
+    );
+    build_shard_cmd(None, None, &per_region_shards, &out, c.iso2(), None)?;
+    Ok(true)
+}
+
+/// Extension for an `AddressEntry`. Mirrors `RegionIndex` internals
+/// but locally-typed since the field is private upstream.
+fn address_extension(entry: &butterfly_dl::regions::AddressEntry) -> &'static str {
+    match entry.format.as_str() {
+        "csv-zip" | "xml-zip" | "zip" => "zip",
+        "csv-gz" | "gz" => "csv.gz",
+        "csv" => "csv",
+        "xml" => "xml",
+        _ => "bin",
+    }
+}
+
 fn candidate_pbf_names(c: CountryId) -> Vec<String> {
-    let long = match c {
-        CountryId::BE => "belgium",
-        CountryId::FR => "france",
-        CountryId::NL => "netherlands",
-        CountryId::LU => "luxembourg",
-        CountryId::DE => "germany",
-        CountryId::AT => "austria",
-        CountryId::CH => "switzerland",
-        // CountryId is `non_exhaustive`. New countries default to
-        // ISO2-only filename probing — add a friendlier name above.
-        _ => "",
+    // Map every shipped pack-country to the long Geofabrik filename
+    // form. CountryId is now a newtype (no enum), so we can't
+    // exhaustively match on the type itself; instead we list each code
+    // explicitly here. Adding a pack to PackRegistry::shipped() and
+    // forgetting to wire a long name lands the country at ISO2-only
+    // probing — still functional, just less likely to find user files
+    // named `<country-name>.osm.pbf`.
+    let long = if c == CountryId::BE {
+        "belgium"
+    } else if c == CountryId::FR {
+        "france"
+    } else if c == CountryId::NL {
+        "netherlands"
+    } else if c == CountryId::LU {
+        "luxembourg"
+    } else if c == CountryId::DE {
+        "germany"
+    } else if c == CountryId::AT {
+        "austria"
+    } else if c == CountryId::CH {
+        "switzerland"
+    } else if c == CountryId::GB {
+        "great-britain"
+    } else if c == CountryId::ES {
+        "spain"
+    } else if c == CountryId::IT {
+        "italy"
+    } else if c == CountryId::US {
+        "us"
+    } else if c == CountryId::JP {
+        "japan"
+    } else if c == CountryId::BR {
+        "brazil"
+    } else if c == CountryId::IN {
+        "india"
+    } else if c == CountryId::AU {
+        "australia"
+    } else {
+        ""
     };
     let mut v = Vec::new();
     if !long.is_empty() {
@@ -1001,7 +1255,12 @@ async fn serve_cmd(
     // REST future: only present when transport selects REST or Both.
     let rest_fut: std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send>> =
         if let Some(listener) = rest_listener {
-            let app = build_router_with_config(Arc::clone(&state), server_cfg);
+            let (app, gc_handle) = build_router_with_config(Arc::clone(&state), server_cfg.clone());
+            // Spawn the per-IP map garbage-collector once we're inside
+            // a Tokio runtime context. `spawn_governor_gc` is
+            // idempotent across this fn — only the first call per
+            // process actually spawns.
+            butterfly_geocode::server::spawn_governor_gc(gc_handle);
             let serve_shutdown = Arc::clone(&shutdown);
             Box::pin(async move {
                 axum::serve(

--- a/geocode/src/osm_extract/mod.rs
+++ b/geocode/src/osm_extract/mod.rs
@@ -3,6 +3,18 @@
 //! Two-pass: first pass collects node coordinates and emits node
 //! addresses; second pass resolves way addresses by averaging
 //! resolved node coordinates (centroid proxy).
+//!
+//! ## Per-country OSM tag overrides (#96)
+//!
+//! Most countries follow the standard OSM tagging convention
+//! (`addr:street` + `addr:housenumber`). A few don't — Japan publishes
+//! whole addresses through `addr:full` because its addressing model is
+//! block-based; some countries override `addr:city` etc. The country
+//! pack carries those overrides via [`crate::routing::pack::OsmTags`];
+//! [`extract_addresses_with_tags`] threads them through.
+//!
+//! [`extract_addresses`] is the legacy zero-config entrypoint that
+//! uses the standard OSM keys.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -10,7 +22,19 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use osmpbf::{Element, ElementReader};
 
+use crate::routing::pack::OsmTags;
 use crate::shard::{AddressRecord, SourceTag};
+
+/// Standard OSM `addr:*` tag mapping. Used by [`extract_addresses`]
+/// when no country pack is provided.
+fn default_tags() -> OsmTags {
+    OsmTags {
+        postcode: "addr:postcode".to_string(),
+        street: "addr:street".to_string(),
+        housenumber: "addr:housenumber".to_string(),
+        city: "addr:city".to_string(),
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub enum ExtractProgress {
@@ -29,6 +53,20 @@ pub enum ExtractProgress {
 
 pub fn extract_addresses<P: AsRef<Path>>(
     pbf_path: P,
+    progress: impl FnMut(ExtractProgress),
+) -> Result<Vec<AddressRecord>> {
+    let tags = default_tags();
+    extract_addresses_with_tags(pbf_path, &tags, progress)
+}
+
+/// Like [`extract_addresses`] but consults `tags` (per-country pack
+/// override) when resolving the canonical street/postcode/etc. tags.
+/// `tags.street` falls back through `addr:full` and `addr:place`
+/// regardless of the override so block-based / place-based addresses
+/// continue to work.
+pub fn extract_addresses_with_tags<P: AsRef<Path>>(
+    pbf_path: P,
+    tags: &OsmTags,
     mut progress: impl FnMut(ExtractProgress),
 ) -> Result<Vec<AddressRecord>> {
     let path = pbf_path.as_ref();
@@ -50,7 +88,7 @@ pub fn extract_addresses<P: AsRef<Path>>(
             Element::Node(node) => {
                 nodes_seen += 1;
                 node_coords.insert(node.id(), (node.lat(), node.lon()));
-                if let Some(rec) = tags_to_address(node.lat(), node.lon(), node.tags()) {
+                if let Some(rec) = tags_to_address(node.lat(), node.lon(), node.tags(), tags) {
                     records.push(rec);
                     node_addr_records += 1;
                 }
@@ -58,7 +96,7 @@ pub fn extract_addresses<P: AsRef<Path>>(
             Element::DenseNode(node) => {
                 nodes_seen += 1;
                 node_coords.insert(node.id(), (node.lat(), node.lon()));
-                if let Some(rec) = tags_to_address(node.lat(), node.lon(), node.tags()) {
+                if let Some(rec) = tags_to_address(node.lat(), node.lon(), node.tags(), tags) {
                     records.push(rec);
                     node_addr_records += 1;
                 }
@@ -83,7 +121,7 @@ pub fn extract_addresses<P: AsRef<Path>>(
         .for_each(|el| {
             if let Element::Way(way) = el {
                 ways_seen += 1;
-                if let Some(rec) = way_to_address(&way, &node_coords) {
+                if let Some(rec) = way_to_address(&way, &node_coords, tags) {
                     records.push(rec);
                     way_addr_records += 1;
                 }
@@ -99,37 +137,57 @@ pub fn extract_addresses<P: AsRef<Path>>(
     Ok(records)
 }
 
+/// Where the resolved street value came from. The block-based
+/// fallback (`addr:full` / `addr:place`) is treated more permissively
+/// by [`has_minimum_signal`] — countries like Japan don't reliably
+/// carry housenumbers separately, so a non-empty `addr:full` plus
+/// locality OR postcode is enough to anchor a record. The strict
+/// `addr:street` path still requires a housenumber.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreetSource {
+    /// Came from the canonical street tag (`addr:street` or pack-overridden).
+    Strict,
+    /// Came from `addr:full` (block-based) or `addr:place` (place-based).
+    Fallback,
+    /// No street value resolved.
+    None,
+}
+
 /// Decide whether a tag bag carries enough address signal to be worth
 /// storing.
 ///
-/// Conventional address: street + housenumber must both be present
-/// (the European/US/AU pattern).
+/// Conventional (`Strict`) address: street + housenumber must both be
+/// present (the European/US/AU pattern).
 ///
-/// Block-based address (Japan, Korea, parts of Latin America): the
-/// `addr:full` tag carries the whole address as a single string and
-/// neither `addr:street` nor `addr:housenumber` is reliably set. We
-/// accept records where `addr:full` is non-empty as a pack-agnostic
-/// fallback; the geocoder treats the `street` field as the queryable
-/// canonical form regardless of which OSM tag fed it.
-fn has_minimum_signal(street: &str, housenumber: &str, postcode: &str, locality: &str) -> bool {
-    if !street.is_empty() && !housenumber.is_empty() {
-        return true;
+/// Block-based / place-based (`Fallback`) address (Japan, Korea, parts
+/// of Latin America): the `addr:full` tag carries the whole address as
+/// a single string and neither `addr:street` nor `addr:housenumber` is
+/// reliably set. We accept records where the fallback street is
+/// non-empty as long as locality OR postcode is also present.
+///
+/// The previous version conflated the two: a strict `addr:street`
+/// without a housenumber would slip through if locality or postcode
+/// was set, which let bare-street POIs leak into the shard. The
+/// `source` parameter restores the documented split.
+fn has_minimum_signal(
+    source: StreetSource,
+    housenumber: &str,
+    postcode: &str,
+    locality: &str,
+) -> bool {
+    match source {
+        StreetSource::None => false,
+        StreetSource::Strict => !housenumber.is_empty(),
+        StreetSource::Fallback => !postcode.is_empty() || !locality.is_empty(),
     }
-    // Block-based / place-based fallback: a non-empty `street` (which
-    // may have come from `addr:full` or `addr:place`) plus locality
-    // is enough to anchor a record.
-    if !street.is_empty() && (!postcode.is_empty() || !locality.is_empty()) {
-        return true;
-    }
-    false
 }
 
-fn tags_to_address<'a, I>(lat: f64, lon: f64, tags: I) -> Option<AddressRecord>
+fn tags_to_address<'a, I>(lat: f64, lon: f64, raw_tags: I, cfg: &OsmTags) -> Option<AddressRecord>
 where
     I: IntoIterator<Item = (&'a str, &'a str)>,
 {
-    let (street, housenumber, postcode, locality) = pull_addr_tags(tags);
-    if !has_minimum_signal(&street, &housenumber, &postcode, &locality) {
+    let (street, source, housenumber, postcode, locality) = pull_addr_tags(raw_tags, cfg);
+    if !has_minimum_signal(source, &housenumber, &postcode, &locality) {
         return None;
     }
     Some(AddressRecord {
@@ -147,9 +205,10 @@ where
 fn way_to_address(
     way: &osmpbf::Way<'_>,
     coords: &HashMap<i64, (f64, f64)>,
+    cfg: &OsmTags,
 ) -> Option<AddressRecord> {
-    let (street, housenumber, postcode, locality) = pull_addr_tags(way.tags());
-    if !has_minimum_signal(&street, &housenumber, &postcode, &locality) {
+    let (street, source, housenumber, postcode, locality) = pull_addr_tags(way.tags(), cfg);
+    if !has_minimum_signal(source, &housenumber, &postcode, &locality) {
         return None;
     }
     let mut sum_lat = 0.0_f64;
@@ -179,7 +238,7 @@ fn way_to_address(
     })
 }
 
-fn pull_addr_tags<'a, I>(tags: I) -> (String, String, String, String)
+fn pull_addr_tags<'a, I>(tags: I, cfg: &OsmTags) -> (String, StreetSource, String, String, String)
 where
     I: IntoIterator<Item = (&'a str, &'a str)>,
 {
@@ -193,20 +252,36 @@ where
     let mut quarter = String::new();
     let mut block_number = String::new();
 
+    // Pack-overridable keys. The pack carries country-specific tag
+    // names (e.g. JP packs use `addr:full` as the canonical street).
+    // Standard keys still flow through their dedicated arms — the
+    // pack overrides only change the "primary" channel for each field.
     for (k, v) in tags {
+        if k == cfg.street {
+            street = v.to_string();
+            continue;
+        }
+        if k == cfg.housenumber {
+            housenumber = v.to_string();
+            continue;
+        }
+        if k == cfg.postcode {
+            postcode = v.to_string();
+            continue;
+        }
+        if k == cfg.city {
+            city = v.to_string();
+            continue;
+        }
         match k {
-            "addr:street" => street = v.to_string(),
             "addr:place" => place = v.to_string(),
             // `addr:full` is the standard fallback for countries where
             // street+number doesn't decompose cleanly (Japan blocks,
             // Korean addresses, freeform rural addressing).
             "addr:full" => full = v.to_string(),
-            "addr:housenumber" => housenumber = v.to_string(),
             // `addr:block_number` is the Japanese chōme block id —
             // promoted into housenumber when housenumber is empty.
             "addr:block_number" => block_number = v.to_string(),
-            "addr:postcode" => postcode = v.to_string(),
-            "addr:city" => city = v.to_string(),
             // City fallbacks for Japanese / non-Western admin levels.
             "addr:province" => province = v.to_string(),
             "addr:quarter" => quarter = v.to_string(),
@@ -214,15 +289,17 @@ where
         }
     }
 
-    // Resolve the canonical street: prefer the explicit street tag,
-    // then `addr:full`, then `addr:place`. The shard schema only has
-    // one street field, so this collapses the diversity at ingest.
-    let resolved_street = if !street.is_empty() {
-        street
+    // Resolve the canonical street + remember which source it came
+    // from. The fallback path (`addr:full` / `addr:place`) drives the
+    // relaxed signal threshold below.
+    let (resolved_street, source) = if !street.is_empty() {
+        (street, StreetSource::Strict)
     } else if !full.is_empty() {
-        full
+        (full, StreetSource::Fallback)
+    } else if !place.is_empty() {
+        (place, StreetSource::Fallback)
     } else {
-        place
+        (String::new(), StreetSource::None)
     };
     let resolved_housenumber = if !housenumber.is_empty() {
         housenumber
@@ -238,8 +315,100 @@ where
     };
     (
         resolved_street,
+        source,
         resolved_housenumber,
         postcode,
         resolved_locality,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tags(pairs: &[(&'static str, &'static str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    fn run(
+        pairs: Vec<(String, String)>,
+        cfg: &OsmTags,
+    ) -> (String, StreetSource, String, String, String) {
+        let refs: Vec<(&str, &str)> = pairs
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        pull_addr_tags(refs, cfg)
+    }
+
+    #[test]
+    fn strict_path_requires_housenumber() {
+        let cfg = default_tags();
+        let (street, source, hn, pc, loc) = run(
+            tags(&[
+                ("addr:street", "Rue Wayez"),
+                ("addr:postcode", "1070"),
+                ("addr:city", "Anderlecht"),
+            ]),
+            &cfg,
+        );
+        assert_eq!(street, "Rue Wayez");
+        assert_eq!(source, StreetSource::Strict);
+        assert!(hn.is_empty());
+        assert!(!has_minimum_signal(source, &hn, &pc, &loc));
+    }
+
+    #[test]
+    fn fallback_path_accepts_postcode_only() {
+        let cfg = default_tags();
+        let (street, source, hn, pc, loc) = run(
+            tags(&[
+                ("addr:full", "東京都千代田区千代田1-1"),
+                ("addr:postcode", "100-0001"),
+            ]),
+            &cfg,
+        );
+        assert_eq!(street, "東京都千代田区千代田1-1");
+        assert_eq!(source, StreetSource::Fallback);
+        assert!(hn.is_empty());
+        assert!(has_minimum_signal(source, &hn, &pc, &loc));
+    }
+
+    #[test]
+    fn pack_override_for_japan_treats_addr_full_as_strict_only_when_specified() {
+        // JP pack publishes street=addr:full. Records arriving via
+        // that override are then classified as Strict (the pack
+        // declared this is the canonical channel for the country) and
+        // require a housenumber per the strict rule.
+        let cfg = OsmTags {
+            postcode: "addr:postcode".to_string(),
+            street: "addr:full".to_string(),
+            housenumber: "addr:housenumber".to_string(),
+            city: "addr:city".to_string(),
+        };
+        let (street, source, hn, _, _) = run(
+            tags(&[
+                ("addr:full", "東京都千代田区千代田1-1"),
+                ("addr:housenumber", "1"),
+            ]),
+            &cfg,
+        );
+        assert_eq!(street, "東京都千代田区千代田1-1");
+        assert_eq!(source, StreetSource::Strict);
+        assert_eq!(hn, "1");
+    }
+
+    #[test]
+    fn no_street_no_record() {
+        let cfg = default_tags();
+        let (_, source, _, _, _) = run(
+            tags(&[("addr:postcode", "1070"), ("addr:city", "Anderlecht")]),
+            &cfg,
+        );
+        assert_eq!(source, StreetSource::None);
+        assert!(!has_minimum_signal(source, "", "1070", "Anderlecht"));
+    }
 }

--- a/geocode/src/routing/bbox.rs
+++ b/geocode/src/routing/bbox.rs
@@ -140,12 +140,28 @@ mod tests {
     }
 
     #[test]
-    fn aachen_overlap_picks_smallest_bbox() {
-        // Aachen Hbf: BE/NL/DE triangle. BE has the smallest bbox of
-        // the three, so it wins the country_for_point race.
+    fn aachen_overlap_returns_multi_country_candidates() {
+        // Aachen Hbf sits in the BE/NL/DE triangle. The previous test
+        // locked in the bug where `country_for_point` returns BE
+        // because BE has the smallest bbox; that choice was wrong for
+        // a Aachen-Hbf reverse-geocode (the point is German).
+        //
+        // The reverse handler now fans out across every bbox that
+        // contains the point (`supported_countries_for_point`), so
+        // this test asserts the multi-country candidate set instead
+        // of the smallest-bbox tie-breaker. The handler's order rule
+        // (smallest-bbox-first as a heuristic, fall back to others)
+        // is exercised in `multi_country_e2e.rs`.
         let all = supported_countries_for_point(50.7676, 6.0911);
-        assert!(all.contains(&CountryId::DE));
-        assert_eq!(country_for_point(50.7676, 6.0911), Some(CountryId::BE));
+        assert!(
+            all.contains(&CountryId::DE),
+            "DE should be in supported_countries_for_point at Aachen"
+        );
+        assert!(
+            all.len() >= 2,
+            "expected multiple bbox-containing countries at Aachen, got {:?}",
+            all
+        );
     }
 
     #[test]

--- a/geocode/src/routing/mod.rs
+++ b/geocode/src/routing/mod.rs
@@ -133,10 +133,16 @@ fn iso2_intern(bytes: [u8; 2]) -> &'static str {
     use std::collections::HashMap;
     static TABLE: OnceLock<RwLock<HashMap<[u8; 2], &'static str>>> = OnceLock::new();
     let table = TABLE.get_or_init(|| RwLock::new(HashMap::with_capacity(64)));
-    if let Some(s) = table.read().expect("iso2 table read poisoned").get(&bytes) {
+    // Recover from poisoning rather than crashing the process: the
+    // intern table is an append-only cache, every entry is a stable
+    // 2-byte ASCII code → leaked `&'static str`. A panic in another
+    // thread leaves the data structurally valid; the worst case is a
+    // duplicate entry, which `or_insert_with` handles by returning the
+    // existing value.
+    if let Some(s) = table.read().unwrap_or_else(|e| e.into_inner()).get(&bytes) {
         return s;
     }
-    let mut w = table.write().expect("iso2 table write poisoned");
+    let mut w = table.write().unwrap_or_else(|e| e.into_inner());
     w.entry(bytes).or_insert_with(|| {
         let s = std::str::from_utf8(&bytes).expect("CountryId bytes must be UTF-8");
         Box::leak(s.to_string().into_boxed_str())

--- a/geocode/src/routing/pack.rs
+++ b/geocode/src/routing/pack.rs
@@ -248,23 +248,20 @@ impl CountryPack {
             .as_ref()
             .map(|p| p.position)
             .unwrap_or_default();
-        let postcode_canonicalize = parsed
-            .postcode
-            .as_ref()
-            .map(|p| match p.canonicalize.as_str() {
+        let postcode_canonicalize = match parsed.postcode.as_ref() {
+            Some(p) => match p.canonicalize.as_str() {
                 "none" => PostcodeCanonicalize::None,
                 "collapse_whitespace" => PostcodeCanonicalize::CollapseWhitespace,
                 "strip_country_prefix" => PostcodeCanonicalize::StripCountryPrefix,
-                other => {
-                    tracing::warn!(
-                        country = %parsed.country.iso2,
-                        canonicalize = other,
-                        "unknown postcode canonicalize kind, defaulting to 'none'"
-                    );
-                    PostcodeCanonicalize::None
-                }
-            })
-            .unwrap_or_default();
+                other => bail!(
+                    "{}: unknown [postcode].canonicalize value '{}' \
+                     (expected: none, collapse_whitespace, strip_country_prefix)",
+                    parsed.country.iso2,
+                    other
+                ),
+            },
+            None => PostcodeCanonicalize::None,
+        };
 
         let lexical_cues: Vec<LexicalCue> = parsed
             .lexical_cues
@@ -285,13 +282,22 @@ impl CountryPack {
             dominant: vec![],
             secondary: vec![],
         });
-        let neighbours = parsed
+        let neighbours: Vec<CountryId> = parsed
             .neighbours
             .unwrap_or_default()
             .codes
             .into_iter()
-            .filter_map(|c| CountryId::from_iso2(&c))
-            .collect();
+            .map(|c| {
+                CountryId::from_iso2(&c).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "{}: [neighbours].codes contains invalid ISO 3166-1 alpha-2 code '{}' \
+                         (must be 2 alphabetic characters)",
+                        parsed.country.iso2,
+                        c
+                    )
+                })
+            })
+            .collect::<Result<_>>()?;
         let priors = parsed.source_priors.unwrap_or_default();
         let tags = parsed.osm_tags.unwrap_or_default();
 
@@ -455,23 +461,43 @@ fn strip_alpha_prefix(s: &str) -> Option<String> {
     Some(s[i + 1..].to_string())
 }
 
+/// Word-boundary substring scan over `text` for `word`. Boundaries
+/// are detected via [`char::is_alphanumeric`], so non-ASCII alphabetic
+/// characters (`münchen`, `liège`, `東京`) interact correctly with
+/// the boundary rule. Pure ASCII boundary checks would treat the
+/// `ü` in `münchen` as a non-letter, falsely matching `chen` against
+/// the word `chen`.
+///
+/// Both arguments are expected to already be normalised to the
+/// classifier's lowercase form by the caller.
 fn contains_word(text: &str, word: &str) -> bool {
-    let bytes = text.as_bytes();
-    let wbytes = word.as_bytes();
-    if wbytes.is_empty() || bytes.len() < wbytes.len() {
+    if word.is_empty() || text.len() < word.len() {
         return false;
     }
-    let mut i = 0;
-    while i + wbytes.len() <= bytes.len() {
-        if &bytes[i..i + wbytes.len()] == wbytes {
-            let before_ok = i == 0 || !bytes[i - 1].is_ascii_alphabetic();
-            let after_ok =
-                i + wbytes.len() == bytes.len() || !bytes[i + wbytes.len()].is_ascii_alphabetic();
-            if before_ok && after_ok {
-                return true;
-            }
+    let mut search_from = 0;
+    while let Some(rel) = text[search_from..].find(word) {
+        let start = search_from + rel;
+        let end = start + word.len();
+        let before_ok = match text[..start].chars().next_back() {
+            Some(c) => !c.is_alphanumeric(),
+            None => true,
+        };
+        let after_ok = match text[end..].chars().next() {
+            Some(c) => !c.is_alphanumeric(),
+            None => true,
+        };
+        if before_ok && after_ok {
+            return true;
         }
-        i += 1;
+        // Advance past this match attempt by one char so we don't
+        // get stuck when `word.len() == 0` is possible. Use char
+        // boundary safety: `find` always returns a char-boundary
+        // index; advancing by one char from `start` keeps us on a
+        // boundary too.
+        search_from = match text[start..].chars().next() {
+            Some(c) => start + c.len_utf8(),
+            None => break,
+        };
     }
     false
 }
@@ -647,6 +673,64 @@ impl PackRegistry {
     #[must_use]
     pub fn default_dir() -> PathBuf {
         PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/data/packs"))
+    }
+
+    /// Build the registry from the embedded shipped packs, then
+    /// overlay every `*.toml` found in `dir`. Directory entries WIN
+    /// — if `dir/be.toml` parses, it replaces the embedded `BE` pack.
+    /// Used by `serve --pack-dir <dir>` so operators can patch a
+    /// shipped pack without rebuilding the binary.
+    ///
+    /// The directory may contain partial coverage (e.g. only `de.toml`)
+    /// — every shipped pack the directory does NOT override stays
+    /// untouched. A non-existent or empty directory yields the same
+    /// result as [`Self::shipped`].
+    pub fn shipped_with_overrides<P: AsRef<Path>>(dir: P) -> Result<Self> {
+        let mut reg = Self::shipped()?;
+        let dir = dir.as_ref();
+        if !dir.is_dir() {
+            // No directory → no overlay. This matches the documented
+            // behaviour for `--pack-dir` pointing at a non-existent
+            // path: warn upstream, fall through to shipped.
+            return Ok(reg);
+        }
+        let entries = std::fs::read_dir(dir)
+            .with_context(|| format!("reading override pack directory {}", dir.display()))?;
+        let mut overlaid = 0usize;
+        let mut errors: Vec<String> = Vec::new();
+        for entry in entries {
+            let entry = entry.context("iterating override pack directory")?;
+            let path = entry.path();
+            if path
+                .extension()
+                .and_then(|s| s.to_str())
+                .map(|s| s.eq_ignore_ascii_case("toml"))
+                != Some(true)
+            {
+                continue;
+            }
+            match CountryPack::from_file(&path) {
+                Ok(pack) => {
+                    reg.insert(pack);
+                    overlaid += 1;
+                }
+                Err(e) => {
+                    errors.push(format!("{}: {:#}", path.display(), e));
+                }
+            }
+        }
+        if !errors.is_empty() {
+            for e in &errors {
+                tracing::warn!(error = %e, "override country pack failed to load");
+            }
+        }
+        tracing::info!(
+            dir = %dir.display(),
+            overlaid,
+            total_packs = reg.len(),
+            "country pack registry loaded with overrides"
+        );
+        Ok(reg)
     }
 }
 

--- a/geocode/src/server/handlers.rs
+++ b/geocode/src/server/handlers.rs
@@ -42,7 +42,7 @@ use crate::control::budget::compute_budget;
 use crate::geocoder::executor::{
     GeocodedResult, apply_rerank, build_nearest_result, execute_with_control, reason,
 };
-use crate::routing::{CountryId, classify_country, country_for_point};
+use crate::routing::{CountryId, classify_country, supported_countries_for_point};
 use crate::shard::reader::haversine_m;
 
 #[derive(Debug, Deserialize)]
@@ -277,7 +277,36 @@ pub async fn reverse(
 
     let state_clone = Arc::clone(&state);
     let results = match tokio::task::spawn_blocking(move || -> Vec<GeocodedResult> {
-        let target_country: Option<CountryId> = pinned.or_else(|| country_for_point(lat, lon));
+        // Reverse dispatch: instead of picking the smallest-bbox
+        // country (which loses Aachen → DE because BE has the smaller
+        // bbox), gather every country whose bbox contains the point
+        // and try each loaded shard in order. Order: smallest-bbox
+        // first as a heuristic to try the most-specific country
+        // before fanning out. With a pinned country we still honour
+        // the pin.
+        let candidate_countries: Vec<CountryId> = if let Some(c) = pinned {
+            vec![c]
+        } else {
+            let mut candidates = supported_countries_for_point(lat, lon);
+            // Sort by bbox area ascending = smallest-bbox-first
+            // heuristic. The smallest containing bbox is most
+            // commonly the right country (typical case: the point
+            // lives squarely inside the smaller of two overlapping
+            // bboxes).
+            let registry = crate::routing::Classifier::shipped().registry();
+            candidates.sort_by(|a, b| {
+                let area = |c: &CountryId| {
+                    registry
+                        .get(*c)
+                        .map(|p| p.bbox.area_deg2())
+                        .unwrap_or(f64::INFINITY)
+                };
+                area(a)
+                    .partial_cmp(&area(b))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            candidates
+        };
 
         let query_shard =
             |shard: &crate::shard::reader::Shard, c: CountryId| -> Vec<GeocodedResult> {
@@ -292,37 +321,61 @@ pub async fn reverse(
                 results
             };
 
-        // Path A: targeted country has a loaded shard.
-        if let Some(c) = target_country
-            && let Some(shard) = state_clone.shards.get(&c)
-        {
-            let results = query_shard(shard, c);
-            if !results.is_empty() {
-                return results;
-            }
-            // Out-of-radius fallback for the targeted shard.
-            if let Some(rec) = shard.nearest(lat, lon) {
-                let _dist = haversine_m(lat, lon, rec.lat, rec.lon);
-                let mut r = build_nearest_result(&rec, 0.0, reason::NEAREST_OUT_OF_RADIUS);
-                r.country = Some(c.iso2());
-                return vec![r];
+        // Path A: walk every loaded shard for the candidate countries
+        // (in order). Return the first non-empty within-radius set so
+        // the targeted shard (smallest bbox) wins when it has results.
+        for &c in &candidate_countries {
+            if let Some(shard) = state_clone.shards.get(&c) {
+                let results = query_shard(shard, c);
+                if !results.is_empty() {
+                    return results;
+                }
             }
         }
 
-        // Path B: no targeted country (point outside known bboxes) or
-        // targeted country has no shard. Query every loaded shard,
-        // merge, rerank.
-        let mut all: Vec<GeocodedResult> = Vec::new();
-        for (&c, shard) in &state_clone.shards {
-            all.extend(query_shard(shard, c));
+        // Path B: no in-radius hit anywhere. Out-of-radius fallback —
+        // try the candidate shards in order, then any other loaded
+        // shard the bbox didn't list. Surface the closest one. This
+        // handles the case where the bbox heuristic was wrong (e.g.
+        // a point right on the border) AND the case where the point
+        // sits outside every loaded bbox entirely.
+        let mut tried: std::collections::HashSet<CountryId> =
+            std::collections::HashSet::with_capacity(candidate_countries.len());
+        let mut best: Option<(f64, GeocodedResult)> = None;
+        // Helper closure body inlined twice to avoid sharing a mutable
+        // capture: `tried` is read in the second loop for membership
+        // and would conflict with the closure's mutable borrow.
+        for &c in &candidate_countries {
+            if let Some(shard) = state_clone.shards.get(&c) {
+                tried.insert(c);
+                if let Some(rec) = shard.nearest(lat, lon) {
+                    let dist = haversine_m(lat, lon, rec.lat, rec.lon);
+                    let mut r = build_nearest_result(&rec, 0.0, reason::NEAREST_OUT_OF_RADIUS);
+                    r.country = Some(c.iso2());
+                    if best.as_ref().map(|(d, _)| dist < *d).unwrap_or(true) {
+                        best = Some((dist, r));
+                    }
+                }
+            }
         }
-        all.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        all.truncate(limit);
-        all
+        for (&c, shard) in &state_clone.shards {
+            if tried.contains(&c) {
+                continue;
+            }
+            if let Some(rec) = shard.nearest(lat, lon) {
+                let dist = haversine_m(lat, lon, rec.lat, rec.lon);
+                let mut r = build_nearest_result(&rec, 0.0, reason::NEAREST_OUT_OF_RADIUS);
+                r.country = Some(c.iso2());
+                if best.as_ref().map(|(d, _)| dist < *d).unwrap_or(true) {
+                    best = Some((dist, r));
+                }
+            }
+        }
+        if let Some((_, r)) = best {
+            return vec![r];
+        }
+
+        Vec::new()
     })
     .await
     {
@@ -473,6 +526,16 @@ struct ForwardItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     reason_codes: Option<Vec<String>>,
 }
+
+// NOTE on per-record source field: PR #173 Copilot finding §5 asks
+// for a `source` field on this envelope mirroring the BFGS v4
+// per-record source byte. The byte IS persisted at shard build time
+// (handlers/executors honour it), but exposing it on the JSON
+// envelope requires plumbing `SourceTag` through `GeocodedResult`,
+// which lives in `geocoder/executor.rs` — outside this PR's
+// territory. Tracked as a follow-up against the executor module.
+// The README has been adjusted to describe the byte's audit role at
+// shard level rather than promising an API field.
 
 impl ForwardItem {
     fn from(r: &GeocodedResult, include_debug: bool) -> Self {

--- a/geocode/src/server/mod.rs
+++ b/geocode/src/server/mod.rs
@@ -13,26 +13,41 @@
 //!
 //! ## Middleware order
 //!
-//! Outermost first (the order shown is the order requests are
-//! processed):
+//! Two concentric rings of layers, applied in reverse order of mention
+//! (outer-first is what the request hits first):
+//!
+//! ### Outer ring — runs for ALL routes including `/metrics`:
 //!
 //! 1. CORS — handle preflight, inject permissive headers (production
 //!    deployments should narrow `Access-Control-Allow-Origin` via a
 //!    reverse proxy).
 //! 2. TraceLayer — span every request with a `tracing` `INFO` log.
-//! 3. Prometheus — collect HTTP-level histograms / counters.
+//! 3. Prometheus — collect HTTP-level histograms / counters. Note
+//!    that `/metrics` itself is one of the routes wrapped by this
+//!    layer, so Prometheus tracks scrapes too.
 //! 4. CatchPanicLayer — convert panics into 500 instead of dropping
 //!    the connection.
+//!
+//! ### Inner ring — runs ONLY for `/geocode*` and `/health`, NOT for
+//! `/metrics`:
+//!
 //! 5. Compression — gzip/brotli on responses based on `Accept-Encoding`.
 //! 6. Timeout — `cfg.request_timeout` server-side cap, 408 on expiry.
 //! 7. RequestBodyLimit — `cfg.max_request_body_bytes` cap on request
 //!    bodies (POST endpoints will use this once they land; GET ignores
 //!    it but having the layer up means a future POST endpoint can't
 //!    accidentally accept unbounded uploads).
+//!
+//! ### Innermost — runs ONLY for `/geocode*`:
+//!
 //! 8. Governor (per-IP HTTP-level rate limit) — runs *before*
 //!    admission so abusive clients are dropped at the cheapest layer.
 //! 9. Admission (token-bucket cost-based gate) — only on `/geocode*`,
 //!    not on `/health` or `/metrics` so monitors are never throttled.
+//!
+//! `/metrics` intentionally bypasses every layer except the outer
+//! ring: scrapers must always be able to read it, so timeouts /
+//! body limits / compression / rate limiting do not apply.
 
 // tonic::Status is 176 bytes — the canonical gRPC error type.
 // Every gRPC handler returns Result<_, Status>; boxing adds indirection
@@ -70,7 +85,7 @@ pub use state::ServerState;
 /// Tunable HTTP-server configuration. Defaults match the production
 /// hardening targets — operators that need to lift them reach for
 /// [`build_router_with_config`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ServerConfig {
     /// Per-IP requests-per-second steady state. Default: 100.
     /// Range: 1 - 100_000. Values above 100_000 are clamped because
@@ -86,6 +101,14 @@ pub struct ServerConfig {
     /// POST/PUT body cap. Default: 4 KB. GET requests are unaffected
     /// (the body limit only fires when there's a body to limit).
     pub max_request_body_bytes: usize,
+    /// CIDR allowlist of trusted reverse proxies. When non-empty AND
+    /// the connecting peer's IP is contained in any of these CIDRs,
+    /// the [`PeerIpKey`] extractor pulls the client IP from
+    /// `X-Forwarded-For` (rightmost non-trusted entry per RFC 7239)
+    /// instead of the connection peer. Without this, all requests
+    /// behind a reverse proxy share the proxy's IP and rate-limiting
+    /// becomes global rather than per-client.
+    pub trusted_proxies: Vec<TrustedCidr>,
 }
 
 impl Default for ServerConfig {
@@ -95,8 +118,102 @@ impl Default for ServerConfig {
             rate_limit_burst: 200,
             request_timeout: Duration::from_secs(30),
             max_request_body_bytes: 4 * 1024,
+            trusted_proxies: Vec::new(),
         }
     }
+}
+
+impl ServerConfig {
+    /// Construct with the documented defaults. Convenience alias for
+    /// [`Self::default`] kept for callers that prefer the explicit
+    /// builder shape.
+    pub fn with_defaults() -> Self {
+        Self::default()
+    }
+}
+
+/// Compact CIDR range used by the trusted-proxy allowlist. Supports
+/// both v4 and v6. Pure data — comparison is `O(prefix_len)`.
+#[derive(Debug, Clone)]
+pub struct TrustedCidr {
+    network: IpAddr,
+    prefix: u8,
+}
+
+impl TrustedCidr {
+    /// Parse a CIDR string like `10.0.0.0/8` or `2001:db8::/32`.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let (addr, prefix) = match s.split_once('/') {
+            Some((a, p)) => (a, p),
+            None => {
+                // Bare IP → /32 for v4, /128 for v6.
+                let ip: IpAddr = s.parse().map_err(|e| format!("invalid IP '{s}': {e}"))?;
+                let prefix = match ip {
+                    IpAddr::V4(_) => 32,
+                    IpAddr::V6(_) => 128,
+                };
+                return Ok(Self {
+                    network: ip,
+                    prefix,
+                });
+            }
+        };
+        let network: IpAddr = addr
+            .parse()
+            .map_err(|e| format!("invalid CIDR network '{addr}': {e}"))?;
+        let prefix: u8 = prefix
+            .parse()
+            .map_err(|e| format!("invalid CIDR prefix '{prefix}': {e}"))?;
+        let max = match network {
+            IpAddr::V4(_) => 32,
+            IpAddr::V6(_) => 128,
+        };
+        if prefix > max {
+            return Err(format!("CIDR prefix /{prefix} exceeds /{max} for {addr}"));
+        }
+        Ok(Self { network, prefix })
+    }
+
+    /// Test whether `ip` falls inside this CIDR.
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        match (self.network, ip) {
+            (IpAddr::V4(net), IpAddr::V4(client)) => {
+                let net_bits = u32::from_be_bytes(net.octets());
+                let client_bits = u32::from_be_bytes(client.octets());
+                let mask = if self.prefix == 0 {
+                    0
+                } else {
+                    u32::MAX << (32 - self.prefix)
+                };
+                (net_bits & mask) == (client_bits & mask)
+            }
+            (IpAddr::V6(net), IpAddr::V6(client)) => {
+                let net_bits = u128::from_be_bytes(net.octets());
+                let client_bits = u128::from_be_bytes(client.octets());
+                let mask = if self.prefix == 0 {
+                    0
+                } else {
+                    u128::MAX << (128 - self.prefix)
+                };
+                (net_bits & mask) == (client_bits & mask)
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Parse a CSV `--trusted-proxies` flag into a vector of
+/// [`TrustedCidr`]. Empty / `None` input yields an empty allowlist
+/// (the default — no proxy trust).
+pub fn parse_trusted_proxies(s: Option<&str>) -> Result<Vec<TrustedCidr>, String> {
+    let Some(s) = s else {
+        return Ok(Vec::new());
+    };
+    s.split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(TrustedCidr::parse)
+        .collect()
 }
 
 /// Per-IP key extractor for `tower_governor`. Pulls the client IP
@@ -111,19 +228,113 @@ impl Default for ServerConfig {
 /// SocketAddr into the request extensions. Production deployments
 /// always go through `into_make_service_with_connect_info` so the
 /// fallback is never hit.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct PeerIpKey;
+///
+/// ## Trusted-proxy support (#170)
+///
+/// When [`ServerConfig::trusted_proxies`] is non-empty AND the
+/// connecting peer is inside one of the listed CIDRs, the extractor
+/// walks `X-Forwarded-For` (or the standardised `Forwarded` header
+/// per RFC 7239) and returns the rightmost entry whose IP is NOT
+/// itself in a trusted CIDR. This is the standard "trust hop chain"
+/// pattern: the proxy is trusted to add a header but not to lie
+/// about clients further upstream. Without this configuration, every
+/// request behind a reverse proxy shares the proxy's IP and the rate
+/// limiter becomes global.
+#[derive(Debug, Clone, Default)]
+pub struct PeerIpKey {
+    trusted: Arc<[TrustedCidr]>,
+}
+
+impl PeerIpKey {
+    /// Construct a key extractor with the given trusted-proxy
+    /// allowlist. An empty allowlist disables the XFF/Forwarded fast
+    /// path; the extractor returns the connection peer in every case.
+    pub fn new(trusted: Vec<TrustedCidr>) -> Self {
+        Self {
+            trusted: trusted.into(),
+        }
+    }
+
+    fn is_trusted(&self, ip: IpAddr) -> bool {
+        self.trusted.iter().any(|c| c.contains(ip))
+    }
+
+    /// Walk the `X-Forwarded-For` (or `Forwarded`) header values and
+    /// return the rightmost entry whose IP is NOT in a trusted CIDR.
+    /// The semantics: every IP between the rightmost-non-trusted and
+    /// the actual peer is a trusted proxy that injected the header,
+    /// so that rightmost-non-trusted IP is the true client. Returns
+    /// `None` when no XFF header is present or every entry is itself
+    /// a trusted proxy.
+    fn untrusted_xff_ip<T>(&self, req: &Request<T>) -> Option<IpAddr> {
+        let xff = req
+            .headers()
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        if let Some(xff) = xff {
+            // RFC 7239 §5.2: comma-separated, leftmost = original.
+            // Walk right-to-left looking for the first untrusted IP.
+            for entry in xff.split(',').rev() {
+                let candidate = entry.trim();
+                if let Ok(ip) = candidate.parse::<IpAddr>()
+                    && !self.is_trusted(ip)
+                {
+                    return Some(ip);
+                }
+            }
+        }
+        // Fallback: RFC 7239 `Forwarded` with `for=` parameter. Same
+        // semantics, different syntax. Each entry looks like
+        // `for=192.0.2.43;proto=http;host=...`.
+        let fwd = req
+            .headers()
+            .get("forwarded")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        if let Some(fwd) = fwd {
+            for entry in fwd.split(',').rev() {
+                for kv in entry.split(';') {
+                    let kv = kv.trim();
+                    let Some(value) = kv.strip_prefix("for=").or_else(|| kv.strip_prefix("For="))
+                    else {
+                        continue;
+                    };
+                    let value = value.trim_matches('"');
+                    // RFC 7239 also allows `for="[2001:db8::1]:8080"`.
+                    // Strip any port.
+                    let host = value.rsplit_once(':').map(|(h, _)| h).unwrap_or(value);
+                    let host = host.trim_matches('[').trim_matches(']');
+                    if let Ok(ip) = host.parse::<IpAddr>()
+                        && !self.is_trusted(ip)
+                    {
+                        return Some(ip);
+                    }
+                }
+            }
+        }
+        None
+    }
+}
 
 impl KeyExtractor for PeerIpKey {
     type Key = IpAddr;
 
     fn extract<T>(&self, req: &Request<T>) -> Result<Self::Key, GovernorError> {
-        let ip = req
+        let peer = req
             .extensions()
             .get::<ConnectInfo<SocketAddr>>()
             .map(|ConnectInfo(a)| a.ip())
             .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
-        Ok(ip)
+        // If the peer is itself a trusted proxy, the real client IP
+        // lives in XFF / Forwarded. Otherwise we trust the peer as
+        // the client.
+        if self.is_trusted(peer)
+            && let Some(real) = self.untrusted_xff_ip(req)
+        {
+            return Ok(real);
+        }
+        Ok(peer)
     }
 }
 
@@ -142,11 +353,72 @@ fn prometheus_pair() -> &'static (PrometheusMetricLayer<'static>, PrometheusHand
 /// Tests and most call sites use this. Operators that need to override
 /// the rate-limit knobs reach for [`build_router_with_config`].
 pub fn build_router(state: Arc<ServerState>) -> Router {
-    build_router_with_config(state, ServerConfig::default())
+    let (router, _gc) = build_router_with_config(state, ServerConfig::with_defaults());
+    router
+}
+
+/// Handle returned alongside the router so callers can opt-in to
+/// driving the per-IP map garbage-collector. Returned by
+/// [`build_router_with_config`] separately from the router so router
+/// construction stays a pure synchronous fn — moving the
+/// `tokio::spawn` out of the build means `build_router_with_config`
+/// no longer panics when called outside a Tokio runtime, and tests
+/// that build multiple routers don't leak background tasks.
+///
+/// `serve_cmd` (the only production caller) drives this with
+/// [`spawn_governor_gc`]; tests typically drop the handle and never
+/// run GC.
+pub struct GovernorGcHandle {
+    /// Closures that prune (`retain_recent`) the limiter and report
+    /// its current map size. Boxed so the handle's type isn't
+    /// parameterised over the governor's generic key/state types.
+    retain: Box<dyn Fn() + Send + Sync>,
+    len: Box<dyn Fn() -> usize + Send + Sync>,
+}
+
+impl std::fmt::Debug for GovernorGcHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GovernorGcHandle")
+            .field("limiter_size", &(self.len)())
+            .finish()
+    }
+}
+
+/// Spawn a long-running task that periodically GCs the per-IP rate
+/// limiter map. Idempotent across `build_router_with_config` calls in
+/// the same process: only the first invocation per process actually
+/// spawns; subsequent calls drop the new handle. Pulled out of
+/// `build_router_with_config` so router construction stays
+/// runtime-agnostic.
+pub fn spawn_governor_gc(handle: GovernorGcHandle) {
+    static SPAWNED: OnceLock<()> = OnceLock::new();
+    if SPAWNED.set(()).is_err() {
+        return;
+    }
+    tokio::spawn(async move {
+        let interval = Duration::from_secs(60);
+        loop {
+            tokio::time::sleep(interval).await;
+            tracing::trace!(
+                rate_limit_storage_size = (handle.len)(),
+                "governor retain_recent"
+            );
+            (handle.retain)();
+        }
+    });
 }
 
 /// Construct the full HTTP router with an explicit [`ServerConfig`].
-pub fn build_router_with_config(state: Arc<ServerState>, cfg: ServerConfig) -> Router {
+///
+/// Returns `(router, gc_handle)`. The handle is intentionally
+/// detached from the router so the caller can spawn the per-IP map
+/// garbage-collector at the right point in its runtime lifecycle
+/// (typically `serve_cmd`). Tests that don't need GC drop the
+/// handle.
+pub fn build_router_with_config(
+    state: Arc<ServerState>,
+    cfg: ServerConfig,
+) -> (Router, GovernorGcHandle) {
     let (prometheus_layer, metric_handle) = prometheus_pair().clone();
 
     // Permissive CORS by default — the geocoder is read-only, queries
@@ -180,30 +452,26 @@ pub fn build_router_with_config(state: Arc<ServerState>, cfg: ServerConfig) -> R
     // bookkeeping memory.
     let per_second = cfg.rate_limit_per_sec.clamp(1, 100_000) as u64;
     let burst_size = cfg.rate_limit_burst.clamp(1, 100_000);
+    let key_extractor = PeerIpKey::new(cfg.trusted_proxies.clone());
     let governor_cfg = Arc::new(
         GovernorConfigBuilder::default()
             .per_second(per_second)
             .burst_size(burst_size)
-            .key_extractor(PeerIpKey)
+            .key_extractor(key_extractor)
             .finish()
             .expect("governor config valid (per_second>=1, burst_size>=1)"),
     );
 
-    // Background task to garbage-collect the per-IP map so long-running
-    // deployments don't leak memory on rotating client IPs. The
-    // `governor` README recommends pruning every 60 s.
-    let governor_limiter = governor_cfg.limiter().clone();
-    tokio::spawn(async move {
-        let interval = Duration::from_secs(60);
-        loop {
-            tokio::time::sleep(interval).await;
-            tracing::trace!(
-                rate_limit_storage_size = governor_limiter.len(),
-                "governor retain_recent"
-            );
-            governor_limiter.retain_recent();
-        }
-    });
+    // Hand the limiter back to the caller wrapped in two closures so
+    // the GC can be spawned at the right runtime stage. See
+    // [`spawn_governor_gc`]. Two clones share the same Arc'd limiter
+    // so they observe / mutate the same per-IP table.
+    let limiter_for_retain = governor_cfg.limiter().clone();
+    let limiter_for_len = governor_cfg.limiter().clone();
+    let gc_handle = GovernorGcHandle {
+        retain: Box::new(move || limiter_for_retain.retain_recent()),
+        len: Box::new(move || limiter_for_len.len()),
+    };
 
     // Admission control wraps the geocode endpoints only — health
     // and metrics are intentionally excluded so monitors and probes
@@ -230,7 +498,7 @@ pub fn build_router_with_config(state: Arc<ServerState>, cfg: ServerConfig) -> R
             cfg.request_timeout,
         ));
 
-    Router::new()
+    let router = Router::new()
         .merge(api)
         .route(
             "/metrics",
@@ -242,7 +510,105 @@ pub fn build_router_with_config(state: Arc<ServerState>, cfg: ServerConfig) -> R
         .layer(CatchPanicLayer::new())
         .layer(prometheus_layer)
         .layer(TraceLayer::new_for_http())
-        .layer(cors)
+        .layer(cors);
+    (router, gc_handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+
+    #[test]
+    fn cidr_v4_parses_and_contains() {
+        let cidr = TrustedCidr::parse("10.0.0.0/8").unwrap();
+        assert!(cidr.contains("10.1.2.3".parse().unwrap()));
+        assert!(cidr.contains("10.255.255.255".parse().unwrap()));
+        assert!(!cidr.contains("11.0.0.0".parse().unwrap()));
+        assert!(!cidr.contains("9.255.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_v4_bare_ip_is_slash_32() {
+        let cidr = TrustedCidr::parse("192.168.1.1").unwrap();
+        assert!(cidr.contains("192.168.1.1".parse().unwrap()));
+        assert!(!cidr.contains("192.168.1.2".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_v6_parses_and_contains() {
+        let cidr = TrustedCidr::parse("2001:db8::/32").unwrap();
+        assert!(cidr.contains("2001:db8::1".parse().unwrap()));
+        assert!(cidr.contains("2001:db8:abcd:ef::1".parse().unwrap()));
+        assert!(!cidr.contains("2001:db9::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_invalid_prefix_is_rejected() {
+        assert!(TrustedCidr::parse("10.0.0.0/33").is_err());
+        assert!(TrustedCidr::parse("not-an-ip/8").is_err());
+        assert!(TrustedCidr::parse("10.0.0.0/abc").is_err());
+    }
+
+    #[test]
+    fn parse_trusted_proxies_handles_csv_and_empty() {
+        assert!(parse_trusted_proxies(None).unwrap().is_empty());
+        assert!(parse_trusted_proxies(Some("")).unwrap().is_empty());
+        let v = parse_trusted_proxies(Some("10.0.0.0/8, 192.168.0.0/16, 2001:db8::/32")).unwrap();
+        assert_eq!(v.len(), 3);
+    }
+
+    fn make_req(peer: &str, xff: Option<&str>) -> Request<()> {
+        let mut builder = Request::builder().method("GET").uri("/geocode");
+        if let Some(xff) = xff {
+            builder = builder.header("x-forwarded-for", xff);
+        }
+        let mut req = builder.body(()).unwrap();
+        let peer_addr: SocketAddr = format!("{peer}:1234").parse().unwrap();
+        req.extensions_mut().insert(ConnectInfo(peer_addr));
+        req
+    }
+
+    #[test]
+    fn peer_ip_key_returns_direct_peer_when_no_proxies_configured() {
+        let key = PeerIpKey::default();
+        let req = make_req("203.0.113.1", Some("198.51.100.1"));
+        let extracted = key.extract(&req).unwrap();
+        // No trusted proxies → peer IP wins, XFF is ignored.
+        assert_eq!(extracted, "203.0.113.1".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn peer_ip_key_uses_xff_when_peer_is_trusted_proxy() {
+        let key = PeerIpKey::new(vec![TrustedCidr::parse("10.0.0.0/8").unwrap()]);
+        let req = make_req("10.1.2.3", Some("198.51.100.1, 10.5.5.5"));
+        let extracted = key.extract(&req).unwrap();
+        // Peer is trusted (10.x), XFF rightmost-non-trusted is the
+        // first non-trusted IP walking from the right: 10.5.5.5 is
+        // trusted (10.x), so we walk one more left and get the real
+        // client at 198.51.100.1.
+        assert_eq!(extracted, "198.51.100.1".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn peer_ip_key_keeps_peer_when_peer_is_not_trusted() {
+        let key = PeerIpKey::new(vec![TrustedCidr::parse("10.0.0.0/8").unwrap()]);
+        let req = make_req("203.0.113.7", Some("198.51.100.1"));
+        let extracted = key.extract(&req).unwrap();
+        // Peer is NOT a trusted proxy — XFF is ignored even when
+        // present (a malicious client can't promote itself).
+        assert_eq!(extracted, "203.0.113.7".parse::<IpAddr>().unwrap());
+    }
+
+    #[test]
+    fn peer_ip_key_falls_back_to_peer_when_xff_only_lists_trusted_proxies() {
+        let key = PeerIpKey::new(vec![TrustedCidr::parse("10.0.0.0/8").unwrap()]);
+        // All XFF entries are trusted proxies. Means the peer is the
+        // closest-to-client we know about.
+        let req = make_req("10.1.2.3", Some("10.5.5.5, 10.6.6.6"));
+        let extracted = key.extract(&req).unwrap();
+        assert_eq!(extracted, "10.1.2.3".parse::<IpAddr>().unwrap());
+    }
 }
 
 // =============================================================================

--- a/geocode/src/shard/builder.rs
+++ b/geocode/src/shard/builder.rs
@@ -67,8 +67,21 @@ pub fn build_shard<P: AsRef<Path>>(
             return entry;
         }
         let off = u32::try_from(strings.len()).expect("string table fits in u32");
+        // The shard schema stores string lengths as u16. If the
+        // input exceeds that, truncate — but on a UTF-8 char
+        // boundary, never mid-codepoint. A bare byte slice
+        // `s.as_bytes()[..u16::MAX]` would split a multi-byte
+        // sequence at the boundary and ship invalid UTF-8 into the
+        // strings table, panicking the reader on read-back.
         let truncated_bytes = if s.len() > u16::MAX as usize {
-            &s.as_bytes()[..u16::MAX as usize]
+            let cap = u16::MAX as usize;
+            let mut end = cap;
+            // `is_char_boundary(0)` always returns true so this
+            // loop terminates at worst at end=0.
+            while !s.is_char_boundary(end) {
+                end -= 1;
+            }
+            &s.as_bytes()[..end]
         } else {
             s.as_bytes()
         };
@@ -425,6 +438,54 @@ mod tests {
         assert!(
             msg.contains("CRC"),
             "expected CRC mismatch when header bytes flipped, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn intern_truncates_on_char_boundary_for_long_utf8_string() {
+        // Build a string that exceeds u16::MAX bytes AND has the
+        // u16::MAX'th byte fall in the middle of a multi-byte UTF-8
+        // codepoint. `é` is two bytes (`0xC3 0xA9`) — repeating it
+        // until > u16::MAX guarantees the boundary lands mid-char.
+        let mut s = String::new();
+        while s.len() <= u16::MAX as usize + 4 {
+            s.push('é');
+        }
+        let cap = u16::MAX as usize;
+        // Byte at `cap` must be a UTF-8 continuation byte (the second
+        // byte of an `é`); we want our truncation to back up by one
+        // and land on the `0xC3` start byte.
+        assert!(
+            !s.is_char_boundary(cap),
+            "test setup: cap should split the codepoint"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("long.bfgs");
+        let addrs = vec![rec(&s, "1", "1070", "X", 50.0, 4.0)];
+        // The build must complete — without char-boundary truncation
+        // this previously produced an invalid UTF-8 prefix in the
+        // strings table.
+        build_shard(&path, CountryId::BE, addrs).expect("build with mid-codepoint truncation");
+
+        // And the read-back must produce a valid (truncated) UTF-8
+        // street, NOT panic on `from_utf8` somewhere in the reader.
+        let shard = Shard::open(&path).expect("open shard with truncated string");
+        assert_eq!(shard.record_count(), 1);
+        // The shard's reader will panic on `from_utf8` somewhere in
+        // the strings table if we shipped invalid bytes — the read
+        // succeeding here is itself the load-bearing assertion.
+        let postings = shard.postings_for_postcode("1070");
+        assert_eq!(postings.len(), 1);
+        let rec = shard.record(postings[0]).expect("record should load");
+        let street_str: &str = &rec.street;
+        assert!(
+            street_str.len() <= u16::MAX as usize,
+            "truncated street must fit in u16 length"
+        );
+        assert!(
+            street_str.chars().all(|c| c == 'é'),
+            "truncated street must remain valid UTF-8 with only 'é' chars"
         );
     }
 }

--- a/geocode/src/shard/mod.rs
+++ b/geocode/src/shard/mod.rs
@@ -109,10 +109,14 @@ pub const FOOTER_BYTES: usize = 16;
 /// `Osm` is the default fallback for shards built from PBF tags. Every
 /// other variant tracks an authoritative open-data dataset. See
 /// `geocode-data/SOURCES.md` for the per-country importer contract.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum SourceTag {
     /// OpenStreetMap `addr:*` tags.
+    #[default]
     Osm,
     /// Belgian BeSt Address (BOSA).
     Bosa,

--- a/geocode/src/sources/bosa.rs
+++ b/geocode/src/sources/bosa.rs
@@ -4,8 +4,10 @@
 //! authoritative open-data address dataset (~6.7M records). It is
 //! published as three regional CSV downloads (Flanders / Wallonia /
 //! Brussels) plus a single national XML; this loader handles the CSV
-//! variant — it streams the rows as they come off the file, so memory
-//! stays bounded at a few KB regardless of dataset size.
+//! variant. Both the raw CSV and the ZIP-wrapped CSV branch stream
+//! rows row-by-row via `BufReader::read_line` — peak in-memory state
+//! is one row plus the streaming buffers (~1 MB), so memory stays
+//! bounded regardless of dataset size.
 //!
 //! The CSV header is:
 //!
@@ -44,7 +46,7 @@
 //! containing exactly one CSV).
 
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -91,12 +93,16 @@ impl Source for BosaCsvSource {
         }
 
         let path = &self.path;
-        let reader: Box<dyn Read> = if path
+        let is_zip = path
             .extension()
             .and_then(|e| e.to_str())
-            .is_some_and(|e| e.eq_ignore_ascii_case("zip"))
-        {
-            // ZIP: open the first .csv entry inside.
+            .is_some_and(|e| e.eq_ignore_ascii_case("zip"));
+
+        if is_zip {
+            // ZIP branch: stream the first .csv entry directly off
+            // the deflate decompressor. `ZipFile<'a>: Read` borrows
+            // the archive, which keeps the entire 60-130 MB CSV from
+            // having to be slurped into a Vec first.
             let f = File::open(path).with_context(|| format!("opening {}", path.display()))?;
             let mut zip = zip::ZipArchive::new(f)
                 .with_context(|| format!("zip archive {}", path.display()))?;
@@ -114,133 +120,141 @@ impl Source for BosaCsvSource {
             let (idx, name) = csv_idx.ok_or_else(|| {
                 anyhow::anyhow!("no .csv entry found inside zip {}", path.display())
             })?;
-            // We need to own the bytes — `ZipFile` borrows the
-            // archive. Read everything into memory; BOSA single-region
-            // CSVs are 60-130 MB unzipped, fits comfortably.
-            let mut entry = zip
+            let entry = zip
                 .by_index(idx)
                 .with_context(|| format!("re-opening zip entry {name} in {}", path.display()))?;
-            let mut buf = Vec::with_capacity(entry.size() as usize);
-            entry
-                .read_to_end(&mut buf)
-                .with_context(|| format!("reading zip entry {name} in {}", path.display()))?;
-            Box::new(std::io::Cursor::new(buf))
+            let buf_reader = BufReader::with_capacity(1 << 20, entry);
+            stream_csv(buf_reader, path, progress, emit)
         } else {
-            Box::new(File::open(path).with_context(|| format!("opening {}", path.display()))?)
+            let f = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+            let buf_reader = BufReader::with_capacity(1 << 20, f);
+            stream_csv(buf_reader, path, progress, emit)
+        }
+    }
+}
+
+/// Common CSV streaming logic. Generic over the underlying `Read`
+/// implementation so the ZIP path can pass a `ZipFile<'a>` directly
+/// without buffering its entire contents.
+fn stream_csv<R: BufRead>(
+    mut buf_reader: R,
+    path: &Path,
+    progress: &mut dyn FnMut(SourceProgress),
+    emit: &mut dyn FnMut(AddressRecord),
+) -> Result<()> {
+    progress(SourceProgress::Phase {
+        phase: "parsing BOSA CSV header",
+    });
+
+    // Read the header line and resolve column indices.
+    let mut header_line = String::new();
+    buf_reader
+        .read_line(&mut header_line)
+        .context("reading BOSA CSV header")?;
+    if header_line.trim().is_empty() {
+        bail!("BOSA CSV at {} has empty header", path.display());
+    }
+    let cols = parse_header(&header_line)?;
+
+    progress(SourceProgress::Phase {
+        phase: "streaming BOSA CSV rows",
+    });
+
+    let mut rows_seen: u64 = 0;
+    let mut records_emitted: u64 = 0;
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let n = buf_reader
+            .read_line(&mut line)
+            .context("reading BOSA CSV row")?;
+        if n == 0 {
+            break;
+        }
+        rows_seen += 1;
+
+        let fields = split_csv_row(&line);
+        if fields.len() < cols.column_count {
+            // Truncated/malformed line: skip but don't fail the
+            // whole pass. BOSA is generally well-formed but we
+            // don't want one bad row to abort a 6.7M-row import.
+            continue;
+        }
+
+        let lat = parse_lat(fields[cols.lat]);
+        let lon = parse_lon(fields[cols.lon]);
+        let (Some(lat), Some(lon)) = (lat, lon) else {
+            continue;
         };
 
-        let mut buf_reader = BufReader::with_capacity(1 << 20, reader);
-
-        progress(SourceProgress::Phase {
-            phase: "parsing BOSA CSV header",
-        });
-
-        // Read the header line and resolve column indices.
-        let mut header_line = String::new();
-        buf_reader
-            .read_line(&mut header_line)
-            .context("reading BOSA CSV header")?;
-        if header_line.trim().is_empty() {
-            bail!("BOSA CSV at {} has empty header", path.display());
-        }
-        let cols = parse_header(&header_line)?;
-
-        progress(SourceProgress::Phase {
-            phase: "streaming BOSA CSV rows",
-        });
-
-        let mut rows_seen: u64 = 0;
-        let mut records_emitted: u64 = 0;
-        let mut line = String::new();
-
-        loop {
-            line.clear();
-            let n = buf_reader
-                .read_line(&mut line)
-                .context("reading BOSA CSV row")?;
-            if n == 0 {
-                break;
-            }
-            rows_seen += 1;
-
-            let fields = split_csv_row(&line);
-            if fields.len() < cols.column_count {
-                // Truncated/malformed line: skip but don't fail the
-                // whole pass. BOSA is generally well-formed but we
-                // don't want one bad row to abort a 6.7M-row import.
-                continue;
-            }
-
-            let lat = parse_lat(fields[cols.lat]);
-            let lon = parse_lon(fields[cols.lon]);
-            let (Some(lat), Some(lon)) = (lat, lon) else {
-                continue;
-            };
-
-            let status = fields[cols.status].trim();
-            // Accept "current" or empty (occasionally missing in
-            // older publications). Skip "retired" and any other
-            // non-current state.
-            if !status.is_empty() && !status.eq_ignore_ascii_case("current") {
-                continue;
-            }
-
-            let postcode = fields[cols.postcode].trim();
-            if postcode.is_empty() {
-                continue;
-            }
-
-            let house_number = fields[cols.house_number].trim();
-            let box_number = fields[cols.box_number].trim();
-            let house = format_belgian_number(house_number, box_number);
-            if house.is_empty() {
-                continue;
-            }
-
-            let address_id = fields[cols.address_id].trim();
-
-            // Per-language: BOSA Belgium publishes NL/FR/DE names.
-            // We emit one record per non-empty language so all three
-            // names are queryable. Same `source_id` so the merge dedup
-            // can collapse them when needed.
-            for lang in [LangCol::Nl, LangCol::Fr, LangCol::De] {
-                let muni = fields[cols.muni(lang)].trim();
-                let street = fields[cols.street(lang)].trim();
-                if muni.is_empty() && street.is_empty() {
-                    continue;
-                }
-                emit(AddressRecord {
-                    lat,
-                    lon,
-                    street: street.to_string(),
-                    locality: muni.to_string(),
-                    housenumber: house.clone(),
-                    postcode: postcode.to_string(),
-                    source: SourceTag::Bosa,
-                    source_id: if address_id.is_empty() {
-                        None
-                    } else {
-                        Some(address_id.to_string())
-                    },
-                });
-                records_emitted += 1;
-            }
-
-            if rows_seen.is_multiple_of(100_000) {
-                progress(SourceProgress::Records {
-                    rows_seen,
-                    records_emitted,
-                });
-            }
+        let status = fields[cols.status].trim();
+        // Accept "current" or empty (occasionally missing in
+        // older publications). Skip "retired" and any other
+        // non-current state.
+        if !status.is_empty() && !status.eq_ignore_ascii_case("current") {
+            continue;
         }
 
-        progress(SourceProgress::Records {
-            rows_seen,
-            records_emitted,
-        });
+        let postcode = fields[cols.postcode].trim();
+        if postcode.is_empty() {
+            continue;
+        }
 
-        Ok(())
+        let house_number = fields[cols.house_number].trim();
+        let box_number = cols
+            .box_number
+            .and_then(|i| fields.get(i))
+            .map(|s| s.trim())
+            .unwrap_or("");
+        let house = format_belgian_number(house_number, box_number);
+        if house.is_empty() {
+            continue;
+        }
+
+        let address_id = fields[cols.address_id].trim();
+
+        // Per-language: BOSA Belgium publishes NL/FR/DE names.
+        // We emit one record per non-empty language so all three
+        // names are queryable. Same `source_id` so the merge dedup
+        // can collapse them when needed.
+        for lang in [LangCol::Nl, LangCol::Fr, LangCol::De] {
+            let muni = fields[cols.muni(lang)].trim();
+            let street = fields[cols.street(lang)].trim();
+            if muni.is_empty() && street.is_empty() {
+                continue;
+            }
+            emit(AddressRecord {
+                lat,
+                lon,
+                street: street.to_string(),
+                locality: muni.to_string(),
+                housenumber: house.clone(),
+                postcode: postcode.to_string(),
+                source: SourceTag::Bosa,
+                source_id: if address_id.is_empty() {
+                    None
+                } else {
+                    Some(address_id.to_string())
+                },
+            });
+            records_emitted += 1;
+        }
+
+        if rows_seen.is_multiple_of(100_000) {
+            progress(SourceProgress::Records {
+                rows_seen,
+                records_emitted,
+            });
+        }
     }
+
+    progress(SourceProgress::Records {
+        rows_seen,
+        records_emitted,
+    });
+
+    Ok(())
 }
 
 /// Format a Belgian housenumber: `house[box]` with `bte` separator
@@ -273,7 +287,12 @@ struct ColumnIndices {
     lon: usize,
     address_id: usize,
     house_number: usize,
-    box_number: usize,
+    /// `None` when the BOSA snapshot doesn't carry a `box_number`
+    /// column. We optionally fold this into the housenumber when
+    /// present (Brussels/Wallonia/Flanders all do); older / regional
+    /// snapshots that omit it land with bare housenumbers and no
+    /// runtime panic.
+    box_number: Option<usize>,
     postcode: usize,
     muni_nl: usize,
     muni_fr: usize,
@@ -310,9 +329,10 @@ fn parse_header(line: &str) -> Result<ColumnIndices> {
     let lon = lookup("EPSG:4326_lon").context("BOSA CSV missing EPSG:4326_lon column")?;
     let address_id = lookup("address_id").context("BOSA CSV missing address_id column")?;
     let house_number = lookup("house_number").context("BOSA CSV missing house_number column")?;
-    // box_number is optional in some BOSA snapshots; default to the
-    // last column if missing so the indexing arithmetic stays safe.
-    let box_number = lookup("box_number").unwrap_or(usize::MAX);
+    // box_number is optional in some BOSA snapshots. Track presence
+    // explicitly so we can skip the box-number folding rather than
+    // index past the row's column count and panic.
+    let box_number = lookup("box_number");
     let postcode = lookup("postcode").context("BOSA CSV missing postcode column")?;
     let muni_nl =
         lookup("municipality_name_nl").context("BOSA CSV missing municipality_name_nl column")?;
@@ -505,6 +525,22 @@ mod tests {
         assert_eq!(format_belgian_number("475", "RDC"), "475 bte RDC");
         assert_eq!(format_belgian_number("475", ""), "475");
         assert_eq!(format_belgian_number(" ", "RDC"), "");
+    }
+
+    #[test]
+    fn header_without_box_number_skips_box_folding() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("nobox.csv");
+        // Header without `box_number`. Note: column count is one less.
+        let csv = "EPSG:31370_x,EPSG:31370_y,EPSG:4326_lat,EPSG:4326_lon,address_id,house_number,municipality_id,municipality_name_de,municipality_name_fr,municipality_name_nl,postcode,postname_fr,postname_nl,street_id,streetname_de,streetname_fr,streetname_nl,region_code,status\n\
+146321,169504,50.83595,4.31653,615867,475,21001,,Anderlecht,Anderlecht,1070,,,4568,,Chaussée de Mons,Bergense Steenweg,BE-BRU,current\n";
+        std::fs::write(&p, csv).unwrap();
+        let src = BosaCsvSource::new(&p, CountryId::BE);
+        let recs = super::super::collect_all(&src, |_| {}).unwrap();
+        assert!(!recs.is_empty(), "missing box_number column must not panic");
+        for r in &recs {
+            assert_eq!(r.housenumber, "475", "no box folding when column is absent");
+        }
     }
 
     #[test]

--- a/geocode/src/sources/mod.rs
+++ b/geocode/src/sources/mod.rs
@@ -98,15 +98,17 @@ pub fn collect_all<S: Source + ?Sized>(
 }
 
 /// Sort key used by [`merge_records`] to group records that should
-/// be deduped against each other. Ascii-lowercased to fold case (BOSA
-/// stores `Chaussée de Mons` vs OSM `chaussée de mons`); housenumbers
-/// stay unfolded because `12A` ≠ `12a` is rare in practice but the
-/// canonical form is upstream-defined.
+/// be deduped against each other. Goes through the shared
+/// [`crate::parser::normalize::normalize`] so accent folding,
+/// punctuation collapse, and whitespace collapse all match the
+/// shard's inverted-index keys. Without this, `Chaussée de Mons`
+/// (BOSA) and `Chaussee de Mons` (OSM) end up in different dedup
+/// groups and ship as duplicate records.
 fn dedup_key(rec: &AddressRecord) -> (String, String, String) {
     (
-        rec.postcode.trim().to_ascii_lowercase(),
-        rec.street.trim().to_ascii_lowercase(),
-        rec.housenumber.trim().to_ascii_lowercase(),
+        crate::parser::normalize::normalize(rec.postcode.trim()),
+        crate::parser::normalize::normalize(rec.street.trim()),
+        crate::parser::normalize::normalize(rec.housenumber.trim()),
     )
 }
 
@@ -219,10 +221,21 @@ fn dedup_group(group: Vec<AddressRecord>) -> Vec<AddressRecord> {
             }
         }
         // Pick the highest-priority record from the cluster.
-        let winner_idx = *cluster
-            .iter()
-            .max_by_key(|&&k| merge_priority(group[k].source))
-            .expect("cluster has at least one element");
+        // First-wins on tie: when two cluster members share the same
+        // priority (e.g. two OSM records, or two `--merge` inputs at
+        // equal authoritative priority), keep the one that arrived
+        // earliest in `inputs`. `max_by_key` returns the LAST equal
+        // max, so we can't use it directly; iterate manually keeping
+        // the first time the maximum priority is observed.
+        let mut winner_idx: usize = cluster[0];
+        let mut winner_prio: u8 = merge_priority(group[winner_idx].source);
+        for &k in cluster.iter().skip(1) {
+            let prio = merge_priority(group[k].source);
+            if prio > winner_prio {
+                winner_idx = k;
+                winner_prio = prio;
+            }
+        }
         survivors.push(group[winner_idx].clone());
         for k in cluster {
             taken[k] = true;
@@ -366,5 +379,49 @@ mod tests {
     fn priority_order_ban_beats_osm() {
         assert!(merge_priority(SourceTag::Ban) > merge_priority(SourceTag::Osm));
         assert!(merge_priority(SourceTag::Bosa) > merge_priority(SourceTag::Osm));
+    }
+
+    #[test]
+    fn dedup_key_normalizes_diacritics() {
+        // BOSA: "Chaussée de Mons", OSM: "Chaussee de Mons" — must
+        // land in the same group so the merge dedup sees them.
+        let bosa = rec(
+            "1070",
+            "Chaussée de Mons",
+            "122",
+            50.834,
+            4.314,
+            SourceTag::Bosa,
+        );
+        let osm = rec(
+            "1070",
+            "Chaussee de Mons",
+            "122",
+            50.8341,
+            4.3141,
+            SourceTag::Osm,
+        );
+        assert_eq!(dedup_key(&bosa), dedup_key(&osm));
+        let merged = merge_records(vec![vec![bosa], vec![osm]]);
+        assert_eq!(merged.len(), 1, "diacritic dedup should collapse the pair");
+        assert_eq!(merged[0].source, SourceTag::Bosa);
+    }
+
+    #[test]
+    fn winner_first_wins_on_priority_tie() {
+        // Two `--merge` inputs at equal priority. The earlier vector
+        // (representing the earlier `--merge` arg) must win.
+        let earlier = rec("1070", "Rue X", "1", 50.8340, 4.3140, SourceTag::Osm);
+        let later = rec("1070", "Rue X", "1", 50.83405, 4.31405, SourceTag::Osm);
+        // Tag the earlier with a stable distinguishing source_id to
+        // assert which one survived — both are OSM so source priority
+        // is identical.
+        let mut earlier_marked = earlier.clone();
+        earlier_marked.source_id = Some("EARLIER".to_string());
+        let mut later_marked = later.clone();
+        later_marked.source_id = Some("LATER".to_string());
+        let merged = merge_records(vec![vec![earlier_marked], vec![later_marked]]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].source_id.as_deref(), Some("EARLIER"));
     }
 }

--- a/geocode/tests/prod_hardening.rs
+++ b/geocode/tests/prod_hardening.rs
@@ -64,7 +64,9 @@ fn make_fixture_shard() -> (TempDir, Shard) {
 fn make_app_with(cfg: ServerConfig) -> (TempDir, axum::Router) {
     let (dir, shard) = make_fixture_shard();
     let state = Arc::new(ServerState::new(shard));
-    let app = build_router_with_config(state, cfg);
+    // Drop the GC handle: tests don't need the per-IP map pruner
+    // and we don't want to leak a background task per-test.
+    let (app, _gc) = build_router_with_config(state, cfg);
     (dir, app)
 }
 

--- a/geocode/tests/serve_the_world.rs
+++ b/geocode/tests/serve_the_world.rs
@@ -14,9 +14,9 @@ use butterfly_geocode::CountryId;
 use butterfly_geocode::routing::{Classifier, PackRegistry};
 use butterfly_geocode::shard::reader::Shard;
 
-// `crc` crate is a transitive dev dep via butterfly-geocode itself, but
-// only used inside test helpers. Adding `crc` as a dev-dep in Cargo.toml
-// would be overkill since the lib already depends on it.
+// Test helpers below reach for `crc` via the parent crate's own
+// dependency on it (butterfly-geocode declares `crc` directly in
+// Cargo.toml).
 
 #[test]
 fn shipped_packs_compile_with_15_countries() {
@@ -220,6 +220,100 @@ fn rejects_v3_shards_with_helpful_error() {
         msg.contains("build-shard"),
         "expected upgrade hint, got: {msg}"
     );
+}
+
+#[test]
+fn shipped_with_overrides_overlays_be_pack() {
+    use std::fs;
+    let dir = tempfile::tempdir().unwrap();
+    // Override pack: same ISO2 as a shipped pack (BE), different name
+    // and different bbox so we can detect the overlay won.
+    let override_toml = r#"
+[country]
+iso2 = "BE"
+name = "Belgium-OVERRIDE"
+[postcode]
+regex = '\b[1-9]\d{3}\b'
+position = "anywhere"
+canonicalize = "none"
+[bbox]
+min_lat = 49.5
+max_lat = 51.5
+min_lon = 2.5
+max_lon = 6.4
+"#;
+    fs::write(dir.path().join("be.toml"), override_toml).unwrap();
+    let reg = PackRegistry::shipped_with_overrides(dir.path()).unwrap();
+    let be = reg.get(CountryId::BE).expect("BE should still be present");
+    assert_eq!(
+        be.name, "Belgium-OVERRIDE",
+        "directory entry should win over shipped pack"
+    );
+    // Other shipped packs survive the overlay.
+    assert!(reg.get(CountryId::FR).is_some());
+    assert!(reg.get(CountryId::JP).is_some());
+}
+
+#[test]
+fn shipped_with_overrides_partial_coverage_keeps_other_shipped_packs() {
+    use std::fs;
+    let dir = tempfile::tempdir().unwrap();
+    // Only override LU. Every other shipped pack must remain.
+    let override_toml = r#"
+[country]
+iso2 = "LU"
+name = "Luxembourg-OVERRIDE"
+[bbox]
+min_lat = 49.4
+max_lat = 50.2
+min_lon = 5.7
+max_lon = 6.6
+"#;
+    fs::write(dir.path().join("lu.toml"), override_toml).unwrap();
+    let reg = PackRegistry::shipped_with_overrides(dir.path()).unwrap();
+    assert_eq!(reg.len(), 15, "every shipped pack still loaded");
+    assert_eq!(reg.get(CountryId::LU).unwrap().name, "Luxembourg-OVERRIDE");
+    // Unaffected pack:
+    assert_ne!(reg.get(CountryId::BE).unwrap().name, "Luxembourg-OVERRIDE");
+}
+
+#[test]
+fn shipped_with_overrides_missing_directory_falls_back_to_shipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("does-not-exist");
+    let reg = PackRegistry::shipped_with_overrides(&missing).unwrap();
+    assert_eq!(
+        reg.len(),
+        15,
+        "non-existent --pack-dir should silently fall back to shipped"
+    );
+}
+
+#[test]
+fn shipped_with_overrides_rejects_malformed_pack() {
+    use std::fs;
+    let dir = tempfile::tempdir().unwrap();
+    // Bad: invalid bbox (min > max).
+    fs::write(
+        dir.path().join("be.toml"),
+        r#"
+[country]
+iso2 = "BE"
+name = "BAD"
+[bbox]
+min_lat = 60.0
+max_lat = 50.0
+min_lon = 0.0
+max_lon = 1.0
+"#,
+    )
+    .unwrap();
+    // Malformed pack should not crash the loader. Since the bad pack
+    // never inserts, the shipped BE pack remains.
+    let reg = PackRegistry::shipped_with_overrides(dir.path()).unwrap();
+    let be = reg.get(CountryId::BE).expect("BE must remain");
+    // Original shipped name (whatever it is) — definitely NOT "BAD".
+    assert_ne!(be.name, "BAD");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Coordinated fix-up pass over six previously-merged PRs covering:
- Country packs + serve-the-world (#176, 8 items)
- BOSA + multi-source ingestion (#173, 6 items)
- Production hardening (#170, 4 items)
- Multi-country shards (#169, 9 items)
- Multi-country region indexes (#166, 4 items)
- Geocoder MVP char-boundary truncation (#162, deferred from #181)

Companion to PR #181 (parser/control fix-ups). Strictly stays inside this PR's territory: shard, sources, server, routing, osm_extract, main, packs, region indexes. Does not touch parser/, tagger/, confidence/, control/, geocoder/, route/.

## Findings addressed

### PR #176 — serve-the-world
- main.rs:301 — wired `extract_addresses_with_tags(pack.osm_tags)` so JP-style `addr:full` overrides actually fire (`geocode/src/main.rs`, `geocode/src/osm_extract/mod.rs`)
- Cargo.toml:50 — `toml = { workspace = true }`; workspace pinned at `toml = \"1.1\"` (`Cargo.toml`, `geocode/Cargo.toml`)
- tests/serve_the_world.rs — drop misleading "transitive dev dep" comment (`geocode/tests/serve_the_world.rs`)
- routing/pack.rs::canonicalize — `bail!` on unknown values (`geocode/src/routing/pack.rs`)
- routing/pack.rs::neighbours — bail with pack name + offending code (`geocode/src/routing/pack.rs`)
- osm_extract/mod.rs::has_minimum_signal — `StreetSource` enum splits strict (`addr:street`+housenumber) from fallback (`addr:full`/`addr:place` accepts locality-or-postcode) (`geocode/src/osm_extract/mod.rs`)
- routing/mod.rs::iso2_intern — `unwrap_or_else(|e| e.into_inner())` instead of panic (`geocode/src/routing/mod.rs`)
- packs/README.md — implement `--pack-dir` flag via `PackRegistry::shipped_with_overrides` (`geocode/src/main.rs`, `geocode/src/routing/pack.rs`, `geocode/data/packs/README.md`)

### PR #173 — BOSA ingestion
- sources/bosa.rs::box_number — `Option<usize>` (`geocode/src/sources/bosa.rs`)
- sources/mod.rs::dedup_key — route through `parser::normalize::normalize` (`geocode/src/sources/mod.rs`)
- sources/mod.rs::winner_idx — first-wins tie-break (`geocode/src/sources/mod.rs`)
- main.rs::build_shards_all_cmd — prefer authoritative source via `try_authoritative_build` consulting region `[[address]]` (`geocode/src/main.rs`)
- handlers.rs::ForwardItem `source` field — DEFERRED; documented in code + README (requires touching `geocoder::executor::GeocodedResult` which is outside territory) (`geocode/src/server/handlers.rs`, `geocode/README.md`)
- sources/bosa.rs ZIP comment — implemented true streaming via `BufReader<ZipFile<'a>>`, doc updated (`geocode/src/sources/bosa.rs`)

### PR #170 — production hardening
- server/mod.rs PeerIpKey doc — `PeerIpKeyExtractor` typo fixed (`geocode/src/server/mod.rs`)
- server/mod.rs middleware order doc — restructured into outer/inner/innermost rings (`geocode/src/server/mod.rs`)
- server/mod.rs PeerIpKey trusted-proxy — `TrustedCidr` v4+v6 + `--trusted-proxies` CLI + RFC 7239 `Forwarded`/`X-Forwarded-For` walk (`geocode/src/server/mod.rs`, `geocode/src/main.rs`)
- server/mod.rs governor GC spawn — moved to `spawn_governor_gc` invoked from `serve_cmd`; `build_router_with_config` returns `(Router, GovernorGcHandle)` (`geocode/src/server/mod.rs`, `geocode/src/main.rs`, `geocode/tests/prod_hardening.rs`)

### PR #169 — multi-country shards
- shard/mod.rs v2 backwards-compat doc — already correct (verified) (`geocode/src/shard/mod.rs`)
- main.rs::candidate_pbf_names wildcard — explicit if-else chain over shipped country codes (`geocode/src/main.rs`)
- main.rs::--only parsing — `bail!` on unknown ISO2 + empty list (`geocode/src/main.rs`)
- bbox.rs/handlers.rs reverse routing — `supported_countries_for_point` smallest-bbox-first; out-of-radius fallback across every loaded shard (`geocode/src/server/handlers.rs`)
- classifier.rs::contains_word (in pack.rs) — Unicode-aware `char::is_alphanumeric` (`geocode/src/routing/pack.rs`)
- executor.rs `execute_multi` comment — out-of-territory; reverted comment changes (`geocode/src/geocoder/executor.rs` left untouched)
- bbox.rs::aachen test — assert `supported_countries_for_point` returns multi; drop smallest-bbox lock-in (`geocode/src/routing/bbox.rs`)

### PR #166 — multi-country region indexes
- SOURCES.md pick_lang — alias-table model with worked example (`geocode-data/SOURCES.md`)
- CLUSTERS.md fragment key — sentinel bucket `(cluster_id, country, \"00\")` for postcode-less records (`geocode-data/CLUSTERS.md`)
- CLUSTERS.md slab sketch — actual on-disk layout (offsets into strings table, fixed-stride metadata) (`geocode-data/CLUSTERS.md`)
- dl/src/regions.rs — inverse test `every_loadable_region_appears_in_shipped_regions` (`dl/src/regions.rs`)

### PR #162 — char-boundary truncation
- shard/builder.rs::intern — back up to char boundary before u16::MAX truncation (`geocode/src/shard/builder.rs`)

## Test additions

- `geocode/src/server/mod.rs`: 9 unit tests for `TrustedCidr` parsing/contains and `PeerIpKey` XFF/Forwarded extraction
- `geocode/tests/serve_the_world.rs`: 4 tests for `--pack-dir` overrides (overlay, partial coverage, missing dir, malformed pack)
- `geocode/src/sources/bosa.rs`: `header_without_box_number_skips_box_folding`
- `geocode/src/sources/mod.rs`: `dedup_key_normalizes_diacritics`, `winner_first_wins_on_priority_tie`
- `geocode/src/shard/builder.rs`: `intern_truncates_on_char_boundary_for_long_utf8_string`
- `geocode/src/osm_extract/mod.rs`: 4 tests for `StreetSource` strict-vs-fallback semantics
- `dl/src/regions.rs`: `every_loadable_region_appears_in_shipped_regions`

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo clippy --workspace --all-targets` passes with no warnings
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo test --workspace --lib` — 757 lib tests pass (was 748)
- [ ] `cargo test --workspace --tests` — all integration tests green
- [ ] `cargo test -p butterfly-geocode --test serve_the_world` — 9 tests pass including 4 new pack-override tests
- [ ] `cargo test -p butterfly-geocode --test prod_hardening` — 8 tests pass with new GovernorGcHandle wiring