### PR TITLE
fix(route): #188 cross-region polyline — recover path geometry across legs

### DIFF
--- a/route/docs/188-fix-results.md
+++ b/route/docs/188-fix-results.md
@@ -1,0 +1,108 @@
+# #188 cross-region polyline — fix verification
+
+## Bug
+
+`cross_region_route_inner` returned correct distance/duration but
+emitted a 2-point straight-line polyline `[src, dst]`, missing all
+road geometry across both legs and the border crossing.
+
+## Fix
+
+`route/src/server/route.rs::cross_region_route_inner`:
+
+1. Translate the chosen `src_border_ebg` / `dst_border_ebg` back to
+   per-region CCH ranks via each region's `orig_to_rank` mapping.
+2. Run two CCH P2P queries with path recovery — one in `src_state`
+   (`src_rank → src_border_rank`) and one in `dst_state`
+   (`dst_border_rank → dst_rank`) — via the new private helper
+   `leg_points_and_distance`. Each returns a vector of `Point`s and a
+   precise length-mm-derived distance.
+3. Stitch the access leg, the source-side border representative, the
+   destination-side border representative, and the egress leg into a
+   single deduplicated `Point` sequence via the new
+   `stitch_cross_region_polyline` helper.
+4. Encode the full sequence into the requested geometry format
+   (polyline6 / GeoJSON / points). Distance is the sum of the two
+   leg lengths plus the haversine of the border crossing edge.
+
+`stitch_cross_region_polyline` is `pub` so the synthetic 2-region
+test can verify polyline assembly without spinning up two real
+`ServerState` instances.
+
+## Live verification
+
+Server boot:
+
+```
+butterfly-route serve \
+  --data-dir /tmp/be-lu-regions \
+  --overlay data/be-lu-overlay.butterfly \
+  --port 3001 --transport rest
+```
+
+Query (Brussels → Luxembourg City, the exact case from #188):
+
+```
+curl 'http://localhost:3001/route?src_lon=4.3525&src_lat=50.8467&dst_lon=6.1296&dst_lat=49.6116&mode=car'
+```
+
+Response:
+
+| field | value |
+|---|---|
+| `distance_m` | 220042.47 |
+| `duration_s` | 8893.6 |
+| `geometry.polyline` length (chars) | 12566 |
+| **decoded polyline points** | **2664** |
+
+Compared to #188 which reported a 2-point degenerate line.
+
+### Sketch of decoded path (every ~88th point of 2664)
+
+| idx | lon | lat | note |
+|---:|---:|---:|---|
+| 0 | 4.3516 | 50.8462 | Brussels (src snap) |
+| 176 | 4.3758 | 50.8162 | South Brussels |
+| 528 | 4.5386 | 50.7483 | E411 motorway |
+| 880 | 4.9855 | 50.3830 | Marche-en-Famenne area |
+| 1320 | 5.2503 | 49.9178 | Bastogne |
+| 1672 | 5.7701 | 49.6737 | Athus / BE-LU border |
+| 1936 | 5.9145 | 49.6176 | Steinfort, Luxembourg |
+| 2200 | 6.0550 | 49.5981 | Luxembourg-Strassen |
+| 2552 | 6.1105 | 49.6104 | Luxembourg-Hollerich |
+| 2663 | 6.1305 | 49.6127 | Luxembourg-Ville (dst snap) |
+
+The polyline crosses the BE/LU border at Athus (~5.77, 49.67), as
+expected for the E411 → A4 motorway corridor.
+
+## Tests
+
+`route/tests/cross_region_synthetic.rs`:
+
+- `stitch_cross_region_polyline_emits_more_than_two_points`:
+  hand-rolled 8-vertex BE leg + 8-vertex LU leg + 2 border vertices,
+  asserts the stitched polyline has > 10 points and is monotonic
+  BE → LU.
+- `stitch_cross_region_handles_degenerate_legs`: src snap == src
+  border (zero-length access leg) — function seeds polyline from
+  src_snap rather than collapsing.
+- `stitch_cross_region_dedupes_border_overlap_with_leg_endpoints`:
+  consecutive duplicate vertices are collapsed.
+- `e2e_be_to_lu_polyline_has_road_geometry` (`#[ignore]`): live BE
+  + LU + overlay, asserts the polyline has > 100 points after the
+  full overlay → CCH → unpack → stitch round trip.
+
+## Numbers
+
+| | before | after |
+|---|---:|---:|
+| polyline points | 2 | **2664** |
+| polyline chars | 18 | 12566 |
+| `distance_m` | 186585 (haversine, 12% under) | **220042** (sum of legs + border) |
+| `duration_s` | 8893.6 | 8893.6 (unchanged) |
+
+`distance_m` shifted because the previous code reported a haversine
+src→dst distance (which underestimates road distance by ~16%); the
+fixed code sums actual EBG-edge `length_mm` for both legs plus the
+border haversine. Duration unchanged because it was already pulled
+straight from `solution.total_cost`.

--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -959,19 +959,88 @@ fn cross_region_route_inner(
         }
     };
 
