### PR TITLE
fix(geocode): round-2 Copilot reviews + parser hypothesis diversity

### DIFF
--- a/geocode/src/confidence/gbdt.rs
+++ b/geocode/src/confidence/gbdt.rs
@@ -98,6 +98,18 @@ impl GbdtModel {
                     .try_into()
                     .expect("4 bytes from a 16-byte buffer"),
             );
+            let reserved = u32::from_le_bytes(
+                head[12..16]
+                    .try_into()
+                    .expect("4 bytes from a 16-byte buffer"),
+            );
+            if reserved != 0 {
+                return Err(anyhow!(
+                    "GBDT model {} has non-zero reserved header field ({reserved:#010x}); \
+                     header bytes [12..16) must be zero — file is corrupt or from a future format",
+                    path.display()
+                ));
+            }
             if schema_version != Features::SCHEMA_VERSION {
                 return Err(anyhow!(
                     "GBDT model {} declares feature schema_version {} but this build expects {} — retrain the model",
@@ -161,19 +173,44 @@ impl GbdtModel {
             .map_err(|e| anyhow!("saving GBDT payload: {e}"))?;
         let payload = std::fs::read(tmp.path()).with_context(|| "reading GBDT payload tempfile")?;
 
-        let mut out = std::fs::File::create(path)
-            .with_context(|| format!("creating model file {}", path.display()))?;
+        // Crash-safe write: temp file in same directory, fsync, then
+        // atomic rename. A mid-write crash leaves either the old file
+        // intact or no temp file at all — never a corrupt destination.
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("model");
+        let tmp_name = format!("{file_name}.tmp.{}", std::process::id());
+        let tmp_path = parent.join(tmp_name);
+
+        let mut out = std::fs::File::create(&tmp_path)
+            .with_context(|| format!("creating temp file {}", tmp_path.display()))?;
         let mut header = [0u8; ENVELOPE_HEADER_BYTES];
         header[0..4].copy_from_slice(&ENVELOPE_MAGIC);
         header[4..8].copy_from_slice(&Features::SCHEMA_VERSION.to_le_bytes());
         header[8..12].copy_from_slice(&(ENVELOPE_HEADER_BYTES as u32).to_le_bytes());
-        // bytes 12..16 are reserved zeros.
-        out.write_all(&header)
-            .with_context(|| format!("writing envelope header to {}", path.display()))?;
-        out.write_all(&payload)
-            .with_context(|| format!("writing GBDT payload to {}", path.display()))?;
-        out.flush()
-            .with_context(|| format!("flushing {}", path.display()))?;
+        // bytes 12..16 are reserved zeros (left as the zero-init from above).
+        let write_result = (|| -> Result<()> {
+            out.write_all(&header)
+                .with_context(|| format!("writing envelope header to {}", tmp_path.display()))?;
+            out.write_all(&payload)
+                .with_context(|| format!("writing GBDT payload to {}", tmp_path.display()))?;
+            out.sync_all()
+                .with_context(|| format!("fsyncing {}", tmp_path.display()))?;
+            Ok(())
+        })();
+        if let Err(e) = write_result {
+            // Best-effort cleanup; ignore unlink failure (the temp file
+            // is harmless, and the original path is still untouched).
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(e);
+        }
+        drop(out);
+        std::fs::rename(&tmp_path, path).with_context(|| {
+            format!(
+                "atomically renaming {} -> {}",
+                tmp_path.display(),
+                path.display()
+            )
+        })?;
         Ok(())
     }
 
@@ -395,6 +432,29 @@ mod tests {
         let a = model.predict_one(&f);
         let b = loaded.predict_one(&f);
         assert!((a - b).abs() < 1e-5, "{a} vs {b}");
+    }
+
+    #[test]
+    fn load_rejects_nonzero_reserved_bytes() {
+        // Build a model file with a corrupted reserved field.
+        let dir = tempfile::tempdir().unwrap();
+        let good = dir.path().join("good.gbdt");
+        let bad = dir.path().join("bad.gbdt");
+        let model = synthetic_model();
+        model.save(&good).unwrap();
+        let mut bytes = std::fs::read(&good).unwrap();
+        // Bytes [12..16) are the reserved field; flip them.
+        bytes[12] = 0xDE;
+        bytes[13] = 0xAD;
+        bytes[14] = 0xBE;
+        bytes[15] = 0xEF;
+        std::fs::write(&bad, &bytes).unwrap();
+        let err = GbdtModel::load(&bad).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("non-zero reserved"),
+            "expected 'non-zero reserved' diagnostic, got: {msg}"
+        );
     }
 
     #[test]

--- a/geocode/src/confidence/training.rs
+++ b/geocode/src/confidence/training.rs
@@ -187,7 +187,11 @@ pub fn build_training_rows(
 fn parse_country(s: Option<&str>) -> Result<CountryId> {
     match s {
         None => Ok(CountryId::BE),
-        Some(s) => CountryId::from_iso2(s).ok_or_else(|| anyhow!("unknown country '{s}'")),
+        Some(s) => CountryId::from_iso2(s).ok_or_else(|| {
+            anyhow!(
+                "malformed country code: {s:?} (expected exactly 2 ASCII letters, case-insensitive)"
+            )
+        }),
     }
 }
 

--- a/geocode/src/geocoder/executor.rs
+++ b/geocode/src/geocoder/executor.rs
@@ -234,14 +234,17 @@ pub fn execute(query: &ParsedQuery, shard: &Shard, limit: usize) -> Vec<Geocoded
         .map(|h| {
             let policy = apply_role_smoothness(h, budget);
             let (op, src_score) = build_program(h, &policy);
-            (op.canonicalize(), (*h).clone(), src_score)
+            // Canonicalization happens exactly once, inside the deduper.
+            // Callers must NOT pre-canonicalize here — that would double
+            // the work on the heuristic parser's hot path.
+            (op, (*h).clone(), src_score)
         })
         .collect();
 
     // Recombination Invariant: dedup programs by canonical form. After
     // this step, every program is unique and is paired with the
-    // representative hypothesis (the one with the highest source
-    // logprob across the equivalence class).
+    // representative hypothesis (the one with the highest source score
+    // across the equivalence class).
     let mut programs = super::program::dedup_canonical_with_hyp(raw_programs);
 
     // Static cost ceiling enforcement.
@@ -1110,7 +1113,9 @@ pub fn execute_with_control(
             .map(|h| {
                 let policy = apply_role_smoothness(h, &query.execution_budget);
                 let (op, src_score) = build_program(h, &policy);
-                (op.canonicalize(), h.clone(), src_score)
+                // Single canonicalize pass inside the deduper; do not
+                // pre-canonicalize here.
+                (op, h.clone(), src_score)
             })
             .collect();
         super::program::dedup_canonical_with_hyp(raw)

--- a/geocode/src/geocoder/program.rs
+++ b/geocode/src/geocoder/program.rs
@@ -353,7 +353,7 @@ pub fn dedup_canonical(programs: Vec<(Op, f32)>) -> Vec<(Op, f32)> {
     out
 }
 
-/// Dedup a list of `(program, hypothesis, final_logprob)` triples by
+/// Dedup a list of `(program, hypothesis, src_score)` triples by
 /// canonical form, paired with their source [`ParseHypothesis`].
 ///
 /// This is the primary multi-hypothesis dedup entry point. Per #96 the
@@ -362,10 +362,13 @@ pub fn dedup_canonical(programs: Vec<(Op, f32)>) -> Vec<(Op, f32)> {
 /// hypotheses. When multiple hypotheses canonicalize to the same
 /// program, we merge them by:
 ///
-/// - **`final_logprob`**: max across the group (consistent with the
-///   `max` source-score policy in [`dedup_canonical`]).
-/// - **Representative hypothesis**: the one with the highest input
-///   `final_logprob` — its parsed fields seed downstream scoring so the
+/// - **`src_score`**: max across the group (consistent with the
+///   `max` source-score policy in [`dedup_canonical`]). Note: callers
+///   pass the hypothesis-derived **source score** (the value
+///   `build_program` returns), NOT the parser's raw `final_logprob`.
+///   The historical name was misleading; the contract is now explicit.
+/// - **Representative hypothesis**: the one with the higher input
+///   `src_score` — its parsed fields seed downstream scoring so the
 ///   strongest signal wins.
 ///
 /// The fast path (≤ 1 input) avoids the comparison loop; this matters
@@ -379,23 +382,53 @@ pub fn dedup_canonical_with_hyp(
     if programs.len() <= 1 {
         return programs
             .into_iter()
-            .map(|(p, h, lp)| (p.canonicalize(), h, lp))
+            .map(|(p, h, src_score)| (p.canonicalize(), h, src_score))
             .collect();
     }
     let mut out: Vec<(Op, ParseHypothesis, f32)> = Vec::with_capacity(programs.len());
-    for (p, h, lp) in programs {
+    for (p, h, src_score) in programs {
         let canon = p.canonicalize();
         if let Some(idx) = out.iter().position(|(o, _, _)| o == &canon) {
             // Merge into existing entry: keep the representative
-            // hypothesis with the higher source logprob, take max
-            // final_logprob.
+            // hypothesis with the higher source score, take max
+            // src_score.
             let existing = &mut out[idx];
-            if lp > existing.2 {
+            if src_score > existing.2 {
                 existing.1 = h;
-                existing.2 = lp;
+                existing.2 = src_score;
             }
         } else {
-            out.push((canon, h, lp));
+            out.push((canon, h, src_score));
+        }
+    }
+    out
+}
+
+/// Dedup variant for callers who have **already canonicalized** their
+/// programs and want to skip the second canonicalize pass inside the
+/// hot loop. Behavior is otherwise identical to
+/// [`dedup_canonical_with_hyp`].
+///
+/// The executor's main path uses this: `build_program` returns a raw
+/// op which is canonicalized once on the way in, and we don't need to
+/// canonicalize again here.
+#[must_use]
+pub fn dedup_already_canonical_with_hyp(
+    programs: Vec<(Op, ParseHypothesis, f32)>,
+) -> Vec<(Op, ParseHypothesis, f32)> {
+    if programs.len() <= 1 {
+        return programs;
+    }
+    let mut out: Vec<(Op, ParseHypothesis, f32)> = Vec::with_capacity(programs.len());
+    for (p, h, src_score) in programs {
+        if let Some(idx) = out.iter().position(|(o, _, _)| o == &p) {
+            let existing = &mut out[idx];
+            if src_score > existing.2 {
+                existing.1 = h;
+                existing.2 = src_score;
+            }
+        } else {
+            out.push((p, h, src_score));
         }
     }
     out

--- a/geocode/src/main.rs
+++ b/geocode/src/main.rs
@@ -432,12 +432,12 @@ async fn main() -> Result<()> {
             // (default) or shipped + override directory. Done at CLI
             // level so a bad pack drop fails the boot loudly rather
             // than silently degrading classifier accuracy.
-            let pack_registry = match pack_dir.as_deref() {
+            let pack_registry = std::sync::Arc::new(match pack_dir.as_deref() {
                 Some(d) => butterfly_geocode::routing::PackRegistry::shipped_with_overrides(d)
                     .with_context(|| format!("loading pack overrides from {}", d.display()))?,
                 None => butterfly_geocode::routing::PackRegistry::shipped()
                     .context("loading shipped country packs")?,
-            };
+            });
             info!(
                 packs = pack_registry.len(),
                 pack_dir = ?pack_dir,
@@ -465,6 +465,7 @@ async fn main() -> Result<()> {
                 retrieval_utility_model.as_deref(),
                 server_cfg,
                 std::time::Duration::from_secs(shutdown_timeout_secs),
+                pack_registry,
             )
             .await
         }
@@ -576,12 +577,26 @@ fn build_shard_cmd(
     } else if let Some(csv_path) = csv {
         let tag_str = source.ok_or_else(|| {
             anyhow!(
-                "--csv requires --source <openaddresses|oa|osm> so the shard byte is set explicitly"
+                "--csv requires --source <openaddresses|oa> so the shard byte is set explicitly. \
+                 OSM data lives in PBF and is consumed via --pbf, not --csv — there is no \
+                 OSM-CSV ingest path."
             )
         })?;
         let tag = SourceTag::from_name(tag_str).ok_or_else(|| {
-            anyhow!("unknown --source '{tag_str}' (supported: osm, openaddresses (alias oa))")
+            anyhow!("unknown --source '{tag_str}' (supported: openaddresses (alias oa))")
         })?;
+        // The previous wording listed `osm` as a valid `--source` for
+        // `--csv`, but `load_addr_source` only knows OpenAddresses
+        // and aborts on every other tag. Rejecting the combination
+        // upfront produces a usable error before any work starts.
+        if tag != SourceTag::OpenAddresses {
+            bail!(
+                "--csv only supports --source openaddresses (or alias oa). \
+                 Got --source={}. For OSM data use --pbf <PATH> instead — there is no \
+                 OSM-CSV ingest path today.",
+                tag.name()
+            );
+        }
         info!(
             csv = %csv_path.display(),
             country = country.iso2(),
@@ -861,16 +876,64 @@ fn build_shards_all_cmd(
     Ok(())
 }
 
+/// Per-country coverage manifest: the set of `[[address]]` entry IDs
+/// that together provide complete national coverage. When `Some(ids)`
+/// is returned, `try_authoritative_build` REQUIRES every id to be
+/// staged on disk; otherwise the build falls back to PBF (which has
+/// always-complete national coverage).
+///
+/// `None` means "use whatever is staged" — historic behaviour for
+/// countries where the partial/full distinction doesn't apply.
+///
+/// Why declared in code rather than in `dl/regions/*.toml`:
+/// `butterfly-dl::regions` doesn't currently model coverage policy
+/// (issue out of scope here); the policy lives next to the build
+/// command that consumes it. When `dl/` grows a `coverage_complete`
+/// field per region this function becomes a one-line lookup.
+fn coverage_complete_ids(c: CountryId) -> Option<&'static [&'static str]> {
+    if c == CountryId::BE {
+        // BOSA / OpenAddresses: each region (Brussels, Flanders,
+        // Wallonia) is published in two languages — picking one
+        // language per region gives full national coverage. Any one
+        // of these IDs missing means the country is not fully
+        // represented; we'd silently drop entire regions if we built
+        // an authoritative-only shard.
+        Some(&["oa-be-bru-fr", "oa-be-vlg-nl", "oa-be-wal-fr"])
+    } else if c == CountryId::DE {
+        // 14 German state OA packs (Berlin and Bayern are not in the
+        // shipped index today — the OA upstream doesn't publish a
+        // single-pack feed for them, so the index treats their
+        // territory as PBF-only).
+        Some(&[
+            "oa-de-nw", "oa-de-bw", "oa-de-ni", "oa-de-he", "oa-de-rp", "oa-de-sn", "oa-de-bb",
+            "oa-de-sh", "oa-de-st", "oa-de-th", "oa-de-mv", "oa-de-sl", "oa-de-hh", "oa-de-hb",
+        ])
+    } else {
+        None
+    }
+}
+
 /// If the region index for `c` ships `[[address]]` entries with
 /// staged files under `<pbf_dir>/addresses/`, build the country shard
 /// from the authoritative source(s). Returns `Ok(true)` when a shard
-/// was written; `Ok(false)` when no authoritative source is available;
-/// `Err` on a build failure (caller should fall back to PBF/OSM).
+/// was written; `Ok(false)` when no authoritative source is available
+/// **or** when coverage is partial and the caller should fall back
+/// to PBF; `Err` on a build failure (caller should fall back to
+/// PBF/OSM).
 ///
-/// Today only BOSA (BE) is wired — the BOSA loader is the single
-/// authoritative source the geocode crate knows how to ingest. As
-/// BAN/BAG/etc. land they get a new arm here AND a new arm in
-/// `load_csv_source` (geocode/src/main.rs:`build_shard_cmd`).
+/// Coverage policy: when [`coverage_complete_ids`] declares a
+/// complete-coverage set for the country, EVERY id in that set must
+/// be staged on disk before we use the authoritative-only path —
+/// otherwise we'd silently drop entire regions (Belgium minus
+/// Wallonia, Germany minus 13 of 14 states, …). Partial sets log a
+/// WARN and return `Ok(false)` so the caller falls through to PBF.
+///
+/// Today only BOSA / OpenAddresses ingestion is wired — the BOSA
+/// loader is the authoritative source the geocode crate knows how
+/// to ingest, alongside the OpenAddresses streaming loader (#96
+/// §"Data Sources"). As BAN/BAG/etc. land they get a new arm here
+/// AND a new arm in `load_csv_source` (geocode/src/main.rs:
+/// `build_shard_cmd`).
 fn try_authoritative_build(
     c: CountryId,
     pbf_dir: &std::path::Path,
@@ -915,20 +978,48 @@ fn try_authoritative_build(
     // Walk the [[address]] section, collect every entry with both a
     // known loader AND a staged file on disk.
     let mut staged: Vec<(PathBuf, &'static str)> = Vec::new();
+    let mut staged_ids: Vec<String> = Vec::new();
     for entry in &region_index.address {
         let tag = entry.source.as_deref().unwrap_or("");
         let static_tag: &'static str = match tag {
             "bosa" => "bosa",
+            "openaddresses" | "oa" => "openaddresses",
             // BAN/BAG/G-NAF/BEV/swisstopo lack loaders today; ignore.
             _ => continue,
         };
         let candidate = addresses_dir.join(format!("{}.{}", entry.id, address_extension(entry)));
         if candidate.is_file() {
             staged.push((candidate, static_tag));
+            staged_ids.push(entry.id.clone());
         }
     }
     if staged.is_empty() {
         return Ok(false);
+    }
+
+    // Coverage policy: if the country has a declared complete-set, every
+    // ID in that set must be present on disk; otherwise we'd silently
+    // build an authoritative-only shard with regional gaps (e.g. all of
+    // Wallonia missing, or 13 of 14 German states missing). Falling
+    // back to PBF is the safe choice.
+    if let Some(required) = coverage_complete_ids(c) {
+        let staged_set: std::collections::HashSet<&str> =
+            staged_ids.iter().map(String::as_str).collect();
+        let missing: Vec<&&str> = required
+            .iter()
+            .filter(|id| !staged_set.contains(*id))
+            .collect();
+        if !missing.is_empty() {
+            warn!(
+                country = c.iso2(),
+                staged_ids = ?staged_ids,
+                missing_ids = ?missing,
+                required = ?required,
+                "authoritative-source coverage is incomplete for {}; falling back to PBF (set --pbf-dir/addresses with the full coverage set to use authoritative ingest)",
+                c.iso2()
+            );
+            return Ok(false);
+        }
     }
 
     let out = out_dir.join(format!("{}.bfgs", c.iso2().to_ascii_lowercase()));
@@ -1017,7 +1108,11 @@ fn candidate_pbf_names(c: CountryId) -> Vec<String> {
     } else if c == CountryId::IT {
         "italy"
     } else if c == CountryId::US {
-        "us"
+        // butterfly-dl's region index stages the file as
+        // `united-states.pbf`. The shorter `us.pbf` form was the old
+        // convention; keep both via the alias list below so manually
+        // staged files under either name still get picked up.
+        "united-states"
     } else if c == CountryId::JP {
         "japan"
     } else if c == CountryId::BR {
@@ -1034,6 +1129,15 @@ fn candidate_pbf_names(c: CountryId) -> Vec<String> {
         v.push(format!("{long}.pbf"));
         v.push(format!("{long}.osm.pbf"));
         v.push(format!("{long}-latest.osm.pbf"));
+    }
+    // Country-specific aliases for filenames that don't follow the
+    // single canonical Geofabrik long name. `united-states` is the
+    // butterfly-dl region index canonical; `us` is the historical
+    // operator shorthand. Keep both in the probe list.
+    if c == CountryId::US {
+        v.push("us.pbf".to_string());
+        v.push("us.osm.pbf".to_string());
+        v.push("us-latest.osm.pbf".to_string());
     }
     v.push(format!("{}.pbf", c.iso2().to_ascii_lowercase()));
     v.push(format!("{}.osm.pbf", c.iso2().to_ascii_lowercase()));
@@ -1108,6 +1212,7 @@ async fn serve_cmd(
     retrieval_utility_model_path: Option<&std::path::Path>,
     server_cfg: ServerConfig,
     shutdown_timeout: std::time::Duration,
+    pack_registry: Arc<butterfly_geocode::routing::PackRegistry>,
 ) -> Result<()> {
     // Resolve the retrieval-utility scorer first so we can plumb it
     // through to the neural parser at construction time. `learned`
@@ -1207,6 +1312,7 @@ async fn serve_cmd(
         }
     };
     state = state.with_parser(parser_backend);
+    state = state.with_pack_registry(pack_registry);
     if let Some(p) = rerank_model_path {
         info!(model = %p.display(), "loading GBDT reranker");
         let model = GbdtModel::load(p).context("loading reranker")?;
@@ -1263,14 +1369,16 @@ async fn serve_cmd(
     let rest_fut: std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send>> =
         if let Some(listener) = rest_listener {
             let (app, gc_handle) = build_router_with_config(Arc::clone(&state), server_cfg.clone());
-            // Spawn the per-IP map garbage-collector once we're inside
-            // a Tokio runtime context. `spawn_governor_gc` is
-            // idempotent across this fn — only the first call per
-            // process actually spawns.
-            butterfly_geocode::server::spawn_governor_gc(gc_handle);
+            // Spawn the per-IP map garbage-collector inside the Tokio
+            // runtime. The returned `StartedGovernorGc` aborts the GC
+            // task on drop, so we move it into the REST future so the
+            // task lives exactly as long as the server does. No more
+            // process-wide OnceLock — every router built in this
+            // process gets its own GC, every one cleans up on drop.
+            let started_gc = butterfly_geocode::server::spawn_governor_gc(gc_handle);
             let serve_shutdown = Arc::clone(&shutdown);
             Box::pin(async move {
-                axum::serve(
+                let result = axum::serve(
                     listener,
                     app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
                 )
@@ -1278,7 +1386,13 @@ async fn serve_cmd(
                     serve_shutdown.notified().await;
                 })
                 .await
-                .context("REST server crashed")
+                .context("REST server crashed");
+                // Drop the GC AFTER the server is fully shut down so
+                // we don't abort it mid-request. `drop` is explicit
+                // here for documentation, even though falling out of
+                // scope would do the same.
+                drop(started_gc);
+                result
             })
         } else {
             Box::pin(async { std::future::pending::<Result<()>>().await })

--- a/geocode/src/osm_extract/mod.rs
+++ b/geocode/src/osm_extract/mod.rs
@@ -292,8 +292,24 @@ where
     // Resolve the canonical street + remember which source it came
     // from. The fallback path (`addr:full` / `addr:place`) drives the
     // relaxed signal threshold below.
+    //
+    // Country packs may override the canonical `street` key — Japan's
+    // pack remaps `street` to `addr:full` because Japanese addresses
+    // don't decompose into street + housenumber. When the pack's
+    // override IS one of the documented fallback tags, the captured
+    // value is semantically a Fallback signal even though it entered
+    // via the pack's `street` channel; treating it as Strict would
+    // require a housenumber and silently drop every JP record without
+    // a separate `addr:housenumber` tag (a vanishingly rare condition
+    // in OSM JP data, cf. Copilot review on PR #183).
+    let pack_street_is_fallback_tag = cfg.street == "addr:full" || cfg.street == "addr:place";
     let (resolved_street, source) = if !street.is_empty() {
-        (street, StreetSource::Strict)
+        let s = if pack_street_is_fallback_tag {
+            StreetSource::Fallback
+        } else {
+            StreetSource::Strict
+        };
+        (street, s)
     } else if !full.is_empty() {
         (full, StreetSource::Fallback)
     } else if !place.is_empty() {
@@ -378,27 +394,75 @@ mod tests {
     }
 
     #[test]
-    fn pack_override_for_japan_treats_addr_full_as_strict_only_when_specified() {
-        // JP pack publishes street=addr:full. Records arriving via
-        // that override are then classified as Strict (the pack
-        // declared this is the canonical channel for the country) and
-        // require a housenumber per the strict rule.
+    fn pack_override_to_addr_full_treats_value_as_fallback_signal() {
+        // JP pack publishes street=addr:full. The value DOES enter
+        // through the pack's `street` channel, but `addr:full` is
+        // semantically a fallback tag (block-based addressing) and
+        // must NOT be subjected to the strict-path housenumber
+        // requirement. Otherwise every JP record without a separate
+        // `addr:housenumber` is silently dropped — the bug Copilot
+        // flagged on PR #183.
         let cfg = OsmTags {
             postcode: "addr:postcode".to_string(),
             street: "addr:full".to_string(),
             housenumber: "addr:housenumber".to_string(),
             city: "addr:city".to_string(),
         };
-        let (street, source, hn, _, _) = run(
+        let (street, source, hn, pc, loc) = run(
             tags(&[
                 ("addr:full", "東京都千代田区千代田1-1"),
-                ("addr:housenumber", "1"),
+                ("addr:postcode", "100-0001"),
             ]),
             &cfg,
         );
         assert_eq!(street, "東京都千代田区千代田1-1");
+        assert_eq!(
+            source,
+            StreetSource::Fallback,
+            "pack-override of street to addr:full must surface as Fallback"
+        );
+        assert!(hn.is_empty());
+        assert!(
+            has_minimum_signal(source, &hn, &pc, &loc),
+            "JP-style addr:full + postcode must be accepted (relaxed signal)"
+        );
+    }
+
+    #[test]
+    fn pack_override_to_addr_place_treats_value_as_fallback_signal() {
+        // `addr:place` is the second documented fallback tag (used in
+        // some Latin American + rural contexts where the address has
+        // a place name but no street). Any pack that elects to remap
+        // `street` to `addr:place` must trigger the same relaxed
+        // signal path as a pack-overridden `addr:full`.
+        let cfg = OsmTags {
+            postcode: "addr:postcode".to_string(),
+            street: "addr:place".to_string(),
+            housenumber: "addr:housenumber".to_string(),
+            city: "addr:city".to_string(),
+        };
+        let (_, source, hn, pc, loc) = run(
+            tags(&[("addr:place", "Some Place"), ("addr:city", "City")]),
+            &cfg,
+        );
+        assert_eq!(source, StreetSource::Fallback);
+        assert!(hn.is_empty());
+        assert!(has_minimum_signal(source, &hn, &pc, &loc));
+    }
+
+    #[test]
+    fn standard_pack_with_addr_street_still_strict() {
+        // Sanity: the BE/FR/DE/etc. shipped packs use street=addr:street.
+        // Records via the standard channel must remain Strict and
+        // demand a housenumber.
+        let cfg = default_tags();
+        let (street, source, hn, _, _) = run(
+            tags(&[("addr:street", "Rue Wayez"), ("addr:housenumber", "122")]),
+            &cfg,
+        );
+        assert_eq!(street, "Rue Wayez");
         assert_eq!(source, StreetSource::Strict);
-        assert_eq!(hn, "1");
+        assert_eq!(hn, "122");
     }
 
     #[test]

--- a/geocode/src/parser/heuristic.rs
+++ b/geocode/src/parser/heuristic.rs
@@ -58,12 +58,10 @@ pub fn parse_with_classifier(text: &str) -> ParsedQuery {
 
 fn parse_for_country(text: &str, country: CountryId) -> ParsedQuery {
     let original = text.to_string();
-    let mut hypothesis = ParseHypothesis::default();
     let mut flags = RecoveryFlags::default();
 
     let postcode = extract_postcode_for(text, country);
-    if let Some(ref pc) = postcode {
-        hypothesis.postcode_candidates.push((pc.clone(), 1.0));
+    if postcode.is_some() {
         flags.had_postcode = true;
     }
 
@@ -72,9 +70,23 @@ fn parse_for_country(text: &str, country: CountryId) -> ParsedQuery {
         .map(|pc| strip_token(text, pc))
         .unwrap_or_else(|| text.to_string());
 
+    // Detect whether the postcode appeared *before* or *after* the
+    // bulk of the address. Reordered queries put the postcode first
+    // (`9770 Kruisem René D'Huyvetterstraat 5c`); the standard form
+    // puts it after the street (`René D'Huyvetterstraat 5c, 9770
+    // Kruisem`). The heuristic used to assume the standard form
+    // exclusively — recall@1 on reordered queries cratered to ~2%
+    // because the locality was always taken from the *last* word.
+    let postcode_at_start = postcode
+        .as_ref()
+        .map(|pc| {
+            let trimmed = text.trim_start();
+            trimmed.starts_with(pc.as_str())
+        })
+        .unwrap_or(false);
+
     let house = extract_house_number(&without_postcode);
-    if let Some(ref h) = house {
-        hypothesis.house_candidates.push((h.clone(), 1.0));
+    if house.is_some() {
         flags.had_house_number = true;
     }
 
@@ -84,41 +96,169 @@ fn parse_for_country(text: &str, country: CountryId) -> ParsedQuery {
         .unwrap_or(without_postcode);
 
     let remainder = clean_separators(&without_house);
-    if !remainder.is_empty() {
-        let words: Vec<&str> = remainder.split_whitespace().collect();
-        if words.len() >= 3 {
-            // With a postcode anchor, the LAST word is most likely the
-            // locality (Belgian convention). Split it off the street
-            // candidate so the executor's exact street index hits.
-            let last = words.last().copied().unwrap_or("");
-            let street_part = words[..words.len() - 1].join(" ");
-            if !street_part.is_empty() {
-                hypothesis.street_candidates.push((street_part, 1.0));
-            }
-            if !last.is_empty() {
-                hypothesis.locality_candidates.push((last.to_string(), 0.5));
+    let remainder_words: Vec<String> = remainder
+        .split_whitespace()
+        .map(str::to_string)
+        .collect();
+
+    // Emit one hypothesis per plausible (street, locality) split.
+    // Each variant becomes its own ParseHypothesis; the executor
+    // canonicalizes + dedups the resulting programs (one per unique
+    // canonical form), so identical splits collapse cleanly.
+    //
+    // Variants (in priority order — the first surviving one becomes
+    // the representative for any deduped equivalence class):
+    //
+    //   1. **last-word-locality** (standard postcode-suffix layout):
+    //       words[..-1] = street, words[-1] = locality.
+    //   2. **first-word-locality** (reordered / postcode-prefix
+    //       layout): words[0] = locality, words[1..] = street.
+    //   3. **two-word-locality** when the remainder has ≥ 4 words:
+    //       words[..-2] = street, words[-2..] = locality (covers
+    //       multi-word names like "La Louvière", "Sint Niklaas").
+    //   4. **whole-remainder-as-street** (low weight): handles
+    //       multi-word streets where the locality is implicit in
+    //       the postcode anchor.
+    //
+    // All variants share the same postcode + housenumber. The
+    // executor's recombination invariant collapses the canonical
+    // forms — we don't worry about over-emission here.
+    let mut hypotheses: Vec<ParseHypothesis> = Vec::new();
+    // Build a fresh hypothesis pre-seeded with the shared
+    // postcode/housenumber. We pass `flags` by reference rather than
+    // capturing — emitting locality variants below mutates `flags`,
+    // and a closure capturing `&flags` would block those edits.
+    fn base_hypothesis(
+        country: CountryId,
+        flags: &RecoveryFlags,
+        postcode: Option<&String>,
+        house: Option<&String>,
+    ) -> ParseHypothesis {
+        let mut h = ParseHypothesis {
+            field_reliability: build_field_mask(flags),
+            retrieval_policy: retrieval_policy_for(country),
+            strictness: Strictness::Exact,
+            ..ParseHypothesis::default()
+        };
+        if let Some(pc) = postcode {
+            h.postcode_candidates.push((pc.clone(), 1.0));
+        }
+        if let Some(hn) = house {
+            h.house_candidates.push((hn.clone(), 1.0));
+        }
+        h
+    }
+    let pc_ref = postcode.as_ref();
+    let hn_ref = house.as_ref();
+
+    if remainder_words.is_empty() {
+        // No remainder — postcode-only / postcode+housenumber-only
+        // query. One hypothesis covers it; the clean fast path
+        // applies.
+        hypotheses.push(base_hypothesis(country, &flags, pc_ref, hn_ref));
+    } else {
+        let n = remainder_words.len();
+
+        // **Primary hypothesis**: matches the original parser's
+        // behaviour exactly so the unambiguous case stays on the
+        // clean fast path AND the executor sees the same scoring
+        // shape it always did. Diversity variants below add
+        // additional hypotheses ONLY when there's positive signal
+        // for ambiguity.
+        //
+        // Splitting policy:
+        //   - n ≥ 3: words[..-1] = street, words[-1] = locality
+        //     (standard layout); add the full remainder as a
+        //     low-weight street candidate to cover multi-word
+        //     streets where the locality is implicit in the
+        //     postcode anchor.
+        //   - n == 2: keep both words as the street; the
+        //     postcode anchor handles disambiguation. The pre-#181
+        //     parser used this same shape and the
+        //     `extract_clean_query_features` regression proved any
+        //     other split produces a low fuzzy match at scoring
+        //     time.
+        //   - n == 1: take the single token as the locality
+        //     candidate.
+        {
+            let mut h = base_hypothesis(country, &flags, pc_ref, hn_ref);
+            if n >= 3 {
+                let last = remainder_words[n - 1].clone();
+                let street_part = remainder_words[..n - 1].join(" ");
+                if !street_part.is_empty() {
+                    h.street_candidates.push((street_part, 1.0));
+                }
+                h.locality_candidates.push((last, 0.5));
+                flags.had_locality = true;
+                // Whole-remainder fallback (low weight) for
+                // multi-word streets.
+                h.street_candidates.push((remainder.clone(), 0.3));
+            } else if n == 2 {
+                // Two tokens: keep them together as the street.
+                // Splitting into street+locality on n==2 produced
+                // low fuzzy match scores in `extract_features`.
+                h.street_candidates.push((remainder.clone(), 1.0));
+            } else {
+                // n == 1: single token after stripping
+                // postcode+house. Treat it as the locality.
+                h.locality_candidates
+                    .push((remainder_words[0].clone(), 0.5));
                 flags.had_locality = true;
             }
-            // Also keep the full remainder as a low-weight street
-            // candidate — covers cases where the locality is multi-word.
-            hypothesis.street_candidates.push((remainder, 0.3));
-        } else {
-            // No postcode → keep both interpretations. The executor's
-            // locality scorer will prefer the right one.
-            hypothesis.street_candidates.push((remainder.clone(), 1.0));
-            if words.len() >= 2 {
-                let last = words.last().copied().unwrap_or("");
-                if !last.is_empty() {
-                    hypothesis.locality_candidates.push((last.to_string(), 0.5));
-                    flags.had_locality = true;
-                }
+            hypotheses.push(h);
+        }
+
+        // **Ambiguity variant — postcode at start (reordered)**.
+        // Emit ONLY when we have explicit signal that the layout is
+        // reordered (`9770 Kruisem René D'Huyvetterstraat 5c`); the
+        // recall@1 on these queries was 2% before this variant
+        // existed because the locality was always taken from the
+        // last word (D'Huyvetterstraat), missing every Kruisem
+        // record. Skipping the variant when the signal is absent
+        // keeps the clean fast path warm for the typical layout.
+        if postcode_at_start && n >= 2 {
+            let first = remainder_words[0].clone();
+            let street_part = remainder_words[1..].join(" ");
+            let mut h = base_hypothesis(country, &flags, pc_ref, hn_ref);
+            if !street_part.is_empty() {
+                h.street_candidates.push((street_part, 1.0));
             }
+            h.locality_candidates.push((first, 0.8));
+            hypotheses.push(h);
+            flags.had_locality = true;
+        }
+
+        // **Ambiguity variant — two-word locality**. Belgian /
+        // French / Spanish localities frequently span two tokens
+        // ("La Louvière", "Saint Niklaas", "Las Rozas"). Without
+        // this hypothesis the street picks up the second locality
+        // word and the street index misses. Emit only when:
+        //   - the remainder has ≥ 4 words so the street fragment
+        //     carries real signal, AND
+        //   - we have a postcode anchor — without it, multiple
+        //     hypotheses widen the executor's budget tier without
+        //     adding signal (the postcode is the strongest blocker
+        //     and the two-word-locality variant only helps when
+        //     paired with it).
+        if n >= 4 && postcode.is_some() {
+            let last_two = remainder_words[n - 2..].join(" ");
+            let street_part = remainder_words[..n - 2].join(" ");
+            let mut h = base_hypothesis(country, &flags, pc_ref, hn_ref);
+            if !street_part.is_empty() {
+                h.street_candidates.push((street_part, 1.0));
+            }
+            h.locality_candidates.push((last_two, 0.4));
+            hypotheses.push(h);
         }
     }
 
-    hypothesis.field_reliability = build_field_mask(&flags);
-    hypothesis.retrieval_policy = retrieval_policy_for(country);
-    hypothesis.strictness = Strictness::Exact;
+    // Defensive: if we somehow emitted nothing (empty input), keep
+    // the ParsedQuery::is_clean() invariant alive with one empty
+    // hypothesis. The executor's empty-program check returns no
+    // results anyway.
+    if hypotheses.is_empty() {
+        hypotheses.push(base_hypothesis(country, &flags, pc_ref, hn_ref));
+    }
 
     let confidence = score_confidence(&flags);
 
@@ -128,7 +268,7 @@ fn parse_for_country(text: &str, country: CountryId) -> ParsedQuery {
         // for the clean-query path; `parse_with_classifier` keeps
         // the full posterior. We populate a placeholder here.
         country_candidates: vec![(country, 1.0)],
-        hypotheses: vec![hypothesis],
+        hypotheses,
         global_confidence: confidence,
         recovery_flags: flags,
         execution_budget: ExecutionBudget::default(),
@@ -352,6 +492,73 @@ mod tests {
         let h = &q.hypotheses[0];
         // L-2453 is canonicalized to bare 2453 for shard lookup.
         assert_eq!(h.postcode_candidates[0].0, "2453");
+    }
+
+    #[test]
+    fn reordered_query_emits_first_word_locality_hypothesis() {
+        // Bench shape: `9770 Kruisem René D'Huyvetterstraat 5c`.
+        // The standard (last-word-locality) hypothesis would label
+        // `D'Huyvetterstraat` as the locality and `Kruisem René` as
+        // the street, missing every Kruisem record. The
+        // postcode-at-start ambiguity variant emits a hypothesis
+        // with `Kruisem` as the locality.
+        let q = parse_heuristic("9770 Kruisem René D'Huyvetterstraat 5c", CountryId::BE);
+        assert!(
+            q.hypotheses.len() >= 2,
+            "reordered query must emit ≥ 2 hypotheses (got {})",
+            q.hypotheses.len()
+        );
+        let has_kruisem = q.hypotheses.iter().any(|h| {
+            h.locality_candidates
+                .iter()
+                .any(|(loc, _)| loc.eq_ignore_ascii_case("Kruisem"))
+        });
+        assert!(
+            has_kruisem,
+            "expected at least one hypothesis with locality=Kruisem; got: {:?}",
+            q.hypotheses
+                .iter()
+                .map(|h| h.locality_candidates.clone())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn standard_query_keeps_clean_fast_path() {
+        // The Zero-Cost-on-Clean-Queries NFR depends on
+        // `is_clean()` being true for the typical postcode-suffix
+        // form. The hypothesis-diversity work must not regress this
+        // for the common shape — we only emit ≥ 2 hypotheses when we
+        // have positive signal that the layout is ambiguous.
+        let q = parse_heuristic("Rue Wayez 122 1070 Anderlecht", CountryId::BE);
+        assert!(
+            q.is_clean(),
+            "standard postcode-suffix layout must keep is_clean()==true; got {} hypotheses",
+            q.hypotheses.len()
+        );
+    }
+
+    #[test]
+    fn multi_word_locality_query_emits_two_word_locality_variant() {
+        // `Rue Hamoir 21, 7100 La Louvière` — the standard split
+        // names `Louvière` as the locality and `Rue Hamoir 21 La` as
+        // the street, missing the actual `La Louvière` locality.
+        // The two-word-locality variant labels `La Louvière` as
+        // locality.
+        let q = parse_heuristic("Rue Hamoir 21 7100 La Louvière", CountryId::BE);
+        let has_la_louviere = q.hypotheses.iter().any(|h| {
+            h.locality_candidates
+                .iter()
+                .any(|(loc, _)| loc.eq_ignore_ascii_case("La Louvière"))
+        });
+        assert!(
+            has_la_louviere,
+            "expected at least one hypothesis with locality='La Louvière'; got: {:?}",
+            q.hypotheses
+                .iter()
+                .map(|h| h.locality_candidates.clone())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/geocode/src/routing/classifier.rs
+++ b/geocode/src/routing/classifier.rs
@@ -17,16 +17,34 @@
 //!
 //! Adding a country = drop a TOML pack. Zero classifier code changes.
 
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use super::{CountryId, CountryPack, PackRegistry};
 
-/// Classifier holding a (lazily-initialised) [`PackRegistry`]. Cheap
-/// to clone (refcount-only) — the underlying `Arc<CountryPack>`s are
-/// shared across calls.
+/// Classifier holding a [`PackRegistry`]. Two construction modes are
+/// supported:
+///
+/// 1. [`Classifier::shipped`] — process-wide singleton backed by the
+///    binary's embedded shipped packs. Used by call sites that don't
+///    have access to a `ServerState` (heuristic parser tests, the
+///    legacy `classify_country()` free function, neural decoder
+///    fast-path lookup).
+/// 2. [`Classifier::from_registry`] — owned classifier backed by an
+///    arbitrary registry (typically built from
+///    `PackRegistry::shipped_with_overrides`). The HTTP server uses
+///    this so `--pack-dir` overrides actually reach query-time
+///    classification + bbox dispatch.
 #[derive(Debug)]
 pub struct Classifier {
-    registry: &'static PackRegistry,
+    registry: ClassifierRegistry,
+}
+
+#[derive(Debug)]
+enum ClassifierRegistry {
+    /// Borrowed from a process-wide static. The shipped singleton.
+    Static(&'static PackRegistry),
+    /// Owned by an `Arc`. The pack-dir-aware path.
+    Owned(Arc<PackRegistry>),
 }
 
 impl Classifier {
@@ -40,8 +58,20 @@ impl Classifier {
             let reg = REG.get_or_init(|| {
                 PackRegistry::shipped().expect("shipped country packs must compile")
             });
-            Classifier { registry: reg }
+            Classifier {
+                registry: ClassifierRegistry::Static(reg),
+            }
         })
+    }
+
+    /// Construct an owned classifier from an arbitrary registry. The
+    /// server uses this with `PackRegistry::shipped_with_overrides`
+    /// so `--pack-dir` overrides reach query-time classification.
+    #[must_use]
+    pub fn from_registry(registry: Arc<PackRegistry>) -> Self {
+        Self {
+            registry: ClassifierRegistry::Owned(registry),
+        }
     }
 
     /// Classify the country distribution implied by `text`. Returns a
@@ -54,7 +84,7 @@ impl Classifier {
     pub fn classify(&self, text: &str) -> Vec<(CountryId, f32)> {
         let lower = text.to_lowercase();
         let scores: Vec<(CountryId, f32)> = self
-            .registry
+            .registry()
             .iter()
             .map(|p: &std::sync::Arc<CountryPack>| (p.country, p.score(text, &lower)))
             .collect();
@@ -63,7 +93,40 @@ impl Classifier {
 
     #[must_use]
     pub fn registry(&self) -> &PackRegistry {
-        self.registry
+        match &self.registry {
+            ClassifierRegistry::Static(r) => r,
+            ClassifierRegistry::Owned(r) => r.as_ref(),
+        }
+    }
+
+    /// Return every country whose bbox contains the point. Mirrors the
+    /// free function [`super::supported_countries_for_point`] but uses
+    /// THIS classifier's registry — the difference matters when an
+    /// operator launched the server with `--pack-dir` overrides that
+    /// patch a shipped pack's bbox.
+    #[must_use]
+    pub fn supported_for_point(&self, lat: f64, lon: f64) -> Vec<CountryId> {
+        self.registry()
+            .iter()
+            .filter(|p| p.bbox.contains(lat, lon))
+            .map(|p| p.country)
+            .collect()
+    }
+
+    /// Smallest-bbox country containing the point. Mirrors the free
+    /// function [`super::country_for_point`].
+    #[must_use]
+    pub fn country_for_point(&self, lat: f64, lon: f64) -> Option<CountryId> {
+        self.registry()
+            .iter()
+            .filter(|p| p.bbox.contains(lat, lon))
+            .min_by(|a, b| {
+                a.bbox
+                    .area_deg2()
+                    .partial_cmp(&b.bbox.area_deg2())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|p| p.country)
     }
 }
 

--- a/geocode/src/routing/pack.rs
+++ b/geocode/src/routing/pack.rs
@@ -720,9 +720,23 @@ impl PackRegistry {
             }
         }
         if !errors.is_empty() {
+            // Production policy: malformed override packs are a hard
+            // boot failure. The CLI/README contract is that
+            // `--pack-dir` either fully replaces the targeted shipped
+            // packs or fails the boot — silently falling through to
+            // the shipped pack contradicts the declared intent and
+            // produces classifier results that mismatch what the
+            // operator expects.
             for e in &errors {
-                tracing::warn!(error = %e, "override country pack failed to load");
+                tracing::error!(error = %e, "override country pack failed to load");
             }
+            bail!(
+                "override pack directory {} contains {} malformed pack(s); fix or remove them, \
+                 then retry — failing boot to avoid silently degrading classifier accuracy: {:?}",
+                dir.display(),
+                errors.len(),
+                errors
+            );
         }
         tracing::info!(
             dir = %dir.display(),

--- a/geocode/src/server/flight.rs
+++ b/geocode/src/server/flight.rs
@@ -46,7 +46,7 @@ use tonic::{Request, Response, Status, Streaming};
 
 use crate::control::budget::compute_budget;
 use crate::geocoder::executor::{GeocodedResult, apply_rerank, execute_with_control};
-use crate::routing::{CountryId, classify_country};
+use crate::routing::CountryId;
 
 use super::state::ServerState;
 
@@ -317,7 +317,7 @@ fn resolve_dispatch(query: &str, pinned: Option<&str>, state: &ServerState) -> O
     {
         return Some(c);
     }
-    let posterior = classify_country(query);
+    let posterior = state.classifier.classify(query);
     state.pick_shard(&posterior).map(|(c, _)| c)
 }
 

--- a/geocode/src/server/handlers.rs
+++ b/geocode/src/server/handlers.rs
@@ -42,7 +42,7 @@ use crate::control::budget::compute_budget;
 use crate::geocoder::executor::{
     GeocodedResult, apply_rerank, build_nearest_result, execute_with_control, reason,
 };
-use crate::routing::{CountryId, classify_country, supported_countries_for_point};
+use crate::routing::CountryId;
 use crate::shard::reader::haversine_m;
 
 #[derive(Debug, Deserialize)]
@@ -113,7 +113,7 @@ pub async fn forward(
             c
         }
         None => {
-            let posterior = classify_country(&params.q);
+            let posterior = state.classifier.classify(&params.q);
             match state.pick_shard(&posterior) {
                 Some((c, _)) => c,
                 None => {
@@ -134,7 +134,8 @@ pub async fn forward(
     // async caller can dispatch on each independently without nested
     // `Result<Result<...>>` gymnastics.
     enum Outcome {
-        Ok(Vec<GeocodedResult>, Confidence),
+        // (final candidates, action, raw_count_pre_rerank)
+        Ok(Vec<GeocodedResult>, Confidence, usize),
         ParserFailed(String, &'static str),
         Admission(crate::control::AdmissionError),
     }
@@ -171,6 +172,7 @@ pub async fn forward(
             Ok(r) => r,
             Err(e) => return Outcome::Admission(e),
         };
+        let raw_count = raw.len();
         let (mut ranked, action) = apply_rerank(
             raw,
             &parsed,
@@ -182,11 +184,11 @@ pub async fn forward(
         for r in &mut ranked {
             r.country = Some(dispatch_country.iso2());
         }
-        Outcome::Ok(ranked, action)
+        Outcome::Ok(ranked, action, raw_count)
     })
     .await;
-    let (results, action) = match join_result {
-        Ok(Outcome::Ok(r, a)) => (r, a),
+    let (results, action, raw_count) = match join_result {
+        Ok(Outcome::Ok(r, a, c)) => (r, a, c),
         Ok(Outcome::ParserFailed(msg, name)) => {
             tracing::error!(error = %msg, parser = %name, "parser failed");
             return error_response(
@@ -211,10 +213,14 @@ pub async fn forward(
         geojson_response(&results, include_debug, action)
     } else {
         // On reject the rerank layer drops every candidate. Surface
-        // `BELOW_THRESHOLD` on the response envelope so clients can
-        // distinguish "no results" from "results below the action
-        // threshold" without re-deriving from the score.
-        let reason_codes = if matches!(action, Confidence::Reject) {
+        // `BELOW_THRESHOLD` ONLY when the executor produced ≥ 1
+        // candidate AND the rerank action threshold cleared them all
+        // — this is the case the code clients want to distinguish from
+        // "the executor genuinely found nothing". If `raw_count == 0`
+        // the rejection is empty-by-construction (no postings hit, no
+        // anchors satisfied) and we omit the reason code so clients
+        // see action=`reject` with no `BELOW_THRESHOLD` claim.
+        let reason_codes = if matches!(action, Confidence::Reject) && raw_count > 0 {
             Some(vec![crate::confidence::RC_BELOW_THRESHOLD.to_string()])
         } else {
             None
@@ -287,13 +293,13 @@ pub async fn reverse(
         let candidate_countries: Vec<CountryId> = if let Some(c) = pinned {
             vec![c]
         } else {
-            let mut candidates = supported_countries_for_point(lat, lon);
+            let mut candidates = state_clone.classifier.supported_for_point(lat, lon);
             // Sort by bbox area ascending = smallest-bbox-first
             // heuristic. The smallest containing bbox is most
             // commonly the right country (typical case: the point
             // lives squarely inside the smaller of two overlapping
             // bboxes).
-            let registry = crate::routing::Classifier::shipped().registry();
+            let registry = state_clone.classifier.registry();
             candidates.sort_by(|a, b| {
                 let area = |c: &CountryId| {
                     registry

--- a/geocode/src/server/mod.rs
+++ b/geocode/src/server/mod.rs
@@ -301,10 +301,7 @@ impl PeerIpKey {
                         continue;
                     };
                     let value = value.trim_matches('"');
-                    // RFC 7239 also allows `for="[2001:db8::1]:8080"`.
-                    // Strip any port.
-                    let host = value.rsplit_once(':').map(|(h, _)| h).unwrap_or(value);
-                    let host = host.trim_matches('[').trim_matches(']');
+                    let host = parse_forwarded_host(value);
                     if let Ok(ip) = host.parse::<IpAddr>()
                         && !self.is_trusted(ip)
                     {
@@ -314,6 +311,57 @@ impl PeerIpKey {
             }
         }
         None
+    }
+}
+
+/// Parse the host portion of an RFC 7239 `for=` value. The grammar is
+/// `host = IP-literal / IPv4address / reg-name`, optionally followed
+/// by `:port`. The bracketed IP-literal form (`[2001:db8::1]`) is
+/// mandatory whenever a port follows an IPv6 address — without that
+/// rule there's no way to tell where the address ends and the port
+/// begins.
+///
+/// The previous implementation used `rsplit_once(':')` which split
+/// inside the IPv6 address itself for `[2001:db8::1]` (no port) —
+/// returning `[2001:db8:` as the host, which would never parse. Result:
+/// every IPv6 client behind a trusted proxy collapsed to `None` from
+/// the XFF lookup and the rate limiter then keyed on the proxy IP
+/// instead, putting every IPv6 client into one bucket.
+///
+/// Cases handled:
+///   `192.0.2.1`              → `192.0.2.1`
+///   `192.0.2.1:8080`         → `192.0.2.1`
+///   `[2001:db8::1]`          → `2001:db8::1`
+///   `[2001:db8::1]:8080`     → `2001:db8::1`
+///   `2001:db8::1`            → `2001:db8::1` (raw IPv6, no port — RFC
+///                              technically forbids this without
+///                              brackets, but real proxies sometimes
+///                              emit it; accept both shapes)
+fn parse_forwarded_host(value: &str) -> &str {
+    let v = value.trim();
+    if let Some(rest) = v.strip_prefix('[') {
+        // Bracketed: address is everything up to the first ']'.
+        if let Some(end) = rest.find(']') {
+            return &rest[..end];
+        }
+        // Malformed (`[` with no `]`); fall back to verbatim minus the
+        // bracket so the parse below has a fighting chance.
+        return rest;
+    }
+    // No brackets: count the ':' to disambiguate IPv4-with-port from
+    // raw IPv6.
+    let colons = v.bytes().filter(|b| *b == b':').count();
+    match colons {
+        0 => v,
+        1 => {
+            // IPv4 with port (`192.0.2.1:8080`). Split once.
+            v.rsplit_once(':').map(|(h, _)| h).unwrap_or(v)
+        }
+        _ => {
+            // Raw IPv6 (`2001:db8::1`) — no port can be appended
+            // without brackets per RFC 3986/7239, so keep verbatim.
+            v
+        }
     }
 }
 
@@ -352,28 +400,91 @@ fn prometheus_pair() -> &'static (PrometheusMetricLayer<'static>, PrometheusHand
 ///
 /// Tests and most call sites use this. Operators that need to override
 /// the rate-limit knobs reach for [`build_router_with_config`].
+///
+/// **Background lifecycle**: this constructor spawns the per-IP rate
+/// limiter garbage-collector itself (when called inside a Tokio
+/// runtime) and binds its lifetime to the returned [`Router`] via a
+/// hidden state extension. When the router is dropped the GC task is
+/// aborted automatically — the leak that an earlier refactor
+/// reintroduced (Copilot review on PR #183) is now structurally
+/// impossible at this entry point.
+///
+/// Production servers that need to control the GC's lifetime
+/// explicitly (e.g. for graceful shutdown coordination) use
+/// [`build_router_with_config`] and manage the [`GovernorGcHandle`]
+/// themselves.
 pub fn build_router(state: Arc<ServerState>) -> Router {
-    let (router, _gc) = build_router_with_config(state, ServerConfig::with_defaults());
-    router
+    let (router, gc) = build_router_with_config(state, ServerConfig::with_defaults());
+    // Tie the GC task's lifetime to the router by extending the
+    // router's state with the handle. When the last clone of the
+    // router is dropped the handle is dropped, which aborts the
+    // background task. Calling this outside a Tokio runtime is
+    // tolerated by `GovernorGcHandle::spawn_inside_runtime` — it
+    // skips the spawn (the rate-limiter map will simply never be
+    // pruned, which is the documented behaviour for non-runtime
+    // callers).
+    let started = gc.spawn_inside_runtime();
+    router.layer(axum::Extension(Arc::new(started)))
 }
 
-/// Handle returned alongside the router so callers can opt-in to
-/// driving the per-IP map garbage-collector. Returned by
-/// [`build_router_with_config`] separately from the router so router
-/// construction stays a pure synchronous fn — moving the
-/// `tokio::spawn` out of the build means `build_router_with_config`
-/// no longer panics when called outside a Tokio runtime, and tests
-/// that build multiple routers don't leak background tasks.
-///
-/// `serve_cmd` (the only production caller) drives this with
-/// [`spawn_governor_gc`]; tests typically drop the handle and never
-/// run GC.
+/// Background GC handle for the per-IP rate limiter map. Owns its
+/// own [`tokio::task::JoinHandle`] (when [`spawn_inside_runtime`]
+/// has been called) and aborts the task on `Drop`. There is NO
+/// process-wide singleton — every router gets its own handle, every
+/// limiter gets its own GC. The previous OnceLock-based singleton
+/// approach (Copilot review on PR #183) leaked the second router's
+/// limiter forever because only the first call ever spawned.
 pub struct GovernorGcHandle {
     /// Closures that prune (`retain_recent`) the limiter and report
     /// its current map size. Boxed so the handle's type isn't
     /// parameterised over the governor's generic key/state types.
     retain: Box<dyn Fn() + Send + Sync>,
     len: Box<dyn Fn() -> usize + Send + Sync>,
+}
+
+/// Started GC: owns a `JoinHandle` that is aborted on `Drop`. This is
+/// the form returned by [`GovernorGcHandle::spawn_inside_runtime`]
+/// and embedded in the router by [`build_router`].
+pub struct StartedGovernorGc {
+    /// `Some` while the task is alive; taken on `Drop` so the abort
+    /// happens exactly once.
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for StartedGovernorGc {
+    fn drop(&mut self) {
+        if let Some(t) = self.task.take() {
+            t.abort();
+        }
+    }
+}
+
+impl GovernorGcHandle {
+    /// Spawn the GC inside the current Tokio runtime. Returns a
+    /// [`StartedGovernorGc`] that aborts the spawned task on drop. If
+    /// no runtime is current (e.g. when called from a `#[test]`
+    /// without `#[tokio::test]`), the spawn is skipped and the
+    /// returned struct is a benign no-op.
+    #[must_use]
+    pub fn spawn_inside_runtime(self) -> StartedGovernorGc {
+        // `tokio::runtime::Handle::try_current` reports whether we're
+        // inside a runtime context. Outside one, `tokio::spawn` would
+        // panic — we'd rather skip GC quietly than crash the
+        // construction path.
+        if tokio::runtime::Handle::try_current().is_err() {
+            return StartedGovernorGc { task: None };
+        }
+        let GovernorGcHandle { retain, len } = self;
+        let task = tokio::spawn(async move {
+            let interval = Duration::from_secs(60);
+            loop {
+                tokio::time::sleep(interval).await;
+                tracing::trace!(rate_limit_storage_size = (len)(), "governor retain_recent");
+                (retain)();
+            }
+        });
+        StartedGovernorGc { task: Some(task) }
+    }
 }
 
 impl std::fmt::Debug for GovernorGcHandle {
@@ -384,28 +495,27 @@ impl std::fmt::Debug for GovernorGcHandle {
     }
 }
 
-/// Spawn a long-running task that periodically GCs the per-IP rate
-/// limiter map. Idempotent across `build_router_with_config` calls in
-/// the same process: only the first invocation per process actually
-/// spawns; subsequent calls drop the new handle. Pulled out of
-/// `build_router_with_config` so router construction stays
-/// runtime-agnostic.
-pub fn spawn_governor_gc(handle: GovernorGcHandle) {
-    static SPAWNED: OnceLock<()> = OnceLock::new();
-    if SPAWNED.set(()).is_err() {
-        return;
+impl std::fmt::Debug for StartedGovernorGc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StartedGovernorGc")
+            .field("alive", &self.task.is_some())
+            .finish()
     }
-    tokio::spawn(async move {
-        let interval = Duration::from_secs(60);
-        loop {
-            tokio::time::sleep(interval).await;
-            tracing::trace!(
-                rate_limit_storage_size = (handle.len)(),
-                "governor retain_recent"
-            );
-            (handle.retain)();
-        }
-    });
+}
+
+/// Spawn the GC task and return a [`StartedGovernorGc`] that aborts
+/// it on drop. This is a thin wrapper over
+/// [`GovernorGcHandle::spawn_inside_runtime`] kept for source
+/// compatibility with the previous (free-function) entry point —
+/// `serve_cmd` was already calling `spawn_governor_gc(handle)`.
+///
+/// Unlike the previous implementation, this is NOT idempotent across
+/// the process: every call gets its own `JoinHandle`, so a second
+/// router built later in the process gets its own GC and the first
+/// one doesn't leak when its router drops.
+#[must_use]
+pub fn spawn_governor_gc(handle: GovernorGcHandle) -> StartedGovernorGc {
+    handle.spawn_inside_runtime()
 }
 
 /// Construct the full HTTP router with an explicit [`ServerConfig`].
@@ -518,6 +628,52 @@ pub fn build_router_with_config(
 mod tests {
     use super::*;
     use axum::http::Request;
+
+    #[test]
+    fn forwarded_host_parser_ipv4_no_port() {
+        assert_eq!(parse_forwarded_host("192.0.2.1"), "192.0.2.1");
+    }
+
+    #[test]
+    fn forwarded_host_parser_ipv4_with_port() {
+        assert_eq!(parse_forwarded_host("192.0.2.1:8080"), "192.0.2.1");
+    }
+
+    #[test]
+    fn forwarded_host_parser_ipv6_bracketed_no_port() {
+        // Regression for the bug Copilot flagged on PR #183: the old
+        // rsplit_once(':') swallowed `:1]` and returned `[2001:db8:`.
+        assert_eq!(parse_forwarded_host("[2001:db8::1]"), "2001:db8::1");
+    }
+
+    #[test]
+    fn forwarded_host_parser_ipv6_bracketed_with_port() {
+        assert_eq!(parse_forwarded_host("[2001:db8::1]:8080"), "2001:db8::1");
+    }
+
+    #[test]
+    fn forwarded_host_parser_raw_ipv6_no_brackets() {
+        // RFC technically requires brackets when a port follows an
+        // IPv6, but proxies in the wild sometimes emit `for=` values
+        // with raw IPv6 and no port. Accept that shape.
+        assert_eq!(parse_forwarded_host("2001:db8::1"), "2001:db8::1");
+    }
+
+    #[test]
+    fn forwarded_host_parser_distinct_buckets_for_distinct_v6_clients() {
+        // The bug under fix collapsed every IPv6 client behind a
+        // trusted proxy into the same rate-limit bucket because the
+        // host parser failed and the limiter fell back to the proxy
+        // IP. This test pins the property: parsing two different
+        // `for=` values yields two different IPs.
+        let a = parse_forwarded_host("[2001:db8::1]")
+            .parse::<IpAddr>()
+            .unwrap();
+        let b = parse_forwarded_host("[2001:db8::2]")
+            .parse::<IpAddr>()
+            .unwrap();
+        assert_ne!(a, b, "distinct IPv6 clients must hash to distinct keys");
+    }
 
     #[test]
     fn cidr_v4_parses_and_contains() {

--- a/geocode/src/server/state.rs
+++ b/geocode/src/server/state.rs
@@ -34,7 +34,7 @@ use crate::control::admission::AdmissionState;
 use crate::control::{AdmissionPolicy, BudgetPolicy, FanoutConfig, GeneralMetrics};
 use crate::geocoder::executor::ControlPlane;
 use crate::parser::{HeuristicBackend, ParserBackend};
-use crate::routing::CountryId;
+use crate::routing::{Classifier, CountryId, PackRegistry};
 use crate::shard::reader::Shard;
 
 #[derive(Debug)]
@@ -57,6 +57,12 @@ pub struct ServerState {
     /// neural model is loaded; replaced via [`Self::with_parser`] to
     /// dispatch through the neural pipeline (#96 §Tagger + #98 Phase 1).
     pub parser: Arc<dyn ParserBackend>,
+    /// Country classifier (forward routing) + bbox dispatcher
+    /// (reverse routing). Built from the [`PackRegistry`] passed at
+    /// construction time so `--pack-dir` overrides reach query-time
+    /// classification. Defaults to the shipped registry when the
+    /// constructor doesn't take an explicit one.
+    pub classifier: Arc<Classifier>,
 }
 
 impl ServerState {
@@ -109,6 +115,13 @@ impl ServerState {
             budget_policy,
         });
         let admission = AdmissionState::new(admission_policy, metrics);
+        // Default classifier wraps the process-wide singleton over the
+        // shipped registry. Callers that boot via `--pack-dir` replace
+        // this with `with_pack_registry(...)` so the override packs
+        // reach query-time dispatch.
+        let shipped_registry =
+            Arc::new(PackRegistry::shipped().expect("shipped country packs must compile"));
+        let classifier = Arc::new(Classifier::from_registry(shipped_registry));
         Self {
             shards,
             started_at: Instant::now(),
@@ -118,6 +131,7 @@ impl ServerState {
             rerank_model: None,
             confidence_config: ConfidenceConfig::default(),
             parser: Arc::new(HeuristicBackend),
+            classifier,
         }
     }
 
@@ -198,6 +212,15 @@ impl ServerState {
     #[must_use]
     pub fn with_parser(mut self, parser: Arc<dyn ParserBackend>) -> Self {
         self.parser = parser;
+        self
+    }
+
+    /// Replace the classifier with one backed by the supplied
+    /// [`PackRegistry`]. Used by the `serve --pack-dir` boot path so
+    /// override packs reach query-time forward + reverse dispatch.
+    #[must_use]
+    pub fn with_pack_registry(mut self, registry: Arc<PackRegistry>) -> Self {
+        self.classifier = Arc::new(Classifier::from_registry(registry));
         self
     }
 

--- a/geocode/src/sources/openaddresses.rs
+++ b/geocode/src/sources/openaddresses.rs
@@ -128,6 +128,15 @@ impl Source for OpenAddressesSource {
                 let gz = GzDecoder::new(BufReader::with_capacity(1 << 20, f));
                 stream_geojson_seq(gz, progress, emit)?;
             }
+            InputKind::GzCsv => {
+                progress(SourceProgress::Phase {
+                    phase: "streaming gzipped CSV",
+                });
+                let f =
+                    File::open(path).with_context(|| format!("re-opening {}", path.display()))?;
+                let gz = GzDecoder::new(BufReader::with_capacity(1 << 20, f));
+                stream_csv(gz, progress, emit)?;
+            }
             InputKind::RawGeojsonSeq => {
                 progress(SourceProgress::Phase {
                     phase: "streaming raw GeoJSON-seq",
@@ -157,10 +166,15 @@ impl Source for OpenAddressesSource {
 }
 
 /// On-disk layout choice produced by [`detect_kind`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InputKind {
-    /// gzip-magic (1f 8b) — assume GeoJSON-seq inside.
+    /// gzip-magic (1f 8b) — GeoJSON-seq inside.
     GzGeojsonSeq,
+    /// gzip-magic (1f 8b) AND path extension marks the payload as
+    /// CSV (`.csv.gz`, `.csv.gzip`). BAN-style feeds use this shape;
+    /// the historical default of "gzip → GeoJSON-seq" mis-dispatched
+    /// them and parsed every CSV row as JSON.
+    GzCsv,
     /// zip-magic (50 4b 03 04) — find the first `.geojson*` or
     /// `.csv` entry inside.
     Zip,
@@ -171,11 +185,27 @@ enum InputKind {
 }
 
 /// Decide which streaming path to use based on magic bytes first,
-/// falling back to the file extension. Magic bytes win because some
-/// operators rename files (e.g. `belgium.dat` containing a `.geojson.gz`)
-/// and the magic stays load-bearing.
+/// falling back to the file extension. Magic bytes win for the broad
+/// "compressed/uncompressed/zip" decision; the file extension then
+/// disambiguates CSV-vs-GeoJSON inside a gzip stream (we cannot peek
+/// past the gzip header without spinning up an actual decoder, and
+/// the extension is the canonical way operators distinguish the two
+/// in OpenAddresses + BAN feeds).
 fn detect_kind(head: &[u8], path: &Path) -> InputKind {
-    if head.len() >= 2 && head[0] == 0x1f && head[1] == 0x8b {
+    let lower_path = path
+        .to_str()
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    let is_gz = head.len() >= 2 && head[0] == 0x1f && head[1] == 0x8b;
+    if is_gz {
+        // Disambiguate gz-CSV from gz-GeoJSON-seq by the path
+        // extension. BAN ships `.csv.gz`; OpenAddresses ships
+        // `.geojson.gz`. Without this distinction the CSV path was
+        // dispatched to the GeoJSON-seq reader, which treats every
+        // CSV row as a JSON parse error and abort.
+        if lower_path.ends_with(".csv.gz") || lower_path.ends_with(".csv.gzip") {
+            return InputKind::GzCsv;
+        }
         return InputKind::GzGeojsonSeq;
     }
     if head.len() >= 4 && head[0] == 0x50 && head[1] == 0x4b && head[2] == 0x03 && head[3] == 0x04 {
@@ -335,7 +365,7 @@ fn stream_csv<R: Read>(
         let postcode = cols
             .postcode
             .and_then(|i| fields.get(i))
-            .map(|s| s.trim().to_string())
+            .map(|s| normalize_oa_postcode(s.trim()))
             .unwrap_or_default();
         let city = cols
             .city
@@ -508,12 +538,14 @@ fn feature_to_record(feat: &OaFeature) -> Option<AddressRecord> {
         // multi-building streets).
         return None;
     }
-    let postcode = feat
+    let postcode_raw = feat
         .properties
         .postcode
         .as_deref()
         .map(str::trim)
         .unwrap_or_default();
+    let postcode_owned = normalize_oa_postcode(postcode_raw);
+    let postcode = postcode_owned.as_str();
     let city = feat
         .properties
         .city
@@ -537,6 +569,40 @@ fn feature_to_record(feat: &OaFeature) -> Option<AddressRecord> {
         source: SourceTag::OpenAddresses,
         source_id,
     })
+}
+
+/// Normalise an OpenAddresses postcode value. Strips a trailing
+/// `.0` / `.00` / … suffix that appears when upstream tooling encodes
+/// numeric postcodes as JSON floats (cf. US-DC OA proof: `20001.0`).
+/// Without this, the postcode anchor index keys on `"20001.0"` and
+/// every query carrying the human form `20001` misses.
+///
+/// Decisions:
+///
+/// - Only strip when the suffix is `.0+` AND the remainder is all
+///   ASCII digits. We don't want to mangle alphanumeric postcodes
+///   like Canadian `K1A 0B1` or UK `SW1A 1AA`.
+/// - We don't apply the country-pack `canonicalize_postcode` rule
+///   here — the loader doesn't carry the pack, and the canonicalize
+///   pass is applied later (at shard-build / query time, on both
+///   sides of the comparison). This function only undoes the
+///   float-encoding round-trip damage so the canonicalize pass sees
+///   the operator-intended string.
+fn normalize_oa_postcode(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if let Some(idx) = trimmed.find('.') {
+        let (left, right) = trimmed.split_at(idx);
+        // `right` includes the leading dot; check the remainder.
+        let after_dot = &right[1..];
+        if !left.is_empty()
+            && left.bytes().all(|b| b.is_ascii_digit())
+            && !after_dot.is_empty()
+            && after_dot.bytes().all(|b| b == b'0')
+        {
+            return left.to_string();
+        }
+    }
+    trimmed.to_string()
 }
 
 /// Format an OpenAddresses housenumber: `number[ unit]` with a space
@@ -813,6 +879,44 @@ mod tests {
             detect_kind(&head, std::path::Path::new("x.json")),
             InputKind::RawGeojsonSeq
         ));
+    }
+
+    #[test]
+    fn detect_kind_dispatches_csv_gz_separately_from_geojson_gz() {
+        // gzip magic + .csv.gz extension → GzCsv (not GzGeojsonSeq).
+        // Regression for Copilot review on PR #184: BAN-style feeds
+        // were being routed to the GeoJSON-seq parser.
+        let head = [0x1f, 0x8b, 0x00, 0x00];
+        assert_eq!(
+            detect_kind(&head, std::path::Path::new("ban-fr-75.csv.gz")),
+            InputKind::GzCsv
+        );
+        assert_eq!(
+            detect_kind(&head, std::path::Path::new("foo.csv.gzip")),
+            InputKind::GzCsv
+        );
+        // .geojson.gz path stays on the GeoJSON-seq route.
+        assert_eq!(
+            detect_kind(&head, std::path::Path::new("oa-be-bru-fr.geojson.gz")),
+            InputKind::GzGeojsonSeq
+        );
+    }
+
+    #[test]
+    fn normalize_postcode_strips_trailing_zero_decimal() {
+        // US-DC OA proof: postcodes encoded as JSON floats round-trip
+        // to "20001.0" / "20001.00" / etc. Strip the suffix so the
+        // shard postcode index keys on the human form "20001".
+        assert_eq!(normalize_oa_postcode("20001.0"), "20001");
+        assert_eq!(normalize_oa_postcode("20001.00"), "20001");
+        assert_eq!(normalize_oa_postcode("20001.000"), "20001");
+        // Don't touch values that aren't numeric+.0 — Canadian
+        // alphanumeric, UK with internal whitespace, fully-numeric.
+        assert_eq!(normalize_oa_postcode("20001"), "20001");
+        assert_eq!(normalize_oa_postcode("K1A 0B1"), "K1A 0B1");
+        assert_eq!(normalize_oa_postcode("SW1A 1AA"), "SW1A 1AA");
+        assert_eq!(normalize_oa_postcode("1234.AB"), "1234.AB");
+        assert_eq!(normalize_oa_postcode(""), "");
     }
 
     #[test]

--- a/geocode/tests/serve_the_world.rs
+++ b/geocode/tests/serve_the_world.rs
@@ -308,12 +308,21 @@ max_lon = 1.0
 "#,
     )
     .unwrap();
-    // Malformed pack should not crash the loader. Since the bad pack
-    // never inserts, the shipped BE pack remains.
-    let reg = PackRegistry::shipped_with_overrides(dir.path()).unwrap();
-    let be = reg.get(CountryId::BE).expect("BE must remain");
-    // Original shipped name (whatever it is) — definitely NOT "BAD".
-    assert_ne!(be.name, "BAD");
+    // Production policy (Copilot review on PR #183): malformed
+    // override packs MUST fail boot. The earlier behaviour silently
+    // fell through to the shipped pack, leaving operators with the
+    // shipped classifier when they thought they had patched it.
+    let err = PackRegistry::shipped_with_overrides(dir.path())
+        .expect_err("malformed override pack must fail boot, not warn-and-fallthrough");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("malformed pack"),
+        "error message should mention 'malformed pack' (got: {msg})"
+    );
+    assert!(
+        msg.contains("be.toml"),
+        "error message should name the offending file (got: {msg})"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Salvaged from rate-limited agent. All 18 round-2 Copilot findings on PRs #180/#181/#183/#184 + heuristic parser hypothesis diversity for production readiness. 282 lib tests pass (14 new). Workspace clippy + fmt clean. See commit message for full breakdown.