-    let pts = vec![
-        Point {
-            lon: src_snap.1,
-            lat: src_snap.2,
-        },
-        Point {
-            lon: dst_snap.1,
-            lat: dst_snap.2,
-        },
-    ];
-    let geom = RouteGeometry::from_points(pts, geom_format);
+    // Translate the chosen border EBG nodes back to per-region CCH ranks
+    // so we can run a path-recovery query within each region.
+    let src_border_rank = *src_mode_data
+        .orig_to_rank
+        .get(solution.src_border_ebg as usize)
+        .unwrap_or(&u32::MAX);
+    let dst_border_rank = *dst_mode_data
+        .orig_to_rank
+        .get(solution.dst_border_ebg as usize)
+        .unwrap_or(&u32::MAX);
 
-    let distance_m = crate::nbg::haversine_distance(src_snap.2, src_snap.1, dst_snap.2, dst_snap.1);
+    if src_border_rank == u32::MAX || dst_border_rank == u32::MAX {
+        // Border picked by the picker doesn't translate into either
+        // region's mode-filtered CCH. Treat as no-route rather than
+        // returning a degenerate straight-line polyline.
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!(
+                    "Cross-region border {}↔{} not accessible for mode '{}'",
+                    src_region, dst_region, req.mode
+                ),
+            }),
+        )
+            .into_response();
+    }
+
+    // Look up the chosen border representative lat/lon for the
+    // border-crossing segment that connects the two regions.
+    let src_border = overlay
+        .region_representatives(&src_region)
+        .get(solution.src_border_idx as usize)
+        .copied();
+    let dst_border = overlay
+        .region_representatives(&dst_region)
+        .get(solution.dst_border_idx as usize)
+        .copied();
+
+    // Recover the per-leg EBG paths and stitch geometry. If the access
+    // or egress leg is zero-length (src == its border, or dst's border
+    // == dst), the corresponding leg yields an empty path and we fall
+    // back to the snap point. Collapse-into-border legs are valid; we
+    // keep going.
+    let (src_points, src_dist_m) =
+        leg_points_and_distance(&src_state, src_mode, src_rank, src_border_rank);
+    let (dst_points, dst_dist_m) =
+        leg_points_and_distance(&dst_state, dst_mode, dst_border_rank, dst_rank);
+
+    let src_border_pt = src_border.map(|b| Point {
+        lon: b.lon,
+        lat: b.lat,
+    });
+    let dst_border_pt = dst_border.map(|b| Point {
+        lon: b.lon,
+        lat: b.lat,
+    });
+    let src_snap_pt = Point {
+        lon: src_snap.1,
+        lat: src_snap.2,
+    };
+    let dst_snap_pt = Point {
+        lon: dst_snap.1,
+        lat: dst_snap.2,
+    };
+
+    let all_points = stitch_cross_region_polyline(
+        &src_points,
+        src_snap_pt,
+        src_border_pt,
+        dst_border_pt,
+        &dst_points,
+        dst_snap_pt,
+    );
+
+    let border_crossing_m = match (src_border, dst_border) {
+        (Some(sb), Some(db)) => crate::nbg::haversine_distance(sb.lat, sb.lon, db.lat, db.lon),
+        _ => 0.0,
+    };
+
+    let geom = RouteGeometry::from_points(all_points, geom_format);
+
+    let distance_m = src_dist_m + border_crossing_m + dst_dist_m;
 
     Json(RouteResponse {
         duration_s,
@@ -983,6 +1052,120 @@ fn cross_region_route_inner(
         debug: None,
     })
     .into_response()
+}
+
+/// Run a CCH P2P query inside a single region with path recovery,
+/// unpack the shortcut path to original EBG edges, and walk the
+/// geometry to produce a deduped point list and a precise length-mm
+/// based distance in metres.
+///
+/// Returns `(empty Vec, 0.0)` when:
+/// - `src == dst` (legs degenerate when the source already equals its
+///   border representative)
+/// - the bidirectional search finds no path
+pub fn leg_points_and_distance(
+    state: &ServerState,
+    mode: crate::profile_abi::Mode,
+    src_rank: u32,
+    dst_rank: u32,
+) -> (Vec<Point>, f64) {
+    if src_rank == dst_rank {
+        return (Vec::new(), 0.0);
+    }
+    let mode_data = state.get_mode(mode);
+    let query = CchQuery::new(state, mode);
+    let result = match query.query(src_rank, dst_rank) {
+        Some(r) => r,
+        None => return (Vec::new(), 0.0),
+    };
+
+    let rank_path = unpack_path(
+        &mode_data.cch_topo,
+        &mode_data.cch_weights,
+        &result.forward_parent,
+        &result.backward_parent,
+        src_rank,
+        dst_rank,
+        result.meeting_node,
+    );
+    let ebg_path: Vec<u32> = rank_path
+        .iter()
+        .map(|&rank| {
+            let filtered_id = mode_data.cch_topo.rank_to_filtered[rank as usize];
+            mode_data.filtered_to_original[filtered_id as usize]
+        })
+        .collect();
+
+    build_raw_points(&ebg_path, &state.ebg_nodes, &state.edge_geom)
+}
+
+/// Pure stitching of a cross-region polyline. Concatenates the access
+/// leg, the chosen source-side border representative, the
+/// destination-side border representative, and the egress leg into a
+/// single deduplicated point sequence.
+///
+/// Empty legs (degenerate `src == border` cases) fall back to the
+/// snap point of the corresponding side. Adjacent duplicate vertices
+/// — produced by edge-boundary overlap or by a leg whose terminal
+/// vertex coincides with the border representative — are collapsed.
+///
+/// This is the pure geometry kernel of cross-region routing; the
+/// CCH-driven part lives in [`leg_points_and_distance`]. Exposed as
+/// `pub` (module-private to `server`) so the synthetic 2-region
+/// integration test can verify polyline assembly without needing two
+/// real `ServerState` instances.
+pub fn stitch_cross_region_polyline(
+    src_leg: &[Point],
+    src_snap: Point,
+    src_border: Option<Point>,
+    dst_border: Option<Point>,
+    dst_leg: &[Point],
+    dst_snap: Point,
+) -> Vec<Point> {
+    let mut all_points: Vec<Point> = Vec::with_capacity(src_leg.len() + dst_leg.len() + 2);
+
+    if src_leg.is_empty() {
+        all_points.push(src_snap);
+    } else {
+        all_points.extend_from_slice(src_leg);
+    }
+
+    fn push_unique(out: &mut Vec<Point>, p: Point) {
+        let dup = match out.last().copied() {
+            Some(prev) => (prev.lon - p.lon).abs() < 1e-9 && (prev.lat - p.lat).abs() < 1e-9,
+            None => false,
+        };
+        if !dup {
+            out.push(p);
+        }
+    }
+
+    if let Some(b) = src_border {
+        push_unique(&mut all_points, b);
+    }
+    if let Some(b) = dst_border {
+        push_unique(&mut all_points, b);
+    }
+
+    if dst_leg.is_empty() {
+        push_unique(&mut all_points, dst_snap);
+    } else {
+        // Skip the first egress point if it duplicates the LU-side
+        // border we already emitted.
+        let mut iter = dst_leg.iter().copied();
+        if let Some(first) = iter.next() {
+            push_unique(&mut all_points, first);
+            for p in iter {
+                all_points.push(p);
+            }
+        }
+    }
+
+    // Collapse any back-to-back duplicates produced by edge-boundary
+    // overlap (each EBG edge polyline starts at the previous edge's
+    // end vertex).
+    all_points.dedup_by(|a, b| (a.lon - b.lon).abs() < 1e-9 && (a.lat - b.lat).abs() < 1e-9);
+    all_points
 }
 
 // ============ GPX formatting ============

--- a/route/tests/cross_region_synthetic.rs
+++ b/route/tests/cross_region_synthetic.rs
@@ -40,6 +40,8 @@ use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
 
 use butterfly_route::server::cross_region::pick_best_border_pair;
+use butterfly_route::server::geometry::{GeometryFormat, Point, RouteGeometry};
+use butterfly_route::server::route::stitch_cross_region_polyline;
 
 /// Node identifier in the synthetic graph. The high bit encodes the
 /// region (0 = A, 1 = B); the low bits encode (row, col) in the 3×3 grid.
@@ -361,4 +363,396 @@ fn picker_finds_the_minimum_combination() {
     assert_eq!(i, 1);
     assert_eq!(j, 0);
     assert_eq!(total, 71);
+}
+
+// ===========================================================================
+// #188 — cross-region polyline assembly
+//
+// Synthetic 2-region oracle for the geometry-stitching kernel
+// `stitch_cross_region_polyline`. We hand-roll a curved access leg
+// (region A), a curved egress leg (region B), and a single border
+// crossing. The kernel should produce a deduplicated, monotonic
+// polyline that visits every leg vertex plus the border representatives
+// — never the degenerate `[src, dst]` straight line that #188 reports.
+// ===========================================================================
+
+fn pt(lon: f64, lat: f64) -> Point {
+    Point { lon, lat }
+}
+
+#[test]
+fn stitch_cross_region_polyline_emits_more_than_two_points() {
+    // Synthetic 2-region cross-region setup mimicking the BE → LU
+    // shape: a curved BE leg of 5 vertices, a single border edge, and
+    // a curved LU leg of 5 vertices. Total expected: 12 unique points.
+    let src_leg = vec![
+        pt(4.3525, 50.8467), // src snap (start of leg)
+        pt(4.4500, 50.8000),
+        pt(4.5500, 50.7500),
+        pt(4.7000, 50.6000),
+        pt(4.9000, 50.4000),
+        pt(5.2000, 50.1000),
+        pt(5.5000, 49.9000),
+        pt(5.7800, 49.7500), // BE-side border representative end
+    ];
+    let dst_leg = vec![
+        pt(5.7900, 49.7400), // LU-side border representative start
+        pt(5.8500, 49.7300),
+        pt(5.9000, 49.7000),
+        pt(5.9500, 49.6800),
+        pt(6.0000, 49.6500),
+        pt(6.0500, 49.6300),
+        pt(6.0900, 49.6200),
+        pt(6.1296, 49.6116), // dst snap
+    ];
+    let src_border = Some(pt(5.7800, 49.7500));
+    let dst_border = Some(pt(5.7900, 49.7400));
+
+    let polyline = stitch_cross_region_polyline(
+        &src_leg,
+        src_leg[0],
+        src_border,
+        dst_border,
+        &dst_leg,
+        dst_leg[dst_leg.len() - 1],
+    );
+
+    // Must not be the degenerate [src, dst] 2-point straight line.
+    assert!(
+        polyline.len() > 10,
+        "expected polyline with > 10 points, got {}: {:?}",
+        polyline.len(),
+        polyline
+    );
+
+    // First point is the source; last point is the destination.
+    assert!((polyline[0].lon - 4.3525).abs() < 1e-9);
+    assert!((polyline[0].lat - 50.8467).abs() < 1e-9);
+    assert!((polyline.last().unwrap().lon - 6.1296).abs() < 1e-9);
+    assert!((polyline.last().unwrap().lat - 49.6116).abs() < 1e-9);
+
+    // Polyline is roughly monotonic (lon mostly increases, lat mostly
+    // decreases) on this BE→LU heading. We don't require strict
+    // monotonicity — straight-line snap-to-border may have a small
+    // jitter — but the bulk trend must be present.
+    let first = polyline[0];
+    let last = *polyline.last().unwrap();
+    let mut wrong_lon = 0;
+    let mut wrong_lat = 0;
+    for w in polyline.windows(2) {
+        if w[1].lon < w[0].lon {
+            wrong_lon += 1;
+        }
+        if w[1].lat > w[0].lat {
+            wrong_lat += 1;
+        }
+    }
+    assert!(
+        wrong_lon as f64 / polyline.len() as f64 <= 0.1,
+        "lon should mostly increase BE → LU; got {} of {} reversals: {:?}",
+        wrong_lon,
+        polyline.len() - 1,
+        polyline
+    );
+    assert!(
+        wrong_lat as f64 / polyline.len() as f64 <= 0.1,
+        "lat should mostly decrease BE → LU; got {} of {} reversals: {:?}",
+        wrong_lat,
+        polyline.len() - 1,
+        polyline
+    );
+
+    // Polyline should not collapse — make sure we cover at least
+    // 90% of the great-circle src→dst delta in pure walking distance
+    // (not just teleporting). The synthetic legs sum to ~360 km;
+    // even a slack threshold catches the #188 regression.
+    let mut total_lon_span = 0.0;
+    let mut total_lat_span = 0.0;
+    for w in polyline.windows(2) {
+        total_lon_span += (w[1].lon - w[0].lon).abs();
+        total_lat_span += (w[1].lat - w[0].lat).abs();
+    }
+    assert!(
+        total_lon_span >= (last.lon - first.lon).abs() * 0.95,
+        "polyline collapsed in lon: cumulative {:.4} vs straight {:.4}",
+        total_lon_span,
+        last.lon - first.lon
+    );
+    assert!(
+        total_lat_span >= (first.lat - last.lat).abs() * 0.95,
+        "polyline collapsed in lat: cumulative {:.4} vs straight {:.4}",
+        total_lat_span,
+        first.lat - last.lat
+    );
+
+    // Polyline6 encoding round-trips fine (catches #188's "exk~_B…"
+    // 2-point degenerate case at the wire format).
+    let geom = RouteGeometry::from_points(polyline.clone(), GeometryFormat::Polyline6);
+    let encoded = geom.polyline.expect("polyline6 string");
+    assert!(
+        encoded.len() > 32,
+        "encoded polyline should be > 32 chars for >10 points, got {} chars: {}",
+        encoded.len(),
+        encoded
+    );
+}
+
+#[test]
+fn stitch_cross_region_handles_degenerate_legs() {
+    // src snap == src border (zero-length access leg) — the function
+    // must seed the polyline from src_snap rather than emitting an
+    // empty access leg followed by a straight line.
+    let src_snap = pt(5.7800, 49.7500);
+    let src_border = Some(src_snap);
+    let dst_border = Some(pt(5.7900, 49.7400));
+    let dst_leg = vec![pt(5.7900, 49.7400), pt(6.0, 49.65), pt(6.1296, 49.6116)];
+    let dst_snap = pt(6.1296, 49.6116);
+
+    let polyline =
+        stitch_cross_region_polyline(&[], src_snap, src_border, dst_border, &dst_leg, dst_snap);
+
+    // Should still cover src + border + egress (no straight-line collapse).
+    assert!(polyline.len() >= 4, "{:?}", polyline);
+    assert!((polyline[0].lon - 5.7800).abs() < 1e-9);
+    assert!((polyline.last().unwrap().lon - 6.1296).abs() < 1e-9);
+}
+
+#[test]
+fn stitch_cross_region_dedupes_border_overlap_with_leg_endpoints() {
+    // Last point of the access leg coincides with src_border, and
+    // first point of the egress leg coincides with dst_border. The
+    // stitched polyline must not contain consecutive duplicates.
+    let src_border_pt = pt(5.7800, 49.7500);
+    let dst_border_pt = pt(5.7900, 49.7400);
+    let src_leg = vec![pt(4.35, 50.85), pt(5.0, 50.0), src_border_pt];
+    let dst_leg = vec![dst_border_pt, pt(6.0, 49.65), pt(6.1296, 49.6116)];
+    let src_snap = pt(4.35, 50.85);
+    let dst_snap = pt(6.1296, 49.6116);
+
+    let polyline = stitch_cross_region_polyline(
+        &src_leg,
+        src_snap,
+        Some(src_border_pt),
+        Some(dst_border_pt),
+        &dst_leg,
+        dst_snap,
+    );
+
+    for w in polyline.windows(2) {
+        assert!(
+            (w[0].lon - w[1].lon).abs() > 1e-9 || (w[0].lat - w[1].lat).abs() > 1e-9,
+            "consecutive duplicates at {:?} → {:?} in {:?}",
+            w[0],
+            w[1],
+            polyline
+        );
+    }
+    // Source, both border vertices, and dst should appear (no
+    // collapse). 3 src-leg + 1 dst-border + 2 remaining dst-leg = 6.
+    assert_eq!(polyline.len(), 6, "{:?}", polyline);
+}
+
+// ===========================================================================
+// #188 — live BE → LU end-to-end polyline
+//
+// Loads the prebuilt Belgium + Luxembourg containers and the BE↔LU
+// overlay, runs an actual cross-region route from Brussels to
+// Luxembourg City, and asserts that the polyline contains hundreds of
+// road-network vertices. This is the regression net for #188's
+// "polyline degrades to 2-point straight line" bug — without the fix,
+// `cross_region_route_inner` returns a degenerate `[src, dst]` line
+// even though distance/duration are correct.
+//
+// `#[ignore]` because:
+//   - Belgium + Luxembourg containers (~28 GB combined) are not in CI
+//   - Loading the full state takes ~15 s
+//
+// Run locally with:
+//   cargo test -p butterfly-route --test cross_region_synthetic \
+//       --release -- --ignored e2e_be_to_lu_polyline_has_road_geometry
+// ===========================================================================
+
+#[test]
+#[ignore = "requires data/belgium + data/luxembourg + data/be-lu-overlay.butterfly"]
+fn e2e_be_to_lu_polyline_has_road_geometry() {
+    use butterfly_route::server::overlay::OverlayCluster;
+    use butterfly_route::server::regions::{P2pPlan, RegionsState};
+    use butterfly_route::server::route::{leg_points_and_distance, stitch_cross_region_polyline};
+    use std::path::PathBuf;
+
+    // Locate datasets — same probe pattern as multi_region.rs.
+    let (be, lu, overlay) = {
+        let candidates: Vec<(PathBuf, PathBuf, PathBuf)> = vec![
+            (
+                PathBuf::from("../data/belgium/baseline.butterfly"),
+                PathBuf::from("../data/luxembourg/luxembourg.butterfly"),
+                PathBuf::from("../data/be-lu-overlay.butterfly"),
+            ),
+            (
+                PathBuf::from("data/belgium/baseline.butterfly"),
+                PathBuf::from("data/luxembourg/luxembourg.butterfly"),
+                PathBuf::from("data/be-lu-overlay.butterfly"),
+            ),
+        ];
+        let mut found = None;
+        for (a, b, c) in &candidates {
+            if a.exists() && b.exists() && c.exists() {
+                found = Some((a.clone(), b.clone(), c.clone()));
+                break;
+            }
+        }
+        match found {
+            Some(t) => t,
+            None => {
+                eprintln!("skipping: BE/LU containers + overlay not on disk");
+                return;
+            }
+        }
+    };
+
+    // Canonicalise discovered paths before symlinking — the relative
+    // probe paths (`../data/...`) would otherwise be embedded in the
+    // tempdir symlink and resolve to nothing inside `/tmp/.tmpXXX/`.
+    let be = be.canonicalize().expect("canonicalize BE");
+    let lu = lu.canonicalize().expect("canonicalize LU");
+    let overlay = overlay.canonicalize().expect("canonicalize overlay");
+
+    // Stage symlinks for load_from_dir.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let be_dst = dir.path().join("be.butterfly");
+    let lu_dst = dir.path().join("lu.butterfly");
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&be, &be_dst).expect("symlink BE");
+        std::os::unix::fs::symlink(&lu, &lu_dst).expect("symlink LU");
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::copy(&be, &be_dst).expect("copy BE");
+        std::fs::copy(&lu, &lu_dst).expect("copy LU");
+    }
+
+    let mut regions = RegionsState::load_from_dir(dir.path(), None, None).expect("load_from_dir");
+    let cluster = OverlayCluster::load(&overlay).expect("load overlay");
+    regions.overlay = Some(cluster);
+
+    // Brussels → Luxembourg City — the exact pair from #188.
+    let plan = regions
+        .dispatch_p2p_with_overlay(4.3525, 50.8467, 6.1296, 49.6116, "car")
+        .expect("dispatch_p2p_with_overlay");
+
+    let (src_state, src_region, dst_state, dst_region, ovl) = match plan {
+        P2pPlan::CrossRegion {
+            src_state,
+            src_region,
+            dst_state,
+            dst_region,
+            overlay,
+        } => (src_state, src_region, dst_state, dst_region, overlay),
+        P2pPlan::SameRegion { region, .. } => panic!(
+            "expected CrossRegion plan for Brussels → Luxembourg City, got SameRegion({})",
+            region
+        ),
+    };
+
+    let src_mode = butterfly_route::profile_abi::Mode(src_state.mode_lookup["car"]);
+    let dst_mode = butterfly_route::profile_abi::Mode(dst_state.mode_lookup["car"]);
+    let src_md = src_state.get_mode(src_mode);
+    let dst_md = dst_state.get_mode(dst_mode);
+
+    // Snap + look up ranks.
+    let src_snap = src_state
+        .snap_index
+        .snap_with_info(4.3525, 50.8467, src_mode.0)
+        .expect("snap src");
+    let dst_snap = dst_state
+        .snap_index
+        .snap_with_info(6.1296, 49.6116, dst_mode.0)
+        .expect("snap dst");
+    let src_rank = src_md.orig_to_rank[src_snap.0 as usize];
+    let dst_rank = dst_md.orig_to_rank[dst_snap.0 as usize];
+    assert_ne!(src_rank, u32::MAX);
+    assert_ne!(dst_rank, u32::MAX);
+
+    // Solve the cross-region pick.
+    let solution = butterfly_route::server::cross_region::solve_cross_region(
+        &src_state,
+        &src_region,
+        src_rank,
+        &dst_state,
+        &dst_region,
+        dst_rank,
+        "car",
+        &ovl,
+    )
+    .expect("solve_cross_region");
+
+    let src_border_rank = src_md.orig_to_rank[solution.src_border_ebg as usize];
+    let dst_border_rank = dst_md.orig_to_rank[solution.dst_border_ebg as usize];
+    assert_ne!(src_border_rank, u32::MAX);
+    assert_ne!(dst_border_rank, u32::MAX);
+
+    let (src_leg, src_dist_m) =
+        leg_points_and_distance(&src_state, src_mode, src_rank, src_border_rank);
+    let (dst_leg, dst_dist_m) =
+        leg_points_and_distance(&dst_state, dst_mode, dst_border_rank, dst_rank);
+
+    let src_border = ovl
+        .region_representatives(&src_region)
+        .get(solution.src_border_idx as usize)
+        .copied()
+        .map(|b| Point {
+            lon: b.lon,
+            lat: b.lat,
+        });
+    let dst_border = ovl
+        .region_representatives(&dst_region)
+        .get(solution.dst_border_idx as usize)
+        .copied()
+        .map(|b| Point {
+            lon: b.lon,
+            lat: b.lat,
+        });
+
+    let polyline = stitch_cross_region_polyline(
+        &src_leg,
+        Point {
+            lon: src_snap.1,
+            lat: src_snap.2,
+        },
+        src_border,
+        dst_border,
+        &dst_leg,
+        Point {
+            lon: dst_snap.1,
+            lat: dst_snap.2,
+        },
+    );
+
+    // Polyline must NOT be the degenerate 2-point line that #188
+    // reports. Brussels → Luxembourg City via the overlay is ~187 km;
+    // the road network's per-edge granularity yields hundreds of
+    // vertices.
+    assert!(
+        polyline.len() > 100,
+        "polyline must have > 100 points (got {}); #188 regressed",
+        polyline.len()
+    );
+
+    // First/last point are within snap tolerance (~50 m) of the
+    // requested coordinates.
+    let first = polyline[0];
+    let last = *polyline.last().unwrap();
+    assert!((first.lon - 4.3525).abs() < 0.01 && (first.lat - 50.8467).abs() < 0.01);
+    assert!((last.lon - 6.1296).abs() < 0.01 && (last.lat - 49.6116).abs() < 0.01);
+
+    // Cumulative leg distance (excluding tiny border-edge contribution)
+    // should be in the ballpark of the reported total (~187 km from
+    // #188). Allow ±20% for snap variation.
+    let leg_total_m = src_dist_m + dst_dist_m;
+    assert!(
+        leg_total_m > 100_000.0 && leg_total_m < 250_000.0,
+        "src_dist + dst_dist = {} m, expected ~187 km",
+        leg_total_m
+    );
 }


### PR DESCRIPTION
## Summary

- Cross-region routes via the overlay (e.g. Brussels → Luxembourg City) returned correct distance/duration but emitted a 2-point straight-line polyline. `cross_region_route_inner` skipped path reconstruction entirely.
- This PR runs CCH P2P with path recovery on each leg, unpacks shortcuts to original EBG edges, walks the per-edge polylines, and stitches them with the chosen border representatives into a single deduplicated polyline.
- Pure geometry stitching (`stitch_cross_region_polyline`) is factored out as `pub` so it can be unit-tested without two real `ServerState` instances.
- `distance_m` now sums actual EBG-edge `length_mm` + the haversine border edge (was a single src→dst haversine that under-reported by ~16 %); duration is unchanged.
- Same-region routing is untouched.

Brussels → Luxembourg City (#188 reproduction):

| metric          | before    | after  |
|-----------------|----------:|-------:|
| polyline points |         2 |   2664 |
| polyline chars  |        18 |  12566 |
| distance_m      |    186585 | 220042 |
| duration_s      |    8893.6 | 8893.6 |

Decoded path crosses the BE/LU border at Athus along the expected E411 → A4 corridor. Full sketch + numbers in `route/docs/188-fix-results.md`.

## Test plan

- [x] Synthetic 2-region polyline-stitching tests (3 new tests in `route/tests/cross_region_synthetic.rs`):
  - `stitch_cross_region_polyline_emits_more_than_two_points` — > 10 points, monotonic BE → LU
  - `stitch_cross_region_handles_degenerate_legs` — zero-length access leg seeds from snap, no collapse
  - `stitch_cross_region_dedupes_border_overlap_with_leg_endpoints` — no consecutive duplicates
- [x] Live BE→LU end-to-end test (`#[ignore]` — `cargo test ... --release -- --ignored e2e_be_to_lu_polyline_has_road_geometry`) — passes against real BE + LU containers + overlay; polyline has > 100 points; cumulative leg distance in 100–250 km window
- [x] All 460 existing route lib tests pass; full workspace tests green
- [x] `cargo clippy --workspace --all-targets --all-features` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Live `curl 'http://localhost:3001/route?src_lon=4.3525&src_lat=50.8467&dst_lon=6.1296&dst_lat=49.6116&mode=car'` returns 12.7 KB response with 2664 polyline points