### PR TITLE
feat(geocode): #192 production neural parser engineering (items 1-6+9 of Fork A+)

### DIFF
--- a/geocode-research/MULTI_COUNTRY_TRAINING.md
+++ b/geocode-research/MULTI_COUNTRY_TRAINING.md
@@ -1,0 +1,233 @@
+# Multi-Country Neural Tagger Training Runbook
+
+Operator runbook for training the production neural parser on multiple
+countries. The Fork A+ engineering work (#192) shipped every piece of
+infrastructure required — corpus-format bridge, multi-country country head,
+multi-country corpus-gen with morphology tables, production architecture,
+LR schedule, gradient clipping. This document is the operator's recipe to
+exercise that infrastructure on the full multi-country target.
+
+The Belgium-only run is documented in `PRODUCTION_TRAINING.md`. It is a
+strict subset of this runbook (`--countries BE`, single PBF). Read that
+first to confirm the pipeline works locally before running multi-country
+overnight.
+
+## Phase 0 — Prerequisites
+
+- A Linux box with **≥ 32 GB RAM** (the training corpus is ~1 GB JSONL
+  loaded fully into memory; head-room for the model + safetensors save).
+- **≥ 200 GB disk** (PBFs + corpora + checkpoints).
+- Rust 1.95, edition 2024.
+- The corpus-gen + butterfly-geocode binaries built in release mode:
+  ```
+  cd /path/to/butterfly-osm
+  cargo build --release --workspace
+  ( cd geocode-training/corpus-gen && cargo build --release )
+  ```
+
+## Phase 1 — Fetch country PBFs
+
+The corpus-gen reads a single Geofabrik PBF per country. butterfly-dl is
+the canonical fetch path; it caches into `data/`.
+
+```bash
+# Already on disk per the project default:
+#   data/belgium.pbf       (~600 MB)
+# Fetch the rest:
+butterfly-dl france           # → data/france.pbf, ~4 GB
+butterfly-dl germany          # → data/germany.pbf, ~4 GB
+butterfly-dl netherlands      # → data/netherlands.pbf, ~1.5 GB
+butterfly-dl us-northeast     # → data/us-northeast.pbf, ~1.7 GB (partial US)
+# For full US coverage, fetch each US-state extract from Geofabrik
+# (us/<state>.pbf) and concatenate via osmium / osmconvert. Geofabrik
+# does not ship a single 'united-states' PBF; the operator chooses
+# which states to include. The morphology tables don't change — US is
+# US whichever region you pull.
+
+butterfly-dl great-britain    # → data/great-britain.pbf, ~1.5 GB
+```
+
+Network-bound. 13–15 GB total over ~1–2 hours on a 100 Mbps link.
+
+## Phase 2 — Generate per-country corpora
+
+corpus-gen produces a JSONL per country. Each gold OSM `addr:*`-tagged
+node yields 1 canonical record + 8 augmented variants (`--augmentations
+8`, the codex-recommended default). The morphology used for abbreviation
+expansion / contraction comes from `geocode-training/corpus-gen/morphology/<iso2>.toml`.
+A morphology table is **required** for any country you generate; the
+shipped set covers BE, FR, NL, DE, US, GB.
+
+```bash
+cd /path/to/butterfly-osm
+mkdir -p geocode-training/output
+
+for cc in BE FR NL DE GB; do
+    pbf="data/$(echo $cc | tr A-Z a-z).pbf"
+    case $cc in
+        BE) pbf="data/belgium.pbf" ;;
+        DE) pbf="data/germany.pbf" ;;
+        FR) pbf="data/france.pbf" ;;
+        NL) pbf="data/netherlands.pbf" ;;
+        GB) pbf="data/great-britain.pbf" ;;
+    esac
+    geocode-training/corpus-gen/target/release/corpus-gen \
+        --pbf "$pbf" \
+        --country "$cc" \
+        --canary-targets "$(echo BE,FR,NL,DE,GB | tr ',' '\n' | grep -v $cc | tr '\n' ',' | sed 's/,$//')" \
+        --morphology-dir geocode-training/corpus-gen/morphology \
+        --augmentations 8 \
+        --out "geocode-training/output/${cc,,}-corpus.jsonl" \
+        --canary "geocode-training/output/${cc,,}-canary.jsonl"
+done
+
+# US is split per-state if needed; rerun corpus-gen per state PBF and
+# concatenate. The ISO code stays "US" on every record.
+for state in northeast; do
+    geocode-training/corpus-gen/target/release/corpus-gen \
+        --pbf "data/us-${state}.pbf" \
+        --country US \
+        --canary-targets BE,FR,NL,DE,GB \
+        --morphology-dir geocode-training/corpus-gen/morphology \
+        --augmentations 8 \
+        --out "geocode-training/output/us-${state}-corpus.jsonl" \
+        --canary "geocode-training/output/us-${state}-canary.jsonl"
+done
+```
+
+Wall-clock: ~9 sec per million records on a laptop. Belgium produces
+~1.5 M records; France around 6 M; Germany around 8 M; full set will
+land around **15–20 M training records** depending on how much US you
+include.
+
+## Phase 3 — Concatenate + shuffle
+
+Combine per-country corpora into one shuffled file. The shuffler is the
+GNU `shuf`; for files larger than RAM, use the disk-backed shuffle
+provided by `terashuf` or `shuf --random-source=/dev/urandom -n N`.
+
+```bash
+cat geocode-training/output/*-corpus.jsonl | shuf > geocode-training/output/world-corpus.jsonl
+wc -l geocode-training/output/world-corpus.jsonl
+# expect 15–20 million lines, 3–4 GB on disk
+```
+
+The trainer reads the entire corpus into RAM. At ~150 bytes/line average
+that's 2–3 GB heap — comfortable on a 32 GB box.
+
+## Phase 4 — Train
+
+Training the production architecture (~825k params at any vocab size up
+to 8 — the country head adds 128 floats per country).
+
+```bash
+./target/release/butterfly-geocode train \
+    --corpus geocode-training/output/world-corpus.jsonl \
+    --countries BE,FR,NL,DE,GB,US \
+    --architecture production \
+    --batch-size 64 \
+    --learning-rate 1e-3 \
+    --lr-schedule cosine \
+    --epochs 30 \
+    --warmup-steps 5000 \
+    --weight-decay 0.01 \
+    --gradient-clip 1.0 \
+    --eval-split 0.05 \
+    --out geocode/data/models/world-prod.safetensors
+```
+
+Wall-clock projection (CPU-only, 20-core x86):
+
+| Records | Epochs | Throughput | Wall-clock |
+|---------|--------|------------|------------|
+| 1.49 M (BE alone) | 10 | ~250 batches/sec | ~40 min |
+| ~15 M (world) | 30 | ~250 batches/sec | **~30 hours** |
+
+The 30-hour figure is the dominant cost. To bring it under 6 h, build
+candle with the `cuda` feature (one line in `geocode/Cargo.toml`):
+
+```toml
+candle-core = { version = "0.10", default-features = false, features = ["cuda"] }
+candle-nn  = { version = "0.10", default-features = false, features = ["cuda"] }
+```
+
+then re-run the training step. A single A100/H100 GPU pushes throughput
+to ~5–10 k batches/sec at this model size, taking the full
+multi-country run from 30h to 3–6h. The architecture is otherwise
+unchanged — same safetensors layout, same sidecar JSON, same inference
+path.
+
+## Phase 5 — Bench
+
+After training completes, validate against per-country bench query
+files. The `bench/geocode/bench.py` script accepts a `--queries` TSV
+and a running geocode server.
+
+```bash
+# Boot the multi-country server. The shard-dir loads every BFGS the
+# server can find — point it at a directory of pre-built shards
+# (one per ISO code).
+./target/release/butterfly-geocode serve \
+    --shard-dir geocode/regions/ \
+    --parser neural \
+    --model geocode/data/models/world-prod.safetensors \
+    --retrieval-utility learned \
+    --retrieval-utility-model geocode/data/models/retrieval-utility-belgium-tiny.gbdt \
+    --port 3003 &
+
+# Run the bench per country.
+for cc in BE FR NL DE GB US; do
+    python3 bench/geocode/bench.py \
+        --engine butterfly \
+        --queries "bench/geocode/queries/${cc,,}.tsv" \
+        --concurrency 1,4,16 \
+        --output "bench/geocode/results/${cc,,}-world-prod-bench" \
+        --limit 5
+done
+```
+
+Compare recall@1 per country against:
+- Belgium-only baseline (`belgium-prod.safetensors`): expectation is
+  parity or small drop, since multi-country training gives up some BE
+  specialization.
+- Multi-country baseline (heuristic parser): expectation is uplift,
+  since the neural parser should outperform simple regex tagging on
+  out-of-distribution country mixes.
+
+If recall drops more than 5 points vs the per-country specialised model,
+the issue is **shared-vs-specialized capacity**: the 825k-param model
+is at its capacity ceiling. Re-train at the next architecture profile
+(d_model=192, n_layers=6 — file as a follow-up issue, not in scope of
+#192).
+
+## Phase 6 — Deploy
+
+The world-prod safetensors + sidecar config drop into
+`geocode/data/models/`. The serve command above is the production
+deployment shape. The Docker image rebuild uses the same path:
+
+```dockerfile
+COPY geocode/data/models/world-prod.safetensors /opt/models/
+COPY geocode/data/models/world-prod.safetensors.config.json /opt/models/
+```
+
+## Validation: this runbook IS reproducible
+
+The Belgium row of Phase 4 is exercised in `PRODUCTION_TRAINING.md`:
+running the exact command at `--countries BE` produces a measurable
+loss curve and a deployable model. Phases 1, 2, 3, 5 are network /
+disk operations whose outputs are deterministic given the same
+upstream PBF snapshots. Phase 4 multi-country is operator-driven
+overnight compute — but no part of the workflow is research-grade
+exploratory. Every step above is a single bash command operating on
+the infrastructure shipped in #192.
+
+## Known omissions (deferred)
+
+- **Per-country eval metrics**: the trainer prints global BIO-acc /
+  country-acc; per-country breakdown requires an additional eval pass
+  iterating per-country. Tracked as #196 (proposed).
+- **Curriculum learning**: train on BE first, then warm-start the world
+  model from the BE checkpoint. Tracked as #197 (proposed).
+- **Mixed-precision (fp16)**: 2x speed on GPU. candle 0.10 supports it
+  but we ship fp32 for CPU stability. Tracked as #198 (proposed).

--- a/geocode-training/corpus-gen/Cargo.toml
+++ b/geocode-training/corpus-gen/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4.6", features = ["derive"] }
 rand = "0.9"
 rand_chacha = "0.9"
 anyhow = "1"
+toml = "0.9"
 
 [profile.release]
 opt-level = 3

--- a/geocode-training/corpus-gen/morphology/be.toml
+++ b/geocode-training/corpus-gen/morphology/be.toml
@@ -1,0 +1,56 @@
+## Belgium morphology table for the geocode corpus generator.
+##
+## Used by:
+## - rendering address fields with country-typical separators
+## - cross-country canary rewrites (e.g. BE-as-FR)
+## - augmentation strategies that contract/expand street types
+
+[country]
+iso2 = "BE"
+name = "Belgium"
+
+[render]
+## Default separator between street+housenumber and the postcode/city block.
+## Belgium and France use "<street> <hn>, <postcode> <city>".
+field_separator_after_house = ", "
+## Separator between postcode and city.
+postcode_city_separator = " "
+## Where the postcode lives relative to the city ("leading" = "1070 Anderlecht",
+## "trailing" = "Anderlecht 1070"). BE puts postcode first.
+postcode_position = "leading"
+
+[postcode]
+## Regex sanity-check (NOT used for parsing; only for rendering canary
+## variants when generating synthetic postcodes).
+regex = '^[1-9][0-9]{3}$'
+## Format-as-printed: how to canonicalize once we have a 4-digit string.
+format = "{}"
+
+[street_types]
+## Each entry: long form, short/abbreviated form. Used by augment::abbr_*
+## and canary cross-country rewrites. Bilingual country: both FR and NL.
+## Capitalized forms come first in each pair; if not specified, lowercase
+## variant is auto-derived.
+long_to_short = [
+    # FR
+    ["Rue", "R."],
+    ["Boulevard", "Bd"],
+    ["Avenue", "Av."],
+    ["Place", "Pl."],
+    ["Chaussée", "Ch."],
+    ["Saint", "St"],
+    ["Sainte", "Ste"],
+    # NL
+    ["Straat", "Str."],
+    ["Laan", "Ln."],
+    ["Plein", "Pl."],
+    # Compound / common nouns embedded in street names use suffix forms.
+    # The substring matchers (below) handle these.
+]
+
+## Substring street markers (for canary rewrites). These are the bits
+## that identify "this is a Belgian-style street" — used by canary
+## generation to find a target word to rewrite.
+[street_types.markers]
+fr = ["rue", "avenue", "boulevard", "chaussée", "place", "impasse"]
+nl = ["straat", "laan", "plein", "gracht", "weg"]

--- a/geocode-training/corpus-gen/morphology/de.toml
+++ b/geocode-training/corpus-gen/morphology/de.toml
@@ -1,0 +1,33 @@
+## Germany morphology table.
+
+[country]
+iso2 = "DE"
+name = "Germany"
+
+[render]
+field_separator_after_house = ", "
+postcode_city_separator = " "
+## German addresses put the postcode FIRST: "Friedrichstraße 100, 10117 Berlin"
+postcode_position = "leading"
+
+[postcode]
+## 5-digit Deutsche Post ZIP.
+regex = '^[0-9]{5}$'
+format = "{}"
+
+[street_types]
+long_to_short = [
+    ["Straße", "Str."],
+    ["Strasse", "Str."],
+    ["Platz", "Pl."],
+    ["Allee", "Al."],
+    ["Weg", "Wg."],
+    ["Gasse", "G."],
+    ["Sankt", "St"],
+]
+
+## German street types are usually SUFFIXED to the noun (compound):
+## "Friedrichstraße", "Marienplatz". So we match by substring, not
+## by leading word.
+[street_types.markers]
+de = ["straße", "strasse", "platz", "allee", "weg", "gasse", "ufer", "ring", "damm", "berg"]

--- a/geocode-training/corpus-gen/morphology/fr.toml
+++ b/geocode-training/corpus-gen/morphology/fr.toml
@@ -1,0 +1,31 @@
+## France morphology table.
+
+[country]
+iso2 = "FR"
+name = "France"
+
+[render]
+field_separator_after_house = ", "
+postcode_city_separator = " "
+postcode_position = "leading"
+
+[postcode]
+regex = '^[0-9]{5}$'
+format = "{}"
+
+[street_types]
+long_to_short = [
+    ["Rue", "R."],
+    ["Boulevard", "Bd"],
+    ["Avenue", "Av."],
+    ["Place", "Pl."],
+    ["Chaussée", "Ch."],
+    ["Impasse", "Imp."],
+    ["Allée", "All."],
+    ["Quai", "Q."],
+    ["Saint", "St"],
+    ["Sainte", "Ste"],
+]
+
+[street_types.markers]
+fr = ["rue", "avenue", "boulevard", "chaussée", "place", "impasse", "allée", "quai"]

--- a/geocode-training/corpus-gen/morphology/gb.toml
+++ b/geocode-training/corpus-gen/morphology/gb.toml
@@ -1,0 +1,34 @@
+## United Kingdom morphology table.
+
+[country]
+iso2 = "GB"
+name = "United Kingdom"
+
+[render]
+field_separator_after_house = ", "
+postcode_city_separator = " "
+## UK postcode goes LAST: "10 Downing Street, London SW1A 2AA"
+postcode_position = "trailing"
+
+[postcode]
+## UK postcode: see Royal Mail PAF / BS 7666. Simplified regex.
+regex = '^[A-Z]{1,2}[0-9][A-Z0-9]? ?[0-9][A-Z]{2}$'
+format = "{}"
+
+[street_types]
+long_to_short = [
+    ["Street", "St"],
+    ["Road", "Rd"],
+    ["Avenue", "Ave"],
+    ["Lane", "Ln"],
+    ["Place", "Pl"],
+    ["Crescent", "Cres"],
+    ["Close", "Cl"],
+    ["Drive", "Dr"],
+    ["Court", "Ct"],
+    ["Square", "Sq"],
+    ["Saint", "St"],
+]
+
+[street_types.markers]
+gb = ["street", "road", "avenue", "lane", "crescent", "close", "place", "square"]

--- a/geocode-training/corpus-gen/morphology/nl.toml
+++ b/geocode-training/corpus-gen/morphology/nl.toml
@@ -1,0 +1,28 @@
+## Netherlands morphology table.
+
+[country]
+iso2 = "NL"
+name = "Netherlands"
+
+[render]
+field_separator_after_house = ", "
+postcode_city_separator = " "
+postcode_position = "leading"
+
+[postcode]
+## NL postcode is 4 digits + space + 2 letters ("1011 AB").
+regex = '^[0-9]{4} ?[A-Z]{2}$'
+format = "{}"
+
+[street_types]
+long_to_short = [
+    ["Straat", "Str."],
+    ["Laan", "Ln."],
+    ["Plein", "Pl."],
+    ["Gracht", "Gr."],
+    ["Weg", "Wg."],
+    ["Sint", "St"],
+]
+
+[street_types.markers]
+nl = ["straat", "laan", "plein", "gracht", "weg", "kade"]

--- a/geocode-training/corpus-gen/morphology/us.toml
+++ b/geocode-training/corpus-gen/morphology/us.toml
@@ -1,0 +1,50 @@
+## United States morphology table.
+
+[country]
+iso2 = "US"
+name = "United States"
+
+[render]
+## US addresses use a comma between street and city, then space-separated
+## state and ZIP: "1600 Pennsylvania Ave NW, Washington DC 20500".
+field_separator_after_house = ", "
+postcode_city_separator = " "
+## US ZIP comes AFTER the city (and state).
+postcode_position = "trailing"
+
+[postcode]
+## 5-digit ZIP, optionally with -4 extension.
+regex = '^[0-9]{5}(-[0-9]{4})?$'
+format = "{}"
+
+[street_types]
+## US street type suffixes (USPS Publication 28).
+long_to_short = [
+    ["Street", "St"],
+    ["Avenue", "Ave"],
+    ["Boulevard", "Blvd"],
+    ["Drive", "Dr"],
+    ["Lane", "Ln"],
+    ["Road", "Rd"],
+    ["Court", "Ct"],
+    ["Place", "Pl"],
+    ["Highway", "Hwy"],
+    ["Parkway", "Pkwy"],
+    ["Circle", "Cir"],
+    ["Plaza", "Plz"],
+    ["Terrace", "Ter"],
+    ["Square", "Sq"],
+    ["North", "N"],
+    ["South", "S"],
+    ["East", "E"],
+    ["West", "W"],
+    ["Northwest", "NW"],
+    ["Northeast", "NE"],
+    ["Southwest", "SW"],
+    ["Southeast", "SE"],
+    ["Saint", "St"],
+]
+
+## US street markers — typically SUFFIXED to the street name.
+[street_types.markers]
+us = ["street", "avenue", "boulevard", "drive", "lane", "road", "court", "highway", "parkway"]

--- a/geocode-training/corpus-gen/src/augment.rs
+++ b/geocode-training/corpus-gen/src/augment.rs
@@ -20,6 +20,7 @@
 
 use crate::bio::{Field, Labeled, Span, bio_from_spans};
 use crate::gold::GoldRecord;
+use crate::morphology::Morphology;
 use rand::Rng;
 use rand_chacha::ChaCha20Rng;
 
@@ -30,18 +31,24 @@ pub struct Augmented {
     pub kind: String,
 }
 
-pub fn apply(g: &GoldRecord, _canonical: &Labeled, rng: &mut ChaCha20Rng, k: u32) -> Augmented {
+pub fn apply(
+    g: &GoldRecord,
+    _canonical: &Labeled,
+    morph: &Morphology,
+    rng: &mut ChaCha20Rng,
+    k: u32,
+) -> Augmented {
     match k % 10 {
         0 => reorder_postcode_first(g),
         1 => drop_field(g, DropTarget::Postcode),
         2 => drop_field(g, DropTarget::City),
-        3 => abbr_contract(g),
-        4 => abbr_expand(g),
+        3 => abbr_contract(g, morph),
+        4 => abbr_expand(g, morph),
         5 => case_transform(g, CaseStyle::Upper),
         6 => case_transform(g, CaseStyle::Lower),
         7 => whitespace_noise(g, rng),
         8 => typo_injection(g, rng),
-        _ => combined_case_abbr(g, rng),
+        _ => combined_case_abbr(g, morph, rng),
     }
 }
 
@@ -155,56 +162,22 @@ fn drop_field(g: &GoldRecord, target: DropTarget) -> Augmented {
     }
 }
 
-/// French/Dutch abbreviation contractions used in BE addressing.
-const ABBR_CONTRACT: &[(&str, &str)] = &[
-    // FR
-    ("Rue", "R."),
-    ("rue", "r."),
-    ("Boulevard", "Bd"),
-    ("boulevard", "bd"),
-    ("Avenue", "Av."),
-    ("avenue", "av."),
-    ("Place", "Pl."),
-    ("place", "pl."),
-    ("Chaussée", "Ch."),
-    ("chaussée", "ch."),
-    ("Saint", "St"),
-    ("saint", "st"),
-    // NL
-    ("Straat", "Str."),
-    ("straat", "str."),
-    ("Laan", "Ln."),
-    ("laan", "ln."),
-];
-
-/// Reverse: contracted → expanded.
-const ABBR_EXPAND: &[(&str, &str)] = &[
-    ("R.", "Rue"),
-    ("r.", "rue"),
-    ("Bd.", "Boulevard"),
-    ("bd.", "boulevard"),
-    ("Bd ", "Boulevard "),
-    ("bd ", "boulevard "),
-    ("Av.", "Avenue"),
-    ("av.", "avenue"),
-    ("Pl.", "Place"),
-    ("pl.", "place"),
-    ("Ch.", "Chaussée"),
-    ("ch.", "chaussée"),
-    ("St ", "Saint "),
-    ("st ", "saint "),
-    ("Str.", "Straat"),
-    ("str.", "straat"),
-    ("Ln.", "Laan"),
-    ("ln.", "laan"),
-];
-
-fn abbr_contract(g: &GoldRecord) -> Augmented {
+/// Contract abbreviations using the morphology's `long_to_short`
+/// table. Tries longest-form first (table is pre-sorted by
+/// [`Morphology::abbreviations`]) so e.g. "Boulevard" matches before
+/// "Bd". Walks the entire street string (not just the prefix) so
+/// suffixed compound forms like German "Friedrichstraße" → "Friedrichstr."
+/// or US "Pennsylvania Avenue" → "Pennsylvania Ave" are handled.
+fn abbr_contract(g: &GoldRecord, morph: &Morphology) -> Augmented {
     let mut g2 = g.clone();
     if let Some(s) = g2.street.as_mut() {
-        for (long, short) in ABBR_CONTRACT {
-            if s.starts_with(long) {
-                *s = format!("{}{}", short, &s[long.len()..]);
+        for (long, short) in morph.abbreviations() {
+            if let Some(idx) = s.find(long.as_str()) {
+                let mut out = String::with_capacity(s.len() + 4);
+                out.push_str(&s[..idx]);
+                out.push_str(&short);
+                out.push_str(&s[idx + long.len()..]);
+                *s = out;
                 break;
             }
         }
@@ -217,12 +190,25 @@ fn abbr_contract(g: &GoldRecord) -> Augmented {
     }
 }
 
-fn abbr_expand(g: &GoldRecord) -> Augmented {
+/// Expand abbreviations: reverse of [`abbr_contract`]. Tries
+/// longest-short-form first so "Blvd" matches before "Bd" / "Bld".
+fn abbr_expand(g: &GoldRecord, morph: &Morphology) -> Augmented {
     let mut g2 = g.clone();
     if let Some(s) = g2.street.as_mut() {
-        for (short, long) in ABBR_EXPAND {
-            if s.starts_with(short) {
-                *s = format!("{}{}", long, &s[short.len()..]);
+        let mut pairs: Vec<(String, String)> = morph
+            .abbreviations()
+            .into_iter()
+            .map(|(l, sh)| (sh, l))
+            .collect();
+        // Longest short-form first.
+        pairs.sort_by_key(|(sh, _)| std::cmp::Reverse(sh.len()));
+        for (short, long) in pairs {
+            if let Some(idx) = s.find(short.as_str()) {
+                let mut out = String::with_capacity(s.len() + 4);
+                out.push_str(&s[..idx]);
+                out.push_str(&long);
+                out.push_str(&s[idx + short.len()..]);
+                *s = out;
                 break;
             }
         }
@@ -442,7 +428,7 @@ fn typo_injection(g: &GoldRecord, rng: &mut ChaCha20Rng) -> Augmented {
     }
 }
 
-fn combined_case_abbr(g: &GoldRecord, rng: &mut ChaCha20Rng) -> Augmented {
+fn combined_case_abbr(g: &GoldRecord, morph: &Morphology, rng: &mut ChaCha20Rng) -> Augmented {
     // Pipeline: contract abbreviations on the GoldRecord, then run the
     // result through case_transform. We mutate the GoldRecord directly
     // (rather than going through `abbr_contract` which produces an
@@ -455,9 +441,13 @@ fn combined_case_abbr(g: &GoldRecord, rng: &mut ChaCha20Rng) -> Augmented {
     };
     let mut g2 = g.clone();
     if let Some(s) = g2.street.as_mut() {
-        for (long, short) in ABBR_CONTRACT {
-            if s.starts_with(long) {
-                *s = format!("{}{}", short, &s[long.len()..]);
+        for (long, short) in morph.abbreviations() {
+            if let Some(idx) = s.find(long.as_str()) {
+                let mut out = String::with_capacity(s.len() + 4);
+                out.push_str(&s[..idx]);
+                out.push_str(&short);
+                out.push_str(&s[idx + long.len()..]);
+                *s = out;
                 break;
             }
         }

--- a/geocode-training/corpus-gen/src/bench_queries.rs
+++ b/geocode-training/corpus-gen/src/bench_queries.rs
@@ -19,6 +19,7 @@
 use crate::augment::{self, Augmented};
 use crate::bio::Labeled;
 use crate::gold::GoldRecord;
+use crate::morphology::Morphology;
 use anyhow::{Result, bail};
 use rand::Rng;
 use rand_chacha::ChaCha20Rng;
@@ -32,6 +33,7 @@ pub fn write_bench_tsv(
     golds: &[GoldRecord],
     path: &Path,
     target: usize,
+    morph: &Morphology,
     rng: &mut ChaCha20Rng,
 ) -> Result<usize> {
     let f = File::create(path)?;
@@ -67,10 +69,18 @@ pub fn write_bench_tsv(
             let canonical = crate::bio::render_canonical(g);
             let text = match *class {
                 "clean" => canonical.text.clone(),
-                "abbreviated" => render_one_kind(g, &canonical, rng, kind_offset_for_class(class)),
-                "typo" => render_one_kind(g, &canonical, rng, kind_offset_for_class(class)),
-                "reordered" => render_one_kind(g, &canonical, rng, kind_offset_for_class(class)),
-                "partial" => render_one_kind(g, &canonical, rng, kind_offset_for_class(class)),
+                "abbreviated" => {
+                    render_one_kind(g, &canonical, morph, rng, kind_offset_for_class(class))
+                }
+                "typo" => {
+                    render_one_kind(g, &canonical, morph, rng, kind_offset_for_class(class))
+                }
+                "reordered" => {
+                    render_one_kind(g, &canonical, morph, rng, kind_offset_for_class(class))
+                }
+                "partial" => {
+                    render_one_kind(g, &canonical, morph, rng, kind_offset_for_class(class))
+                }
                 _ => unreachable!(),
             };
             // Skip degenerate (empty / too short) outputs.
@@ -104,7 +114,13 @@ fn kind_offset_for_class(class: &&str) -> u32 {
     }
 }
 
-fn render_one_kind(g: &GoldRecord, canonical: &Labeled, rng: &mut ChaCha20Rng, k: u32) -> String {
-    let Augmented { text, .. } = augment::apply(g, canonical, rng, k);
+fn render_one_kind(
+    g: &GoldRecord,
+    canonical: &Labeled,
+    morph: &Morphology,
+    rng: &mut ChaCha20Rng,
+    k: u32,
+) -> String {
+    let Augmented { text, .. } = augment::apply(g, canonical, morph, rng, k);
     text
 }

--- a/geocode-training/corpus-gen/src/bio.rs
+++ b/geocode-training/corpus-gen/src/bio.rs
@@ -7,11 +7,25 @@
 //! Field set: STREET, HNUM, POST, CITY, UNIT. Five fields × 2 (B/I) + O = 11
 //! possible labels (we use indices, not strings, in the training output).
 //!
-//! IMPORTANT: when augmentation rewrites the canonical text, the BIO labels
-//! must be re-derived against the new byte string. We never try to
-//! "synthesize" labels from offsets — we always tag spans against the
-//! rewritten string. This is the design that survives typo injection without
-//! drift (per the codex/gemini review on label preservation).
+//! ## Provenance-based labeling
+//!
+//! BIO labels are derived from the **gold record's per-field provenance**
+//! at render time, NOT from post-hoc tokenizer alignment over a flat
+//! string. `render_canonical` walks the gold record component by
+//! component (street, housenumber, postcode, city, unit), appends each
+//! to a buffer, and records the resulting byte range as a `Span`. The
+//! BIO byte vector is then a direct projection of those spans onto
+//! `text.len()` bytes — no string-search step, no fuzzy alignment.
+//!
+//! This is the design that addresses the codex review (`CORPUS_DESIGN_NOTES.md`):
+//! every output codepoint owns a field id, derived from the structured
+//! source rather than recovered after the fact.
+//!
+//! When augmentation rewrites the canonical text, the BIO labels are
+//! re-derived against the new byte string via the same span-driven
+//! mechanism (the augmenter mutates the spans alongside the text and
+//! calls `bio_from_spans` against the rewritten pair). This is the
+//! design that survives typo injection without drift.
 
 use crate::gold::GoldRecord;
 

--- a/geocode-training/corpus-gen/src/canary.rs
+++ b/geocode-training/corpus-gen/src/canary.rs
@@ -1,43 +1,89 @@
 //! Cross-shard regression canary.
 //!
-//! BE addresses rewritten with FR or NL conventions, kept OUT of the
-//! training corpus and emitted to a separate JSONL file. The goal: at eval
-//! time, run the trained parser on the canary file and verify it still
-//! tags / routes BE correctly despite seeing FR/NL surface forms. If it
-//! drops accuracy, the training corpus is leaking shard quirks.
+//! Source-country addresses rewritten with target-country conventions,
+//! kept OUT of the training corpus and emitted to a separate JSONL
+//! file. The goal: at eval time, run the trained parser on the canary
+//! file and verify it still tags / routes the SOURCE country correctly
+//! despite seeing the target country's surface forms. If accuracy
+//! drops, the training corpus is leaking shard quirks.
 //!
-//! The country label stays "BE" — that's the whole point. The parser must
-//! learn geography over orthography.
+//! The country label stays as the SOURCE country — that's the whole
+//! point. The parser must learn geography over orthography.
+//!
+//! The rewrite logic: find a source-country street marker (e.g. NL
+//! `straat`, FR `rue`) in the input, swap it for the equivalent
+//! target-country marker. The `Morphology` table for both countries
+//! lists their markers per language; rewriting is just substring
+//! substitution.
 
 use crate::gold::GoldRecord;
+use crate::morphology::Morphology;
 use crate::output::TrainRecord;
 use rand_chacha::ChaCha20Rng;
 
-const FR_STREET_TYPE_FLIPS: &[(&str, &str)] = &[
-    // NL → FR (so an NL-named street looks French)
-    ("straat", "rue"),
-    ("Straat", "Rue"),
-    ("laan", "avenue"),
-    ("Laan", "Avenue"),
-    ("plein", "place"),
-    ("Plein", "Place"),
-];
+/// Pairs of "source-marker" → "target-marker" — what to swap and what
+/// to swap it for. We construct these at canary-build time by zipping
+/// the source's `markers` with the target's `markers` (parallel by
+/// position within each language tag).
+fn rewrite_pairs(source: &Morphology, target: &Morphology) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    // Use the union of language tags across both packs.
+    let mut langs: Vec<&str> = source
+        .street_types
+        .markers
+        .keys()
+        .map(|s| s.as_str())
+        .collect();
+    for k in target.street_types.markers.keys() {
+        if !langs.contains(&k.as_str()) {
+            langs.push(k.as_str());
+        }
+    }
+    for lang in langs {
+        let src = source.markers_for(lang);
+        let dst = target.markers_for(lang);
+        // If the target speaks a different language, fall back to ANY
+        // language in the target — this is the cross-language canary
+        // (NL → FR, BE → DE, etc).
+        let dst_fallback: Vec<&str> = target.all_markers();
+        let (src, dst_pool): (&[String], Vec<&str>) = match (src, dst) {
+            (Some(s), Some(d)) => (s, d.iter().map(String::as_str).collect()),
+            (Some(s), None) => (s, dst_fallback.clone()),
+            _ => continue,
+        };
+        if dst_pool.is_empty() {
+            continue;
+        }
+        for (i, src_marker) in src.iter().enumerate() {
+            // Pair by position within the markers list when possible
+            // (i.e. NL `straat`[0] → FR `rue`[0]); fall back to first
+            // target marker if the index doesn't line up.
+            let dst_marker = dst_pool.get(i).copied().unwrap_or(dst_pool[0]);
+            // Capitalized form too.
+            let mut sc = src_marker.chars();
+            let mut dc = dst_marker.chars();
+            let src_cap: String = sc
+                .next()
+                .map(|c| c.to_uppercase().collect::<String>())
+                .unwrap_or_default()
+                + sc.as_str();
+            let dst_cap: String = dc
+                .next()
+                .map(|c| c.to_uppercase().collect::<String>())
+                .unwrap_or_default()
+                + dc.as_str();
+            pairs.push((src_cap, dst_cap));
+            pairs.push((src_marker.clone(), dst_marker.to_string()));
+        }
+    }
+    // Longest-first so substring matches don't shadow longer ones.
+    pairs.sort_by_key(|(s, _)| std::cmp::Reverse(s.len()));
+    pairs
+}
 
-const NL_STREET_TYPE_FLIPS: &[(&str, &str)] = &[
-    // FR → NL (so a FR-named street looks Dutch)
-    ("rue", "straat"),
-    ("Rue", "Straat"),
-    ("avenue", "laan"),
-    ("Avenue", "Laan"),
-    ("place", "plein"),
-    ("Place", "Plein"),
-    ("boulevard", "laan"),
-    ("Boulevard", "Laan"),
-];
-
-fn rewrite_street(s: &str, flips: &[(&str, &str)]) -> Option<String> {
-    for (from, to) in flips {
-        if let Some(idx) = s.find(from) {
+fn rewrite_street(s: &str, pairs: &[(String, String)]) -> Option<String> {
+    for (from, to) in pairs {
+        if let Some(idx) = s.find(from.as_str()) {
             let mut out = String::with_capacity(s.len() + 4);
             out.push_str(&s[..idx]);
             out.push_str(to);
@@ -48,18 +94,25 @@ fn rewrite_street(s: &str, flips: &[(&str, &str)]) -> Option<String> {
     None
 }
 
-pub fn rewrite_be_as_fr(g: &GoldRecord, _rng: &mut ChaCha20Rng) -> Option<TrainRecord> {
-    let new_street = rewrite_street(g.street.as_deref()?, FR_STREET_TYPE_FLIPS)?;
+/// Rewrite a single gold record from the source country's idiom into
+/// the target country's idiom. Returns `None` if no marker matched —
+/// the record is just not relevant for this canary pair.
+pub fn rewrite_with(
+    g: &GoldRecord,
+    source: &Morphology,
+    target: &Morphology,
+    _rng: &mut ChaCha20Rng,
+) -> Option<TrainRecord> {
+    let pairs = rewrite_pairs(source, target);
+    let new_street = rewrite_street(g.street.as_deref()?, &pairs)?;
     let mut g2 = g.clone();
     g2.street = Some(new_street);
-    Some(rendered_record(&g2, "canary_be_as_fr"))
-}
-
-pub fn rewrite_be_as_nl(g: &GoldRecord, _rng: &mut ChaCha20Rng) -> Option<TrainRecord> {
-    let new_street = rewrite_street(g.street.as_deref()?, NL_STREET_TYPE_FLIPS)?;
-    let mut g2 = g.clone();
-    g2.street = Some(new_street);
-    Some(rendered_record(&g2, "canary_be_as_nl"))
+    let kind = format!(
+        "canary_{}_as_{}",
+        source.country.iso2.to_lowercase(),
+        target.country.iso2.to_lowercase()
+    );
+    Some(rendered_record(&g2, &kind))
 }
 
 fn rendered_record(g: &GoldRecord, kind: &str) -> TrainRecord {
@@ -72,3 +125,63 @@ fn rendered_record(g: &GoldRecord, kind: &str) -> TrainRecord {
         augmentation: kind.to_string(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::morphology::Morphology;
+    use rand::SeedableRng;
+    use std::path::PathBuf;
+
+    fn morph_dir() -> PathBuf {
+        let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.push("morphology");
+        p
+    }
+
+    #[test]
+    fn rewrites_be_street_as_fr_keeps_country_label() {
+        let be = Morphology::load_from_dir(morph_dir(), "BE").unwrap();
+        let fr = Morphology::load_from_dir(morph_dir(), "FR").unwrap();
+        let g = GoldRecord {
+            osm_id: 1,
+            country: "BE".to_string(),
+            street: Some("Brusselsestraat".to_string()), // NL marker "straat"
+            housenumber: Some("12".to_string()),
+            postcode: Some("3000".to_string()),
+            city: Some("Leuven".to_string()),
+            unit: None,
+            lat: 50.0,
+            lon: 5.0,
+        };
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let out = rewrite_with(&g, &be, &fr, &mut rng).unwrap();
+        assert_eq!(out.country, "BE", "country label must stay as source");
+        assert!(
+            !out.text.contains("straat"),
+            "straat marker should be rewritten, got: {}",
+            out.text
+        );
+        assert!(out.augmentation.starts_with("canary_be_as_fr"));
+    }
+
+    #[test]
+    fn unmatched_record_returns_none() {
+        let be = Morphology::load_from_dir(morph_dir(), "BE").unwrap();
+        let fr = Morphology::load_from_dir(morph_dir(), "FR").unwrap();
+        let g = GoldRecord {
+            osm_id: 1,
+            country: "BE".to_string(),
+            street: Some("Foo Bar Baz".to_string()), // no marker present
+            housenumber: Some("1".to_string()),
+            postcode: Some("3000".to_string()),
+            city: Some("Leuven".to_string()),
+            unit: None,
+            lat: 0.0,
+            lon: 0.0,
+        };
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        assert!(rewrite_with(&g, &be, &fr, &mut rng).is_none());
+    }
+}
+

--- a/geocode-training/corpus-gen/src/main.rs
+++ b/geocode-training/corpus-gen/src/main.rs
@@ -13,6 +13,7 @@ mod bench_queries;
 mod bio;
 mod canary;
 mod gold;
+mod morphology;
 mod output;
 
 use anyhow::Result;
@@ -32,8 +33,9 @@ struct Args {
     #[arg(short, long, default_value = "corpus.jsonl")]
     out: PathBuf,
 
-    /// Cross-shard canary output path. BE addresses rewritten with FR/NL
-    /// conventions for held-out regression testing of shard memorization.
+    /// Cross-shard canary output path. Source-country addresses rewritten
+    /// with `--canary-targets` countries' conventions for held-out
+    /// regression testing of shard memorization.
     #[arg(long, default_value = "canary.jsonl")]
     canary: PathBuf,
 
@@ -41,8 +43,22 @@ struct Args {
     #[arg(long, default_value = "BE")]
     country: String,
 
-    /// Number of augmented variants per gold record (default 10).
-    #[arg(short = 'n', long, default_value_t = 10)]
+    /// Comma-separated ISO 3166-1 alpha-2 codes of the canary target
+    /// countries. Each target country's morphology is used to rewrite
+    /// source-country streets with its conventions, generating held-out
+    /// counterfactual examples. Empty to skip canary generation.
+    #[arg(long, default_value = "FR,NL")]
+    canary_targets: String,
+
+    /// Directory containing morphology TOML files (one per ISO code,
+    /// e.g. `morphology/be.toml`).
+    #[arg(long, default_value = "morphology")]
+    morphology_dir: PathBuf,
+
+    /// Number of augmented variants per gold record (default 8 per
+    /// codex review). Each gold record contributes 1 canonical record
+    /// + N augmented variants to the training corpus.
+    #[arg(short = 'n', long, default_value_t = 8)]
     augmentations: u32,
 
     /// Optional cap on number of gold records read from the PBF
@@ -75,8 +91,38 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let mut rng = ChaCha20Rng::seed_from_u64(args.seed);
 
+    // Load source-country morphology + canary-target morphologies.
+    let source_iso = args.country.trim().to_ascii_uppercase();
+    let canary_isos: Vec<String> = args
+        .canary_targets
+        .split(',')
+        .map(|s| s.trim().to_ascii_uppercase())
+        .filter(|s| !s.is_empty() && s != &source_iso)
+        .collect();
+
+    let source_morph = morphology::Morphology::load_from_dir(&args.morphology_dir, &source_iso)?;
+    eprintln!(
+        "[corpus-gen] source morphology: {} ({})",
+        source_morph.country.iso2, source_morph.country.name,
+    );
+
+    let canary_targets: Vec<morphology::Morphology> = canary_isos
+        .iter()
+        .map(|iso| morphology::Morphology::load_from_dir(&args.morphology_dir, iso))
+        .collect::<Result<Vec<_>>>()?;
+    if !canary_targets.is_empty() {
+        eprintln!(
+            "[corpus-gen] canary targets: {}",
+            canary_targets
+                .iter()
+                .map(|m| m.country.iso2.as_str())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+    }
+
     eprintln!("[corpus-gen] reading PBF: {}", args.pbf.display());
-    let golds = gold::read_pbf(&args.pbf, &args.country, args.limit)?;
+    let golds = gold::read_pbf(&args.pbf, &source_iso, args.limit)?;
     eprintln!("[corpus-gen] gold records: {}", golds.len());
 
     let mut writer = output::JsonlWriter::new(&args.out)?;
@@ -92,13 +138,11 @@ fn main() -> Result<()> {
     for (i, g) in golds.iter().enumerate() {
         // Skip the canary stride from the training corpus and route them to canary instead.
         if i % canary_stride == 0 {
-            if let Some(record) = canary::rewrite_be_as_fr(g, &mut rng) {
-                canary_writer.write(&record)?;
-                canary_written += 1;
-            }
-            if let Some(record) = canary::rewrite_be_as_nl(g, &mut rng) {
-                canary_writer.write(&record)?;
-                canary_written += 1;
+            for tgt in &canary_targets {
+                if let Some(record) = canary::rewrite_with(g, &source_morph, tgt, &mut rng) {
+                    canary_writer.write(&record)?;
+                    canary_written += 1;
+                }
             }
             continue;
         }
@@ -116,7 +160,7 @@ fn main() -> Result<()> {
 
         // N augmented variants. Each picks one or more rewrite strategies.
         for k in 0..args.augmentations {
-            let variant = augment::apply(g, &canonical, &mut rng, k);
+            let variant = augment::apply(g, &canonical, &source_morph, &mut rng, k);
             writer.write(&output::TrainRecord {
                 text: variant.text,
                 bio_labels: variant.bio_labels,
@@ -147,8 +191,13 @@ fn main() -> Result<()> {
     );
 
     if let Some(bench_path) = &args.bench_queries {
-        let n =
-            bench_queries::write_bench_tsv(&golds, bench_path, args.bench_queries_count, &mut rng)?;
+        let n = bench_queries::write_bench_tsv(
+            &golds,
+            bench_path,
+            args.bench_queries_count,
+            &source_morph,
+            &mut rng,
+        )?;
         eprintln!(
             "[corpus-gen] wrote {} bench queries to {}",
             n,

--- a/geocode-training/corpus-gen/src/morphology.rs
+++ b/geocode-training/corpus-gen/src/morphology.rs
@@ -1,0 +1,253 @@
+//! Per-country morphology tables.
+//!
+//! Each country has a TOML pack under `morphology/<iso2>.toml`. The pack
+//! describes:
+//!
+//! - rendering conventions: field separators, where the postcode lives
+//!   relative to the city, etc.
+//! - street-type tables: long-form ↔ short-form abbreviation pairs (e.g.
+//!   `Rue` ↔ `R.` in FR, `Straße` ↔ `Str.` in DE), and street-marker
+//!   substrings used to identify a street as belonging to a given style.
+//! - postcode validation regex (sanity-only, not used for parsing).
+//!
+//! The morphology tables are loaded ONCE at startup. Each augmentation
+//! and canary rewriter takes a `&Morphology` so it can speak the right
+//! country's idiom — moving BE/FR/NL/DE/US/GB out of `match` arms and
+//! into data.
+
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Where the postcode goes in the rendered string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PostcodePosition {
+    /// Postcode appears BEFORE the city.
+    Leading,
+    /// Postcode appears AFTER the city.
+    Trailing,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CountryMeta {
+    pub iso2: String,
+    /// Display name. Loaded from TOML for documentation but not used
+    /// at runtime (we identify by ISO code).
+    #[allow(dead_code)]
+    pub name: String,
+}
+
+#[allow(dead_code)] // fields documented for future renderer plumbing
+#[derive(Debug, Clone, Deserialize)]
+pub struct RenderRules {
+    /// Separator placed AFTER the housenumber and before the
+    /// postcode/city block (typically `, `).
+    pub field_separator_after_house: String,
+    /// Separator between postcode and city (typically a single space).
+    pub postcode_city_separator: String,
+    /// Where the postcode lives relative to the city.
+    pub postcode_position: PostcodePosition,
+}
+
+#[allow(dead_code)] // postcode validation is data-only at this stage
+#[derive(Debug, Clone, Deserialize)]
+pub struct PostcodeRules {
+    pub regex: String,
+    /// Format string. Currently only `"{}"` (identity) is honoured —
+    /// non-trivial canonicalization is a future extension.
+    #[serde(default = "default_postcode_format")]
+    pub format: String,
+}
+
+fn default_postcode_format() -> String {
+    "{}".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreetTypes {
+    /// Pairs of `[long, short]` forms. Both forms keep their case.
+    /// The augmenter applies `.to_lowercase()` for the lower-case
+    /// variant; capitalized variants come from the TOML directly.
+    #[serde(default)]
+    pub long_to_short: Vec<[String; 2]>,
+
+    /// Sub-tables of substring markers, keyed by language tag (`fr`,
+    /// `nl`, `de`, etc.). Used by canary cross-country rewrites — the
+    /// rewriter looks up the source country's markers, finds one in
+    /// the input, and swaps it for the corresponding marker in the
+    /// target country's morphology.
+    #[serde(default)]
+    pub markers: HashMap<String, Vec<String>>,
+}
+
+/// Loaded morphology for one country.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Morphology {
+    pub country: CountryMeta,
+    /// Rendering conventions — separators, postcode position. Available
+    /// for future renderer upgrades; the current generator's BIO renderer
+    /// is in `bio.rs::render_canonical`. Kept here so per-country
+    /// rendering can plug in without re-introducing a hardcoded path.
+    #[allow(dead_code)]
+    pub render: RenderRules,
+    /// Postcode regex (sanity-only; not used for parsing).
+    #[allow(dead_code)]
+    pub postcode: PostcodeRules,
+    pub street_types: StreetTypes,
+}
+
+impl Morphology {
+    /// Load from a TOML file.
+    pub fn from_toml_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        let s = std::fs::read_to_string(path)
+            .with_context(|| format!("reading morphology TOML at {}", path.display()))?;
+        toml::from_str::<Self>(&s)
+            .with_context(|| format!("parsing morphology TOML at {}", path.display()))
+    }
+
+    /// Load by ISO code from a directory of `<iso2>.toml` files.
+    pub fn load_from_dir<P: AsRef<Path>>(dir: P, iso2: &str) -> Result<Self> {
+        let iso = iso2.trim().to_ascii_lowercase();
+        if iso.len() != 2 {
+            return Err(anyhow!("invalid ISO code {iso2:?}"));
+        }
+        let path = dir.as_ref().join(format!("{}.toml", iso));
+        Self::from_toml_path(path)
+    }
+
+    /// Build the abbreviation table used by `augment::abbr_contract`
+    /// and `augment::abbr_expand`. Returns pairs of (long, short)
+    /// covering both capitalized AND lowercase variants, in the order
+    /// the augmenter should try them (longest-first to avoid partial
+    /// matches).
+    pub fn abbreviations(&self) -> Vec<(String, String)> {
+        let mut out: Vec<(String, String)> = Vec::with_capacity(self.street_types.long_to_short.len() * 2);
+        for pair in &self.street_types.long_to_short {
+            out.push((pair[0].clone(), pair[1].clone()));
+            // Add a lowercase variant if distinct from the cased one.
+            let long_l = pair[0].to_lowercase();
+            let short_l = pair[1].to_lowercase();
+            if long_l != pair[0] || short_l != pair[1] {
+                out.push((long_l, short_l));
+            }
+        }
+        // Sort longest-first so "Boulevard" matches before "Bd"-prefixed
+        // street names with the bare "Bd" abbreviation.
+        out.sort_by_key(|(l, _)| std::cmp::Reverse(l.len()));
+        out
+    }
+
+    /// Lookup of street markers for a given language tag.
+    pub fn markers_for(&self, lang: &str) -> Option<&[String]> {
+        self.street_types
+            .markers
+            .get(lang)
+            .map(std::vec::Vec::as_slice)
+    }
+
+    /// All marker substrings flattened (any lang).
+    pub fn all_markers(&self) -> Vec<&str> {
+        let mut out = Vec::new();
+        for v in self.street_types.markers.values() {
+            for s in v {
+                out.push(s.as_str());
+            }
+        }
+        out
+    }
+}
+
+/// Registry of loaded morphology tables, keyed by uppercase ISO code.
+///
+/// Currently the corpus generator only needs the source country's
+/// morphology + an explicit list of canary targets (loaded individually
+/// via [`Morphology::load_from_dir`]), but this registry is the
+/// natural shape for a future "load everything once and look up by
+/// ISO" pattern (e.g. when a single corpus pass spans multiple
+/// countries via PBF concatenation).
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct MorphologyRegistry {
+    by_iso: HashMap<String, Morphology>,
+}
+
+#[allow(dead_code)]
+impl MorphologyRegistry {
+    /// Build by loading the requested ISO codes from `dir/<iso2>.toml`.
+    pub fn load<P: AsRef<Path>, S: AsRef<str>>(dir: P, isos: &[S]) -> Result<Self> {
+        let mut by_iso = HashMap::new();
+        for iso in isos {
+            let m = Morphology::load_from_dir(&dir, iso.as_ref())?;
+            by_iso.insert(iso.as_ref().trim().to_ascii_uppercase(), m);
+        }
+        Ok(Self { by_iso })
+    }
+
+    pub fn get(&self, iso2: &str) -> Option<&Morphology> {
+        self.by_iso.get(&iso2.trim().to_ascii_uppercase())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn morphology_dir() -> PathBuf {
+        // Cargo tests run with CARGO_MANIFEST_DIR pointing at the crate root.
+        let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.push("morphology");
+        p
+    }
+
+    #[test]
+    fn loads_belgium_pack() {
+        let m = Morphology::load_from_dir(morphology_dir(), "BE").unwrap();
+        assert_eq!(m.country.iso2, "BE");
+        assert_eq!(m.render.postcode_position, PostcodePosition::Leading);
+        assert!(m.markers_for("fr").is_some());
+        assert!(m.markers_for("nl").is_some());
+        let abbrs = m.abbreviations();
+        assert!(abbrs.iter().any(|(l, _)| l == "Boulevard"));
+        // Longest-first ordering.
+        assert!(
+            abbrs.first().unwrap().0.len() >= abbrs.last().unwrap().0.len(),
+            "abbreviations not sorted longest-first"
+        );
+    }
+
+    #[test]
+    fn loads_us_pack_with_trailing_postcode() {
+        let m = Morphology::load_from_dir(morphology_dir(), "us").unwrap();
+        assert_eq!(m.country.iso2, "US");
+        assert_eq!(m.render.postcode_position, PostcodePosition::Trailing);
+        let abbrs = m.abbreviations();
+        assert!(abbrs.iter().any(|(l, s)| l == "Boulevard" && s == "Blvd"));
+        assert!(abbrs.iter().any(|(l, s)| l == "Northwest" && s == "NW"));
+    }
+
+    #[test]
+    fn loads_germany_pack() {
+        let m = Morphology::load_from_dir(morphology_dir(), "DE").unwrap();
+        let markers = m.markers_for("de").unwrap();
+        assert!(markers.iter().any(|s| s == "straße"));
+        assert!(markers.iter().any(|s| s == "platz"));
+    }
+
+    #[test]
+    fn registry_loads_multiple() {
+        let reg = MorphologyRegistry::load(morphology_dir(), &["BE", "FR", "DE"]).unwrap();
+        assert!(reg.get("BE").is_some());
+        assert!(reg.get("fr").is_some()); // case-insensitive
+        assert!(reg.get("DE").is_some());
+        assert!(reg.get("XX").is_none());
+    }
+
+    #[test]
+    fn unknown_country_errs() {
+        assert!(Morphology::load_from_dir(morphology_dir(), "ZZ").is_err());
+    }
+}

--- a/geocode/src/main.rs
+++ b/geocode/src/main.rs
@@ -145,25 +145,53 @@ enum Command {
     /// for shipping the proof-of-life model.
     Train {
         /// Output safetensors path. A sidecar `.config.json` with the
-        /// model architecture is written next to it.
+        /// model architecture + country vocab is written next to it.
         #[arg(long)]
         out: PathBuf,
-        /// Path to a JSONL corpus. Each line: `{"text", "country", "spans": [{"field","start","end"}, ...]}`.
+        /// Path to a JSONL corpus. Two formats are accepted (auto-detected):
+        ///
+        /// 1. Spans format (legacy): `{"text", "country", "spans": [{"field","start","end"}, ...]}`.
+        /// 2. corpus-gen BIO format: `{"text", "country", "bio_labels": [...], "augmentation": "..."}`.
         #[arg(long)]
         corpus: Option<PathBuf>,
         /// Number of synthetic examples to generate when no corpus is
         /// provided. Default 4096.
         #[arg(long, default_value_t = 4096)]
         synthetic: usize,
+        /// Comma-separated list of ISO 3166-1 alpha-2 country codes that
+        /// the model's country head will be sized for. Order does not
+        /// matter — the vocab is internally lex-sorted.
+        #[arg(long, default_value = "BE")]
+        countries: String,
+        /// Architecture profile. `tiny` (the proof-of-life shipped model)
+        /// or `production` (#96 Fork A+: d=128, l=4, h=8, ~825k params).
+        #[arg(long, default_value = "tiny")]
+        architecture: String,
         /// Number of training epochs.
         #[arg(long, default_value_t = 8)]
         epochs: usize,
         /// Mini-batch size.
-        #[arg(long, default_value_t = 16)]
+        #[arg(long, default_value_t = 64)]
         batch_size: usize,
-        /// Learning rate for AdamW.
-        #[arg(long, default_value_t = 2e-3)]
+        /// Peak learning rate for AdamW.
+        #[arg(long, default_value_t = 1e-3)]
         learning_rate: f64,
+        /// LR schedule kind: `cosine`, `linear`, or `constant`.
+        /// All variants do a linear warmup ramp first.
+        #[arg(long, default_value = "cosine")]
+        lr_schedule: String,
+        /// AdamW weight-decay coefficient.
+        #[arg(long, default_value_t = 0.01)]
+        weight_decay: f64,
+        /// Max global gradient L2-norm. Set to 0 to disable clipping.
+        #[arg(long, default_value_t = 1.0)]
+        gradient_clip: f64,
+        /// Number of linear-warmup steps. `0` disables warmup.
+        #[arg(long, default_value_t = 1000)]
+        warmup_steps: usize,
+        /// Eval split fraction in `[0.0, 1.0)`. Default 0.1.
+        #[arg(long, default_value_t = 0.1)]
+        eval_split: f32,
         /// Random seed.
         #[arg(long, default_value_t = 0xB17EBAD0)]
         seed: u64,
@@ -416,17 +444,31 @@ async fn main() -> Result<()> {
             out,
             corpus,
             synthetic,
+            countries,
+            architecture,
             epochs,
             batch_size,
             learning_rate,
+            lr_schedule,
+            weight_decay,
+            gradient_clip,
+            warmup_steps,
+            eval_split,
             seed,
         } => train_cmd(
             out,
             corpus,
             synthetic,
+            &countries,
+            &architecture,
             epochs,
             batch_size,
             learning_rate,
+            &lr_schedule,
+            weight_decay,
+            gradient_clip,
+            warmup_steps,
+            eval_split,
             seed,
         ),
         Command::Serve {
@@ -1199,19 +1241,35 @@ fn candidate_pbf_names(c: CountryId) -> Vec<String> {
     v
 }
 
+#[allow(clippy::too_many_arguments)]
 fn train_cmd(
     out: PathBuf,
     corpus_path: Option<PathBuf>,
     synthetic_n: usize,
+    countries_csv: &str,
+    architecture: &str,
     epochs: usize,
     batch_size: usize,
     learning_rate: f64,
+    lr_schedule: &str,
+    weight_decay: f64,
+    gradient_clip: f64,
+    warmup_steps: usize,
+    eval_split: f32,
     seed: u64,
 ) -> Result<()> {
     use butterfly_geocode::tagger::training::{
-        TrainConfig, generate_belgium_synthetic, read_jsonl_corpus, train_and_save,
+        CountryVocab, LrSchedule, TrainConfig, generate_belgium_synthetic, read_jsonl_corpus,
+        train_and_save,
     };
     use butterfly_geocode::tagger::transformer::ModelConfig;
+
+    let vocab = CountryVocab::from_csv(countries_csv)?;
+    info!(
+        countries = vocab.countries().join(",").as_str(),
+        n = vocab.len(),
+        "country vocab"
+    );
 
     let corpus = if let Some(path) = corpus_path {
         info!(path = %path.display(), "loading corpus");
@@ -1228,16 +1286,52 @@ fn train_cmd(
         c
     };
 
-    let cfg = ModelConfig::tiny();
+    let cfg = match architecture.trim().to_ascii_lowercase().as_str() {
+        "tiny" => {
+            // tiny is BE-only by definition; reject multi-country with tiny.
+            if vocab.len() != 1 {
+                bail!(
+                    "architecture=tiny is single-country; got vocab len={}. Use --architecture production for multi-country.",
+                    vocab.len()
+                );
+            }
+            ModelConfig::tiny()
+        }
+        "production" => ModelConfig::production(vocab.len()),
+        other => bail!("unknown --architecture {:?} (use tiny|production)", other),
+    };
+    info!(
+        architecture = architecture,
+        d_model = cfg.d_model,
+        n_layers = cfg.n_layers,
+        n_heads = cfg.n_heads,
+        d_ff = cfg.d_ff,
+        n_countries = cfg.n_countries,
+        params_approx = cfg.approx_param_count(),
+        "model config"
+    );
+
+    let schedule = LrSchedule::parse(lr_schedule)?;
+    let grad_clip = if gradient_clip > 0.0 {
+        Some(gradient_clip)
+    } else {
+        None
+    };
+
     let train_cfg = TrainConfig {
         epochs,
         batch_size,
         learning_rate,
+        weight_decay,
+        gradient_clip: grad_clip,
+        warmup_steps,
+        lr_schedule: schedule,
+        eval_split,
         seed,
         ..Default::default()
     };
 
-    let metrics = train_and_save(cfg, train_cfg, &corpus, &out)?;
+    let metrics = train_and_save(cfg, train_cfg, &vocab, &corpus, &out)?;
     info!("training complete");
     if let Some(last) = metrics.last() {
         info!(

--- a/geocode/src/parser/neural.rs
+++ b/geocode/src/parser/neural.rs
@@ -27,6 +27,7 @@ use candle_core::Device;
 
 use crate::routing::{CountryId, classify_country};
 use crate::shard::reader::Shard;
+use crate::tagger::training::CountryVocab;
 use crate::tagger::transformer::{ModelConfig, TaggerModel};
 use crate::types::ParsedQuery;
 
@@ -47,6 +48,9 @@ use super::retrieval_utility::RetrievalUtilityScorer;
 pub struct NeuralParser {
     pub model_path: PathBuf,
     pub config: ModelConfig,
+    /// Country vocabulary used at training time. Index `i` of the
+    /// model's country head corresponds to `country_vocab[i]`.
+    pub country_vocab: CountryVocab,
     model: TaggerModel,
     device: Device,
     pub beam_cfg: BeamConfig,
@@ -80,10 +84,12 @@ impl NeuralParser {
     /// `<path>.config.json` next to the weights — written by
     /// [`crate::tagger::training::train_and_save`].
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let (model, cfg, device) = crate::tagger::training::load_model(path.as_ref())?;
+        let (model, cfg, country_vocab, device) =
+            crate::tagger::training::load_model(path.as_ref())?;
         Ok(Self {
             model_path: path.as_ref().to_path_buf(),
             config: cfg,
+            country_vocab,
             model,
             device,
             beam_cfg: BeamConfig::default(),
@@ -113,7 +119,8 @@ impl NeuralParser {
             }
             None => decode(text, &inference, shard, &self.beam_cfg, &self.util_cfg),
         };
-        let country_candidates = merge_country_candidates(text, &inference.country_posterior);
+        let country_candidates =
+            merge_country_candidates(text, &inference.country_posterior, &self.country_vocab);
         Ok(to_parsed_query(text, &decoded, country_candidates, 5))
     }
 
@@ -130,19 +137,40 @@ impl NeuralParser {
     }
 }
 
-/// Multiply the cheap classifier posterior by the model's country head
-/// posterior, then renormalize. MVP: single country (BE) → both
-/// collapse to `(BE, 1.0)`.
-fn merge_country_candidates(text: &str, model_posterior: &[f32]) -> Vec<(CountryId, f32)> {
+/// Merge the cheap-classifier country posterior with the model's
+/// country-head posterior.
+///
+/// The cheap classifier returns `Vec<(CountryId, weight)>` over ALL
+/// shipped country packs. The model head returns a posterior indexed
+/// by the trained [`CountryVocab`] — which may be a subset of the
+/// shipped packs (e.g. trained on `[BE]` but the classifier knows
+/// about FR/NL/DE/...).
+///
+/// For each `(CountryId, cheap_p)` from the classifier, we look up
+/// the country in the trained vocab. If present, multiply its
+/// `cheap_p` by `model_posterior[id]`. If absent (the model never
+/// saw this country during training, so its head can't speak to
+/// it), the cheap classifier's value is used unchanged. Then
+/// renormalize.
+///
+/// The single-country (`BE`) case collapses to the cheap classifier's
+/// own posterior — the model is just a sanity check for the country
+/// it does know.
+fn merge_country_candidates(
+    text: &str,
+    model_posterior: &[f32],
+    vocab: &CountryVocab,
+) -> Vec<(CountryId, f32)> {
     let cheap = classify_country(text);
     if cheap.is_empty() {
         return cheap;
     }
-    // Model is BE-only (n_countries==1) on the shipped tiny model.
-    // For multi-country: multiply pairwise then normalize.
     let mut out: Vec<(CountryId, f32)> = Vec::with_capacity(cheap.len());
-    for (idx, (cid, cheap_p)) in cheap.iter().enumerate() {
-        let model_p = model_posterior.get(idx).copied().unwrap_or(1.0);
+    for (cid, cheap_p) in &cheap {
+        let model_p = vocab
+            .id_of(cid.as_str())
+            .and_then(|id| model_posterior.get(id as usize).copied())
+            .unwrap_or(1.0);
         out.push((*cid, cheap_p * model_p));
     }
     let total: f32 = out.iter().map(|(_, p)| *p).sum();
@@ -162,7 +190,9 @@ mod tests {
     use super::*;
     use crate::shard::AddressRecord;
     use crate::shard::builder::build_shard;
-    use crate::tagger::training::{TrainConfig, generate_belgium_synthetic, train_and_save};
+    use crate::tagger::training::{
+        CountryVocab, LrSchedule, TrainConfig, generate_belgium_synthetic, train_and_save,
+    };
     use tempfile::tempdir;
 
     fn small_shard() -> (tempfile::TempDir, Shard) {
@@ -198,12 +228,16 @@ mod tests {
         let tcfg = TrainConfig {
             epochs: 2,
             batch_size: 8,
+            warmup_steps: 0,
+            lr_schedule: LrSchedule::Constant,
+            gradient_clip: None,
             ..Default::default()
         };
         let dir = tempdir().unwrap();
         let out = dir.path().join("tiny.safetensors");
         let cfg = ModelConfig::tiny();
-        let _ = train_and_save(cfg, tcfg, &corpus, &out).unwrap();
+        let vocab = CountryVocab::new(&["BE"]).unwrap();
+        let _ = train_and_save(cfg, tcfg, &vocab, &corpus, &out).unwrap();
         let parser = NeuralParser::load(&out).unwrap();
         let (_sd, shard) = small_shard();
         let parsed = parser

--- a/geocode/src/tagger/training.rs
+++ b/geocode/src/tagger/training.rs
@@ -2,40 +2,76 @@
 //!
 //! ## Pipeline
 //!
-//! 1. **Corpus** — JSONL, one example per line. Format:
-//!    ```json
-//!    {
-//!      "text": "Rue Wayez 122 1070 Anderlecht",
-//!      "country": "BE",
-//!      "spans": [
-//!        {"field": "street",   "start": 0,  "end": 9},
-//!        {"field": "house",    "start": 10, "end": 13},
-//!        {"field": "postcode", "start": 14, "end": 18},
-//!        {"field": "locality", "start": 19, "end": 29}
-//!      ]
-//!    }
-//!    ```
-//!    `start`/`end` are byte offsets into `text`. Each example is
-//!    converted to a per-byte BIO label sequence at training time.
+//! 1. **Corpus** — JSONL, one example per line. **Two formats are
+//!    accepted**, auto-detected per record:
+//!
+//!    - **Spans format** (legacy, hand-authored fixtures, the trainer's
+//!      original schema):
+//!      ```json
+//!      {
+//!        "text": "Rue Wayez 122 1070 Anderlecht",
+//!        "country": "BE",
+//!        "spans": [
+//!          {"field": "street",   "start": 0,  "end": 9},
+//!          {"field": "house",    "start": 10, "end": 13},
+//!          {"field": "postcode", "start": 14, "end": 18},
+//!          {"field": "locality", "start": 19, "end": 29}
+//!        ]
+//!      }
+//!      ```
+//!
+//!    - **BIO-labels format** emitted by `geocode-training/corpus-gen`
+//!      (one label per byte of `text`):
+//!      ```json
+//!      {
+//!        "text": "Rue Wayez 122, 1070 Anderlecht",
+//!        "country": "BE",
+//!        "bio_labels": [1,2,2,2,2,2,2,2,2,0,3,4,4,0,0,5,6,6,6,0,7,8,8,8,8,8,8,8,8,8],
+//!        "augmentation": "canonical",
+//!        "source_record_id": "osm:n12345"
+//!      }
+//!      ```
+//!      The corpus-gen scheme uses `{O=0, B/I-Street=1/2, B/I-Hnum=3/4,
+//!      B/I-Post=5/6, B/I-City=7/8, B/I-Unit=9/10}`. Labels 0-8 align
+//!      one-to-one with the trainer's BIO scheme; labels 9-10 (Unit)
+//!      are folded to `O` (the trainer has no Unit field).
+//!
+//!    `augmentation` is optional (defaults to "canonical"). It is used
+//!    by the country-head loss masking heuristic — variants like
+//!    `drop_postcode` / `drop_city` make the country ambiguous, so we
+//!    zero out their contribution to the country-head loss (per the
+//!    codex review in `geocode-research/CORPUS_DESIGN_NOTES.md`).
 //!
 //! 2. **Synthetic generator** — when no corpus is provided, the
 //!    [`generate_belgium_synthetic`] function emits N synthetic Belgium
 //!    addresses by sampling Cartesian products of street/house/postcode/
 //!    locality pools. This is the proof-of-life corpus shipped with
-//!    the tiny model. **Not** the shard-agnostic augmentation strategy
-//!    from #96 §Tagger — that is filed as Phase 2 of #98.
+//!    the tiny model.
 //!
 //! 3. **Loss** — weighted CE on BIO + CE on country. Default weights
 //!    `bio=1.0, country=0.3` reflect the relative supervision strength
 //!    (BIO is per-token, country is per-sequence — country head needs
-//!    less weight).
+//!    less weight). Per-example country-loss masking is applied based
+//!    on `augmentation` (drop-field variants get country-loss masked
+//!    out — the country can't be inferred from a missing field, so
+//!    supervising on it injects noise).
 //!
-//! 4. **Optimizer** — AdamW from `candle_nn::AdamW`. Default lr=1e-3,
-//!    weight_decay=1e-4.
+//! 4. **Optimizer** — AdamW from `candle_nn::AdamW`. Defaults:
+//!    `lr=1e-3, weight_decay=0.01, gradient_clip=1.0`. Learning-rate
+//!    schedule: cosine annealing with linear warmup (configurable to
+//!    linear decay or constant).
 //!
-//! 5. **Checkpoint** — `VarMap::save(path)` writes safetensors. A
+//! 5. **Country vocabulary** — built from the `--countries BE,FR,NL,DE,US`
+//!    CLI flag (or equivalent programmatic [`CountryVocab::new`]).
+//!    Each country gets a deterministic id (lex-ordered uppercase ISO
+//!    codes), plumbed through to `ModelConfig.n_countries` and the
+//!    sidecar config JSON. Inference at runtime reads the vocab back
+//!    so the country-head posterior decodes to ISO codes.
+//!
+//! 6. **Checkpoint** — `VarMap::save(path)` writes safetensors. A
 //!    sidecar JSON next to the safetensors holds the [`ModelConfig`]
-//!    so [`load_model`] can reconstruct the architecture.
+//!    plus the [`CountryVocab`] so [`load_model`] can reconstruct the
+//!    architecture and decode country posteriors back to ISO codes.
 
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
@@ -55,12 +91,111 @@ use super::transformer::{
     BIO_I_POSTCODE, BIO_I_STREET, BIO_O, ModelConfig, TaggerModel,
 };
 
+/// Country vocabulary — deterministic uppercase-ISO-2 → id mapping.
+///
+/// The id is the index into [`countries`] (which is sorted lexicographically
+/// for determinism). The `Default` impl returns a single-country `["BE"]`
+/// vocab — preserves the previous BE-only behaviour for callers that don't
+/// need multi-country.
+///
+/// [`countries`]: CountryVocab::countries
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CountryVocab {
+    /// Uppercase ISO 3166-1 alpha-2 codes, lex-sorted.
+    countries: Vec<String>,
+}
+
+impl Default for CountryVocab {
+    fn default() -> Self {
+        Self {
+            countries: vec!["BE".to_string()],
+        }
+    }
+}
+
+impl CountryVocab {
+    /// Build from a slice of ISO codes. Codes are uppercased, trimmed,
+    /// deduplicated, and lex-sorted. Returns `Err` if any code isn't
+    /// 2 ASCII alphabetic chars or if the slice is empty.
+    pub fn new<S: AsRef<str>>(codes: &[S]) -> Result<Self> {
+        if codes.is_empty() {
+            bail!("country vocab must contain at least one country");
+        }
+        let mut out = Vec::with_capacity(codes.len());
+        for c in codes {
+            let s = c.as_ref().trim().to_ascii_uppercase();
+            if s.len() != 2 || !s.bytes().all(|b| b.is_ascii_alphabetic()) {
+                bail!(
+                    "country code {:?} is not a 2-letter ISO 3166-1 alpha-2 code",
+                    c.as_ref()
+                );
+            }
+            if !out.contains(&s) {
+                out.push(s);
+            }
+        }
+        out.sort();
+        Ok(Self { countries: out })
+    }
+
+    /// Parse a comma-separated list (`"BE,FR,NL,DE,US"`).
+    pub fn from_csv(s: &str) -> Result<Self> {
+        let parts: Vec<&str> = s
+            .split(',')
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .collect();
+        Self::new(&parts)
+    }
+
+    /// Look up the id of an ISO code (case-insensitive). Returns
+    /// `None` if the code isn't in the vocab.
+    #[must_use]
+    pub fn id_of(&self, iso2: &str) -> Option<u32> {
+        let s = iso2.trim().to_ascii_uppercase();
+        self.countries
+            .iter()
+            .position(|c| *c == s)
+            .map(|i| i as u32)
+    }
+
+    /// ISO code at id `idx`, or `None` if out of range.
+    #[must_use]
+    pub fn iso_of(&self, idx: usize) -> Option<&str> {
+        self.countries.get(idx).map(String::as_str)
+    }
+
+    /// All countries in the vocab, lex-sorted.
+    #[must_use]
+    pub fn countries(&self) -> &[String] {
+        &self.countries
+    }
+
+    /// Number of countries (== `ModelConfig.n_countries`).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.countries.len()
+    }
+
+    /// Whether the vocab is empty. Always false for a vocab built via
+    /// the constructors (they reject empty input).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.countries.is_empty()
+    }
+}
+
 /// Stored alongside the safetensors file so [`load_model`] can
 /// reconstruct the architecture without hard-coding it. Filename:
 /// `<model_path>.config.json`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CheckpointSidecar {
     config: ModelConfig,
+    /// Country vocabulary used at training time. Defaults to a single-
+    /// country `["BE"]` for backwards compatibility with older sidecars
+    /// that pre-date the multi-country head.
+    #[serde(default)]
+    country_vocab: CountryVocab,
 }
 
 /// Field id literal in the corpus JSONL.
@@ -101,6 +236,13 @@ pub struct CorpusSpan {
     pub end: usize,
 }
 
+/// One training example, in either of the two on-disk formats.
+///
+/// `spans` and `bio_labels` are mutually-exclusive on the JSONL side
+/// but the in-memory struct carries both — we collapse to a normalized
+/// form when read. If `bio_labels` is non-empty, it takes precedence
+/// (it is exact byte-aligned supervision from corpus-gen). If empty,
+/// `spans` is used.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CorpusExample {
     pub text: String,
@@ -108,10 +250,45 @@ pub struct CorpusExample {
     pub country: String,
     #[serde(default)]
     pub spans: Vec<CorpusSpan>,
+    /// Per-byte BIO labels (one byte per byte of `text`). Emitted by
+    /// `geocode-training/corpus-gen`. Trainer scheme is 0=O,
+    /// {1,2}=B/I-Street, {3,4}=B/I-Hnum, {5,6}=B/I-Post, {7,8}=B/I-City.
+    /// corpus-gen also defines {9,10} for B/I-Unit; the trainer folds
+    /// those down to O.
+    #[serde(default)]
+    pub bio_labels: Vec<u8>,
+    /// Augmentation tag — `"canonical"`, `"drop_postcode"`, etc.
+    /// Used by the trainer for ambiguity-aware country-loss masking.
+    #[serde(default = "default_augmentation")]
+    pub augmentation: String,
 }
 
 fn default_country() -> String {
     "BE".to_string()
+}
+
+fn default_augmentation() -> String {
+    "canonical".to_string()
+}
+
+/// Augmentation kinds for which the country head can't be reliably
+/// supervised — the source string is country-ambiguous (a missing
+/// postcode could match BE/FR/NL/LU, etc).
+///
+/// Per the codex review (`geocode-research/CORPUS_DESIGN_NOTES.md`):
+/// "don't force fake certainty on ambiguous positives".
+#[must_use]
+pub fn country_loss_weight_for(augmentation: &str) -> f32 {
+    match augmentation {
+        // Drop-field variants are country-ambiguous — supervising on
+        // the country head injects noise.
+        "drop_postcode" => 0.0,
+        "drop_city" => 0.0,
+        // All other variants are fully informative for the country
+        // head (canonical, abbreviations, casing, whitespace, typos,
+        // reorderings, canary cross-shard rewrites).
+        _ => 1.0,
+    }
 }
 
 /// `(token_ids, attention_mask, loss_mask, bio_labels, country_id)`
@@ -127,6 +304,57 @@ fn default_country() -> String {
 ///   sentinels".
 pub type ExampleTensors = (Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>, u32);
 
+/// Map corpus-gen's BIO label byte (0..=10) onto the trainer's BIO label
+/// (0..=8). Labels 0..=8 are identity. corpus-gen's UNIT B/I (9,10) collapse
+/// to O — the trainer has no UNIT field. Anything else also folds to O so
+/// a malformed corpus can't crash training; it just loses supervision on
+/// that byte.
+fn corpus_gen_to_trainer_bio(b: u8) -> u32 {
+    match b {
+        0..=8 => b as u32,
+        // 9, 10 = B/I-Unit in corpus-gen → O in the trainer.
+        _ => BIO_O as u32,
+    }
+}
+
+/// Build per-byte trainer BIO labels from a corpus example. Prefers
+/// `bio_labels` (corpus-gen format) over `spans` (legacy hand-authored
+/// fixtures). Length of the returned vec equals `text.len()` bytes.
+fn build_byte_labels(ex: &CorpusExample) -> Result<Vec<u32>> {
+    let n_bytes = ex.text.len();
+    if !ex.bio_labels.is_empty() {
+        // corpus-gen guarantees one label per byte; enforce the
+        // invariant rather than silently truncating.
+        if ex.bio_labels.len() != n_bytes {
+            bail!(
+                "bio_labels length {} != text byte length {}",
+                ex.bio_labels.len(),
+                n_bytes
+            );
+        }
+        return Ok(ex
+            .bio_labels
+            .iter()
+            .map(|&b| corpus_gen_to_trainer_bio(b))
+            .collect());
+    }
+    // Legacy spans format.
+    let mut byte_labels = vec![BIO_O as u32; n_bytes];
+    for span in &ex.spans {
+        let Some(field) = field_name_to_id(&span.field) else {
+            continue;
+        };
+        if span.end <= span.start || span.end > n_bytes {
+            continue;
+        }
+        byte_labels[span.start] = b_label(field) as u32;
+        for slot in byte_labels.iter_mut().take(span.end).skip(span.start + 1) {
+            *slot = i_label(field) as u32;
+        }
+    }
+    Ok(byte_labels)
+}
+
 /// Convert a corpus example to
 /// (token_ids, attention_mask, loss_mask, bio_labels, country_id).
 ///
@@ -136,25 +364,11 @@ pub type ExampleTensors = (Vec<u32>, Vec<u32>, Vec<u32>, Vec<u32>, u32);
 pub fn example_to_tensors(
     ex: &CorpusExample,
     pad_to: usize,
-    n_countries: usize,
+    vocab: &CountryVocab,
 ) -> Result<ExampleTensors> {
     let (ids, attention_mask) = ByteTokenizer.encode_padded(&ex.text, pad_to);
 
-    // Build per-byte BIO labels for the original text.
-    let n_bytes = ex.text.len();
-    let mut byte_labels = vec![BIO_O; n_bytes];
-    for span in &ex.spans {
-        let Some(field) = field_name_to_id(&span.field) else {
-            continue;
-        };
-        if span.end <= span.start || span.end > n_bytes {
-            continue;
-        }
-        byte_labels[span.start] = b_label(field);
-        for slot in byte_labels.iter_mut().take(span.end).skip(span.start + 1) {
-            *slot = i_label(field);
-        }
-    }
+    let byte_labels = build_byte_labels(ex)?;
 
     // Map back into token-stream positions: ids = [BOS, b0, b1, ..., EOS, PAD...]
     // BOS gets BIO_O, byte i gets byte_labels[i] (truncated by the tokenizer).
@@ -169,9 +383,7 @@ pub fn example_to_tensors(
     }
     let n_body = body_end.saturating_sub(body_start);
     let n_kept = n_body.min(byte_labels.len());
-    for i in 0..n_kept {
-        bio[body_start + i] = byte_labels[i] as u32;
-    }
+    bio[body_start..body_start + n_kept].copy_from_slice(&byte_labels[..n_kept]);
 
     // Loss mask: 1 only for body byte positions [body_start, body_end).
     // BOS at position 0, EOS at body_end, and any PAD beyond are zero.
@@ -184,13 +396,13 @@ pub fn example_to_tensors(
         *slot = 1;
     }
 
-    let country_id = match ex.country.to_uppercase().as_str() {
-        "BE" => 0,
-        _ => 0, // MVP only ships BE; multi-country is #96
-    };
-    if (country_id as usize) >= n_countries {
-        bail!("country id {country_id} out of range for n_countries={n_countries}");
-    }
+    let country_id = vocab.id_of(&ex.country).ok_or_else(|| {
+        anyhow!(
+            "country {:?} is not in the trained country vocabulary {:?}",
+            ex.country,
+            vocab.countries()
+        )
+    })?;
 
     Ok((ids, attention_mask, loss_mask, bio, country_id))
 }
@@ -214,6 +426,30 @@ pub fn read_jsonl_corpus<P: AsRef<Path>>(path: P) -> Result<Vec<CorpusExample>> 
     Ok(out)
 }
 
+/// Learning-rate schedule kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LrSchedule {
+    /// Linear warmup → cosine annealing to 0.
+    Cosine,
+    /// Linear warmup → linear decay to 0.
+    Linear,
+    /// Linear warmup → constant. Equivalent to a flat LR after warmup.
+    Constant,
+}
+
+impl LrSchedule {
+    /// Parse from a CLI string. Accepts `cosine`, `linear`, `constant`.
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "cosine" => Ok(Self::Cosine),
+            "linear" => Ok(Self::Linear),
+            "constant" => Ok(Self::Constant),
+            _ => bail!("unknown lr schedule {:?} (use cosine|linear|constant)", s),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct TrainConfig {
     pub epochs: usize,
@@ -224,19 +460,55 @@ pub struct TrainConfig {
     pub country_loss_weight: f32,
     pub seed: u64,
     pub eval_split: f32,
+    /// Max global gradient norm. Each step renormalizes the variables'
+    /// gradients to at most this L2-norm. `None` disables clipping.
+    pub gradient_clip: Option<f64>,
+    /// Number of warmup steps (linear ramp from 0 → `learning_rate`).
+    /// `0` disables warmup. Default 1000.
+    pub warmup_steps: usize,
+    /// Learning-rate schedule applied AFTER warmup.
+    pub lr_schedule: LrSchedule,
 }
 
 impl Default for TrainConfig {
     fn default() -> Self {
         Self {
             epochs: 8,
-            batch_size: 16,
-            learning_rate: 2e-3,
-            weight_decay: 1e-4,
+            batch_size: 64,
+            learning_rate: 1e-3,
+            weight_decay: 0.01,
             bio_loss_weight: 1.0,
             country_loss_weight: 0.3,
             seed: 0xB17EBAD0,
             eval_split: 0.1,
+            gradient_clip: Some(1.0),
+            warmup_steps: 1000,
+            lr_schedule: LrSchedule::Cosine,
+        }
+    }
+}
+
+/// Compute the LR for a given global step, given total steps + cfg.
+///
+/// Public so the train_cmd CLI plumbing can log the schedule profile
+/// for observability.
+#[must_use]
+pub fn lr_at_step(cfg: &TrainConfig, step: usize, total_steps: usize) -> f64 {
+    let lr_max = cfg.learning_rate;
+    if cfg.warmup_steps > 0 && step < cfg.warmup_steps {
+        // Linear warmup.
+        let t = (step as f64 + 1.0) / cfg.warmup_steps as f64;
+        return lr_max * t;
+    }
+    let post_warmup = step.saturating_sub(cfg.warmup_steps);
+    let post_warmup_total = total_steps.saturating_sub(cfg.warmup_steps).max(1);
+    let progress = (post_warmup as f64 / post_warmup_total as f64).clamp(0.0, 1.0);
+    match cfg.lr_schedule {
+        LrSchedule::Constant => lr_max,
+        LrSchedule::Linear => lr_max * (1.0 - progress),
+        LrSchedule::Cosine => {
+            // Cosine annealing to 0.
+            lr_max * 0.5 * (1.0 + (std::f64::consts::PI * progress).cos())
         }
     }
 }
@@ -251,9 +523,17 @@ pub struct EpochMetrics {
 }
 
 /// Train the model and write weights + sidecar config to `out`.
+///
+/// The country vocab is plumbed through to:
+/// - `cfg.n_countries` (must equal `vocab.len()`)
+/// - the country head's output dimension (set by [`TaggerModel::new`])
+/// - per-example country id encoding
+/// - the safetensors sidecar (so inference can decode posteriors back
+///   to ISO codes without a parallel config file)
 pub fn train_and_save<P: AsRef<Path>>(
     cfg: ModelConfig,
     train_cfg: TrainConfig,
+    vocab: &CountryVocab,
     corpus: &[CorpusExample],
     out: P,
 ) -> Result<Vec<EpochMetrics>> {
@@ -262,6 +542,13 @@ pub fn train_and_save<P: AsRef<Path>>(
         bail!("training corpus is empty");
     }
     cfg.validate().map_err(|e| anyhow!("invalid config: {e}"))?;
+    if cfg.n_countries != vocab.len() {
+        bail!(
+            "ModelConfig.n_countries ({}) must equal CountryVocab len ({})",
+            cfg.n_countries,
+            vocab.len()
+        );
+    }
 
     let device = Device::Cpu;
     let varmap = VarMap::new();
@@ -282,8 +569,9 @@ pub fn train_and_save<P: AsRef<Path>>(
     }
 
     let pad_to = cfg.max_seq_len;
+    let train_vars = varmap.all_vars();
     let mut opt = AdamW::new(
-        varmap.all_vars(),
+        train_vars.clone(),
         ParamsAdamW {
             lr: train_cfg.learning_rate,
             weight_decay: train_cfg.weight_decay,
@@ -294,6 +582,24 @@ pub fn train_and_save<P: AsRef<Path>>(
 
     let mut metrics = Vec::with_capacity(train_cfg.epochs);
 
+    let n_batches_per_epoch = train_idx.len().div_ceil(train_cfg.batch_size);
+    let total_steps = (n_batches_per_epoch * train_cfg.epochs).max(1);
+    let mut global_step: usize = 0;
+
+    eprintln!(
+        "[train] vocab={} epochs={} batch={} steps_per_epoch={} total_steps={} lr_max={} schedule={:?} warmup={} weight_decay={} grad_clip={:?}",
+        vocab.countries().join(","),
+        train_cfg.epochs,
+        train_cfg.batch_size,
+        n_batches_per_epoch,
+        total_steps,
+        train_cfg.learning_rate,
+        train_cfg.lr_schedule,
+        train_cfg.warmup_steps,
+        train_cfg.weight_decay,
+        train_cfg.gradient_clip,
+    );
+
     for epoch in 0..train_cfg.epochs {
         // Shuffle training indices each epoch.
         let mut order = train_idx.clone();
@@ -302,27 +608,36 @@ pub fn train_and_save<P: AsRef<Path>>(
         let mut train_loss_sum = 0.0_f32;
         let mut train_n = 0usize;
         for chunk in order.chunks(train_cfg.batch_size) {
+            // Update the LR before stepping.
+            let lr = lr_at_step(&train_cfg, global_step, total_steps);
+            opt.set_learning_rate(lr);
+
             let batch: Vec<&CorpusExample> = chunk.iter().map(|&i| &corpus[i]).collect();
-            let (ids_t, attn_t, loss_t, bio_t, country_t) =
-                build_batch(&batch, pad_to, cfg.n_countries, &device)?;
+            let (ids_t, attn_t, loss_t, bio_t, country_t, country_loss_w_t) =
+                build_batch(&batch, pad_to, vocab, &device)?;
             let (bio_logits, country_logits) = model
                 .forward(&ids_t, &attn_t)
                 .map_err(|e| anyhow!("forward: {e}"))?;
             // Loss mask excludes BOS/EOS; supervision is body-only.
             let l_bio = bio_loss_masked(&bio_logits, &bio_t, &loss_t)?;
-            let l_country = loss::cross_entropy(&country_logits, &country_t)
-                .map_err(|e| anyhow!("country ce: {e}"))?;
+            let l_country = country_loss_masked(&country_logits, &country_t, &country_loss_w_t)?;
             let l_bio_w = (l_bio * train_cfg.bio_loss_weight as f64)
                 .map_err(|e| anyhow!("scale bio: {e}"))?;
             let l_country_w = (l_country * train_cfg.country_loss_weight as f64)
                 .map_err(|e| anyhow!("scale country: {e}"))?;
             let total = (l_bio_w + l_country_w).map_err(|e| anyhow!("sum: {e}"))?;
-            opt.backward_step(&total)
-                .map_err(|e| anyhow!("backward: {e}"))?;
+            // Backward → optionally clip → step.
+            let mut grads = total.backward().map_err(|e| anyhow!("backward: {e}"))?;
+            if let Some(max_norm) = train_cfg.gradient_clip {
+                clip_grads_in_place(&train_vars, &mut grads, max_norm)?;
+            }
+            opt.step(&grads).map_err(|e| anyhow!("opt step: {e}"))?;
+
             train_loss_sum += total
                 .to_scalar::<f32>()
                 .map_err(|e| anyhow!("scalar: {e}"))?;
             train_n += 1;
+            global_step += 1;
         }
 
         let train_loss = if train_n > 0 {
@@ -337,7 +652,7 @@ pub fn train_and_save<P: AsRef<Path>>(
             corpus,
             &eval_idx,
             pad_to,
-            cfg.n_countries,
+            vocab,
             train_cfg.bio_loss_weight,
             train_cfg.country_loss_weight,
             &device,
@@ -365,12 +680,55 @@ pub fn train_and_save<P: AsRef<Path>>(
 
     // Sidecar config so loaders don't need to hardcode the architecture.
     let sidecar_path = sidecar_path_for(out);
-    let sidecar = CheckpointSidecar { config: cfg };
+    let sidecar = CheckpointSidecar {
+        config: cfg,
+        country_vocab: vocab.clone(),
+    };
     let mut f = File::create(&sidecar_path)
         .with_context(|| format!("creating sidecar {}", sidecar_path.display()))?;
     f.write_all(serde_json::to_string_pretty(&sidecar)?.as_bytes())?;
 
     Ok(metrics)
+}
+
+/// Renormalize all per-variable gradients to a global L2-norm of at
+/// most `max_norm`. Reads the gradient from `grads`, scales, and
+/// re-inserts. No-op if the global norm is already below the threshold.
+fn clip_grads_in_place(
+    vars: &[candle_core::Var],
+    grads: &mut candle_core::backprop::GradStore,
+    max_norm: f64,
+) -> Result<()> {
+    // Compute global L2 norm.
+    let mut sq_sum = 0.0f64;
+    for v in vars {
+        if let Some(g) = grads.get(v.as_tensor()) {
+            let n = g
+                .sqr()
+                .map_err(|e| anyhow!("grad sqr: {e}"))?
+                .sum_all()
+                .map_err(|e| anyhow!("grad sum: {e}"))?
+                .to_scalar::<f32>()
+                .map_err(|e| anyhow!("grad scalar: {e}"))?;
+            sq_sum += n as f64;
+        }
+    }
+    let global_norm = sq_sum.sqrt();
+    if !global_norm.is_finite() {
+        bail!("non-finite gradient norm ({global_norm}) — training divergence");
+    }
+    if global_norm <= max_norm || global_norm == 0.0 {
+        return Ok(());
+    }
+    let scale = max_norm / global_norm;
+    for v in vars {
+        let t = v.as_tensor();
+        if let Some(g) = grads.get(t) {
+            let scaled = (g * scale).map_err(|e| anyhow!("grad scale: {e}"))?;
+            grads.insert(t, scaled);
+        }
+    }
+    Ok(())
 }
 
 fn sidecar_path_for(model_path: &Path) -> std::path::PathBuf {
@@ -383,8 +741,16 @@ fn sidecar_path_for(model_path: &Path) -> std::path::PathBuf {
     p
 }
 
-/// Load a previously saved model. Returns the model and its config.
-pub fn load_model<P: AsRef<Path>>(path: P) -> Result<(TaggerModel, ModelConfig, Device)> {
+/// Load a previously saved model. Returns the model, its config, the
+/// country vocabulary it was trained on, and the device.
+///
+/// Older sidecars (pre-multi-country) lack the `country_vocab` field;
+/// the deserializer falls back to the [`CountryVocab::default`]
+/// (`["BE"]`), preserving backwards compatibility with the shipped
+/// `belgium-tiny.safetensors`.
+pub fn load_model<P: AsRef<Path>>(
+    path: P,
+) -> Result<(TaggerModel, ModelConfig, CountryVocab, Device)> {
     let path = path.as_ref();
     let sidecar_path = sidecar_path_for(path);
     let sidecar_str = std::fs::read_to_string(&sidecar_path)
@@ -392,6 +758,7 @@ pub fn load_model<P: AsRef<Path>>(path: P) -> Result<(TaggerModel, ModelConfig, 
     let sidecar: CheckpointSidecar =
         serde_json::from_str(&sidecar_str).context("parsing sidecar config")?;
     let cfg = sidecar.config;
+    let vocab = sidecar.country_vocab;
 
     let device = Device::Cpu;
     let mut varmap = VarMap::new();
@@ -402,34 +769,38 @@ pub fn load_model<P: AsRef<Path>>(path: P) -> Result<(TaggerModel, ModelConfig, 
     varmap
         .load(path)
         .map_err(|e| anyhow!("load weights: {e}"))?;
-    Ok((model, cfg, device))
+    Ok((model, cfg, vocab, device))
 }
 
 /// Build a batch tensor from references into the corpus.
 ///
-/// Returns `(ids, attention_mask, loss_mask, bio, country)`.
+/// Returns `(ids, attention_mask, loss_mask, bio, country, country_loss_w)`.
 /// `attention_mask` is fed to the transformer; `loss_mask` excludes
-/// BOS/EOS as well as PAD from supervision.
+/// BOS/EOS as well as PAD from BIO supervision; `country_loss_w` is a
+/// per-example weight in `[0.0, 1.0]` that masks out country-head
+/// supervision for ambiguous augmentations (drop-field variants).
+#[allow(clippy::type_complexity)]
 fn build_batch(
     batch: &[&CorpusExample],
     pad_to: usize,
-    n_countries: usize,
+    vocab: &CountryVocab,
     device: &Device,
-) -> Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
+) -> Result<(Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)> {
     let b = batch.len();
     let mut ids_buf = Vec::with_capacity(b * pad_to);
     let mut attn_buf = Vec::with_capacity(b * pad_to);
     let mut loss_buf = Vec::with_capacity(b * pad_to);
     let mut bio_buf = Vec::with_capacity(b * pad_to);
     let mut country_buf = Vec::with_capacity(b);
+    let mut country_w_buf = Vec::with_capacity(b);
     for ex in batch {
-        let (ids, attn_mask, loss_mask, bio, country) =
-            example_to_tensors(ex, pad_to, n_countries)?;
+        let (ids, attn_mask, loss_mask, bio, country) = example_to_tensors(ex, pad_to, vocab)?;
         ids_buf.extend_from_slice(&ids);
         attn_buf.extend_from_slice(&attn_mask);
         loss_buf.extend_from_slice(&loss_mask);
         bio_buf.extend_from_slice(&bio);
         country_buf.push(country);
+        country_w_buf.push(country_loss_weight_for(&ex.augmentation));
     }
     let ids_t =
         Tensor::from_vec(ids_buf, (b, pad_to), device).map_err(|e| anyhow!("ids tensor: {e}"))?;
@@ -441,7 +812,35 @@ fn build_batch(
         Tensor::from_vec(bio_buf, (b, pad_to), device).map_err(|e| anyhow!("bio tensor: {e}"))?;
     let country_t =
         Tensor::from_vec(country_buf, (b,), device).map_err(|e| anyhow!("country tensor: {e}"))?;
-    Ok((ids_t, attn_t, loss_t, bio_t, country_t))
+    let country_w_t = Tensor::from_vec(country_w_buf, (b,), device)
+        .map_err(|e| anyhow!("country loss weight tensor: {e}"))?;
+    Ok((ids_t, attn_t, loss_t, bio_t, country_t, country_w_t))
+}
+
+/// Cross-entropy loss over the country head with per-example masking.
+///
+/// `logits: (B, n_countries)`, `targets: (B,)`, `mask: (B,)` f32.
+/// Computes mean CE over examples weighted by the mask. If the mask
+/// is all zero (very rare — would mean the entire batch is drop-field
+/// variants), the loss is zero with no gradient, which is correct.
+fn country_loss_masked(logits: &Tensor, targets: &Tensor, mask: &Tensor) -> Result<Tensor> {
+    let logp = candle_nn::ops::log_softmax(logits, candle_core::D::Minus1)
+        .map_err(|e| anyhow!("country log_softmax: {e}"))?;
+    let nll = logp
+        .gather(&targets.unsqueeze(1).map_err(|e| anyhow!("unsq: {e}"))?, 1)
+        .map_err(|e| anyhow!("gather: {e}"))?
+        .squeeze(1)
+        .map_err(|e| anyhow!("squeeze: {e}"))?
+        .neg()
+        .map_err(|e| anyhow!("neg: {e}"))?;
+    let weighted = nll.mul(mask).map_err(|e| anyhow!("mul: {e}"))?;
+    let total = weighted.sum_all().map_err(|e| anyhow!("sum: {e}"))?;
+    let denom = mask
+        .sum_all()
+        .map_err(|e| anyhow!("sum mask: {e}"))?
+        .clamp(1.0, f64::INFINITY)
+        .map_err(|e| anyhow!("clamp: {e}"))?;
+    total.div(&denom).map_err(|e| anyhow!("div: {e}"))
 }
 
 /// Cross-entropy loss over BIO with masking on padded tokens.
@@ -497,7 +896,7 @@ fn evaluate(
     corpus: &[CorpusExample],
     eval_idx: &[usize],
     pad_to: usize,
-    n_countries: usize,
+    vocab: &CountryVocab,
     bio_w: f32,
     country_w: f32,
     device: &Device,
@@ -512,15 +911,22 @@ fn evaluate(
     let mut country_correct = 0u64;
     let mut country_total = 0u64;
 
-    for &i in eval_idx {
-        let ex = &corpus[i];
-        let batch = vec![ex];
-        let (ids_t, attn_t, loss_t, bio_t, country_t) =
-            build_batch(&batch, pad_to, n_countries, device)?;
+    // Batched eval — process EVAL_BATCH examples per forward to amortize
+    // tensor construction + forward overhead. With 149k eval examples
+    // (10% of a 1.5M-record corpus) the per-example loop took longer
+    // than training itself; batching brings eval back in line with
+    // training throughput.
+    const EVAL_BATCH: usize = 128;
+    for chunk in eval_idx.chunks(EVAL_BATCH) {
+        let batch: Vec<&CorpusExample> = chunk.iter().map(|&i| &corpus[i]).collect();
+        let (ids_t, attn_t, loss_t, bio_t, country_t, _country_w_t) =
+            build_batch(&batch, pad_to, vocab, device)?;
         let (bio_logits, country_logits) = model
             .forward(&ids_t, &attn_t)
             .map_err(|e| anyhow!("eval forward: {e}"))?;
         let l_bio = bio_loss_masked(&bio_logits, &bio_t, &loss_t)?;
+        // Eval uses unmasked country CE so the metric is comparable
+        // across runs (eval set isn't filtered for ambiguity).
         let l_country = loss::cross_entropy(&country_logits, &country_t)
             .map_err(|e| anyhow!("eval country ce: {e}"))?;
         let total = (l_bio * bio_w as f64).map_err(|e| anyhow!("scale: {e}"))?
@@ -781,6 +1187,8 @@ pub fn generate_belgium_synthetic(n: usize, seed: u64) -> Vec<CorpusExample> {
             text,
             country: "BE".to_string(),
             spans,
+            bio_labels: Vec::new(),
+            augmentation: "canonical".to_string(),
         });
     }
     out
@@ -821,8 +1229,11 @@ mod tests {
                     end: 8,
                 },
             ],
+            bio_labels: Vec::new(),
+            augmentation: "canonical".to_string(),
         };
-        let (ids, _attn, loss_mask, bio, _) = example_to_tensors(&ex, 16, 1).unwrap();
+        let vocab = CountryVocab::new(&["BE"]).unwrap();
+        let (ids, _attn, loss_mask, bio, _) = example_to_tensors(&ex, 16, &vocab).unwrap();
         // BOS is index 0 → BIO_O.
         assert_eq!(bio[0] as usize, BIO_O);
         assert_eq!(bio[1] as usize, BIO_B_STREET); // 'R'
@@ -850,15 +1261,23 @@ mod tests {
     #[test]
     fn training_loop_decreases_loss_on_synthetic() {
         let corpus = generate_belgium_synthetic(64, 0xBEEF);
+        // Use a higher learning rate + no warmup for the smoke test —
+        // the default warmup_steps=1000 dwarfs the 24 batches in this
+        // tiny harness, leaving the model essentially untrained.
         let tcfg = TrainConfig {
             epochs: 3,
             batch_size: 8,
+            learning_rate: 2e-3,
+            warmup_steps: 0,
+            lr_schedule: LrSchedule::Constant,
+            gradient_clip: None,
             ..Default::default()
         };
         let dir = tempdir().unwrap();
         let out = dir.path().join("tiny.safetensors");
         let cfg = ModelConfig::tiny();
-        let metrics = train_and_save(cfg, tcfg, &corpus, &out).unwrap();
+        let vocab = CountryVocab::new(&["BE"]).unwrap();
+        let metrics = train_and_save(cfg, tcfg, &vocab, &corpus, &out).unwrap();
         assert_eq!(metrics.len(), 3);
         // Training loss must trend downward — last epoch < first epoch.
         assert!(
@@ -867,9 +1286,206 @@ mod tests {
             metrics
         );
         // Reload and run inference.
-        let (model, _cfg, device) = load_model(&out).unwrap();
+        let (model, _cfg, _vocab, device) = load_model(&out).unwrap();
         let infer_out =
             super::super::infer(&model, "Rue Wayez 122 1070 Anderlecht", &device).unwrap();
         assert!(!infer_out.bio_label_top1.is_empty());
+    }
+
+    #[test]
+    fn country_vocab_round_trips_iso_codes() {
+        let v = CountryVocab::new(&["be", "FR", "nl ", " DE", "us"]).unwrap();
+        // Lex-sorted, uppercased, deduped.
+        assert_eq!(v.countries(), &["BE", "DE", "FR", "NL", "US"]);
+        assert_eq!(v.id_of("be"), Some(0));
+        assert_eq!(v.id_of("FR"), Some(2));
+        assert_eq!(v.id_of("XX"), None);
+        assert_eq!(v.iso_of(2), Some("FR"));
+        assert_eq!(v.iso_of(99), None);
+        assert_eq!(v.len(), 5);
+    }
+
+    #[test]
+    fn country_vocab_rejects_invalid_codes() {
+        assert!(CountryVocab::new::<&str>(&[]).is_err());
+        assert!(CountryVocab::new(&["BEL"]).is_err());
+        assert!(CountryVocab::new(&["B1"]).is_err());
+        assert!(CountryVocab::from_csv("").is_err());
+        assert!(CountryVocab::from_csv("BE,").is_ok()); // trailing comma trimmed
+    }
+
+    #[test]
+    fn country_vocab_csv_parsing() {
+        let v = CountryVocab::from_csv("BE,FR,NL,DE,US").unwrap();
+        assert_eq!(v.countries(), &["BE", "DE", "FR", "NL", "US"]);
+    }
+
+    #[test]
+    fn corpus_gen_bio_format_is_decoded() {
+        // "Rue X 12" — corpus-gen scheme:
+        //   B-Street(1) I-Street(2) I-Street(2) O(0) B-Street(1) [oops, no — single-letter "X" is street]
+        // Use realistic example: text "Rue 1" with bio_labels matching corpus-gen.
+        // Corpus-gen scheme: 0=O, 1=B-Street, 2=I-Street, 3=B-Hnum, 4=I-Hnum
+        let ex = CorpusExample {
+            text: "Rue 1".to_string(),
+            country: "BE".to_string(),
+            spans: Vec::new(),
+            bio_labels: vec![
+                1, // B-Street 'R'
+                2, // I-Street 'u'
+                2, // I-Street 'e'
+                0, // O ' '
+                3, // B-Hnum '1'
+            ],
+            augmentation: "canonical".to_string(),
+        };
+        let vocab = CountryVocab::new(&["BE"]).unwrap();
+        let (ids, _attn, _loss, bio, country) = example_to_tensors(&ex, 16, &vocab).unwrap();
+        // Trainer scheme aligned 1:1 with corpus-gen 0..=8.
+        assert_eq!(bio[0] as usize, BIO_O); // BOS
+        assert_eq!(bio[1] as usize, BIO_B_STREET);
+        assert_eq!(bio[2] as usize, BIO_I_STREET);
+        assert_eq!(bio[3] as usize, BIO_I_STREET);
+        assert_eq!(bio[4] as usize, BIO_O);
+        assert_eq!(bio[5] as usize, BIO_B_HOUSE);
+        // EOS at position 6.
+        assert_eq!(ids[6], crate::tagger::tokenizer::EOS);
+        assert_eq!(country, 0);
+    }
+
+    #[test]
+    fn corpus_gen_unit_labels_fold_to_o() {
+        // corpus-gen UNIT (9, 10) collapses to O in the trainer.
+        let ex = CorpusExample {
+            text: "ab".to_string(),
+            country: "BE".to_string(),
+            spans: Vec::new(),
+            bio_labels: vec![9, 10],
+            augmentation: "canonical".to_string(),
+        };
+        let vocab = CountryVocab::new(&["BE"]).unwrap();
+        let (_ids, _attn, _loss, bio, _) = example_to_tensors(&ex, 16, &vocab).unwrap();
+        assert_eq!(bio[1] as usize, BIO_O); // 'a' (was UNIT B → O)
+        assert_eq!(bio[2] as usize, BIO_O); // 'b' (was UNIT I → O)
+    }
+
+    #[test]
+    fn bio_labels_length_mismatch_is_rejected() {
+        let ex = CorpusExample {
+            text: "Rue 1".to_string(),
+            country: "BE".to_string(),
+            spans: Vec::new(),
+            bio_labels: vec![1, 2, 0], // length 3, text is 5 bytes
+            augmentation: "canonical".to_string(),
+        };
+        let vocab = CountryVocab::new(&["BE"]).unwrap();
+        assert!(example_to_tensors(&ex, 16, &vocab).is_err());
+    }
+
+    #[test]
+    fn unknown_country_in_corpus_is_rejected() {
+        let ex = CorpusExample {
+            text: "abc".to_string(),
+            country: "XX".to_string(),
+            spans: Vec::new(),
+            bio_labels: vec![0, 0, 0],
+            augmentation: "canonical".to_string(),
+        };
+        let vocab = CountryVocab::new(&["BE", "FR"]).unwrap();
+        assert!(example_to_tensors(&ex, 16, &vocab).is_err());
+    }
+
+    #[test]
+    fn jsonl_corpus_reads_both_formats() {
+        use std::io::Write;
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("mixed.jsonl");
+        let mut f = File::create(&path).unwrap();
+        // bio_labels variant.
+        writeln!(
+            f,
+            r#"{{"text":"Rue 1","country":"BE","bio_labels":[1,2,2,0,3]}}"#
+        )
+        .unwrap();
+        // spans variant (legacy).
+        writeln!(
+            f,
+            r#"{{"text":"Rue 1","country":"BE","spans":[{{"field":"street","start":0,"end":3}},{{"field":"house","start":4,"end":5}}]}}"#
+        )
+        .unwrap();
+        drop(f);
+        let corpus = read_jsonl_corpus(&path).unwrap();
+        assert_eq!(corpus.len(), 2);
+        assert_eq!(corpus[0].bio_labels.len(), 5);
+        assert!(corpus[0].spans.is_empty());
+        assert!(corpus[1].bio_labels.is_empty());
+        assert_eq!(corpus[1].spans.len(), 2);
+    }
+
+    #[test]
+    fn drop_postcode_zeros_country_loss_weight() {
+        assert_eq!(country_loss_weight_for("canonical"), 1.0);
+        assert_eq!(country_loss_weight_for("drop_postcode"), 0.0);
+        assert_eq!(country_loss_weight_for("drop_city"), 0.0);
+        assert_eq!(country_loss_weight_for("typo_injection"), 1.0);
+        assert_eq!(country_loss_weight_for("case_upper"), 1.0);
+    }
+
+    #[test]
+    fn lr_schedule_warmup_then_anneal() {
+        let cfg = TrainConfig {
+            learning_rate: 1.0,
+            warmup_steps: 100,
+            lr_schedule: LrSchedule::Cosine,
+            ..Default::default()
+        };
+        // During warmup: linear ramp.
+        let lr0 = lr_at_step(&cfg, 0, 1000);
+        assert!(lr0 > 0.0 && lr0 < 0.05);
+        let lr50 = lr_at_step(&cfg, 49, 1000);
+        assert!((lr50 - 0.5).abs() < 0.02, "lr50 = {lr50}");
+        // After warmup: cosine descends.
+        let lr_post = lr_at_step(&cfg, 100, 1000);
+        assert!(
+            (lr_post - 1.0).abs() < 1e-6,
+            "should peak right at end of warmup, got {lr_post}"
+        );
+        let lr_end = lr_at_step(&cfg, 1000, 1000);
+        assert!(lr_end < 1e-6, "should anneal to ~0, got {lr_end}");
+        // Constant schedule stays flat.
+        let cfg2 = TrainConfig {
+            lr_schedule: LrSchedule::Constant,
+            ..cfg
+        };
+        assert!((lr_at_step(&cfg2, 500, 1000) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn lr_schedule_parses() {
+        assert_eq!(LrSchedule::parse("cosine").unwrap(), LrSchedule::Cosine);
+        assert_eq!(LrSchedule::parse("LINEAR").unwrap(), LrSchedule::Linear);
+        assert_eq!(LrSchedule::parse("constant").unwrap(), LrSchedule::Constant);
+        assert!(LrSchedule::parse("bogus").is_err());
+    }
+
+    #[test]
+    fn sidecar_round_trips_country_vocab() {
+        let corpus = generate_belgium_synthetic(32, 0xCAFE);
+        let tcfg = TrainConfig {
+            epochs: 1,
+            batch_size: 8,
+            warmup_steps: 0,
+            lr_schedule: LrSchedule::Constant,
+            ..Default::default()
+        };
+        let dir = tempdir().unwrap();
+        let out = dir.path().join("rt.safetensors");
+        let vocab = CountryVocab::new(&["BE"]).unwrap();
+        let cfg = ModelConfig::tiny();
+        train_and_save(cfg, tcfg, &vocab, &corpus, &out).unwrap();
+        // Sidecar contains the vocab.
+        let (_model, cfg2, vocab2, _device) = load_model(&out).unwrap();
+        assert_eq!(cfg2.n_countries, 1);
+        assert_eq!(vocab2.countries(), vocab.countries());
     }
 }

--- a/geocode/src/tagger/transformer.rs
+++ b/geocode/src/tagger/transformer.rs
@@ -130,6 +130,66 @@ impl ModelConfig {
         }
     }
 
+    /// Production profile for the Fork A+ neural parser engineering.
+    ///
+    /// d_model=128, n_heads=8 (each 16-dim), n_layers=4, d_ff=512.
+    /// vocab=260 (256 byte values + 4 specials), max_seq_len=128.
+    ///
+    /// Rough parameter count (excluding biases ≪ embeds):
+    /// - embed: 260 × 128 = 33 280
+    /// - 4 encoder blocks, each:
+    ///   - QKV: 128 × (3·128) = 49 152
+    ///   - attn out: 128 × 128 = 16 384
+    ///   - FFN fc1: 128 × 512 = 65 536
+    ///   - FFN fc2: 512 × 128 = 65 536
+    ///   - LN×2: 2 × 2 × 128 = 512
+    ///   - sums to 197 120 per block × 4 layers = 788 480
+    /// - final LN: 256
+    /// - bio_head: 128 × 9 = 1 152
+    /// - country_head: 128 × n_countries (varies)
+    ///
+    /// At n_countries=1 ≈ 823 168 fp32 weights ≈ 3.3 MB safetensors.
+    /// At n_countries=8 ≈ 824 064 fp32 weights ≈ 3.3 MB. Headroom for
+    /// the 8 MB target in the spec.
+    ///
+    /// Note: the 2.5M-param figure quoted in the Fork A+ task brief
+    /// assumed a larger embedding/vocab; with a 260-token byte vocab
+    /// the natural footprint at d_model=128/n_layers=4 is ~0.8 M
+    /// params. This is the right size for byte-level NER and matches
+    /// the "production but still tiny" target.
+    #[must_use]
+    pub fn production(n_countries: usize) -> Self {
+        Self {
+            d_model: 128,
+            n_heads: 8,
+            n_layers: 4,
+            d_ff: 512,
+            max_seq_len: MAX_SEQ_LEN,
+            vocab_size: VOCAB_SIZE,
+            num_bio_labels: NUM_BIO_LABELS,
+            n_countries: n_countries.max(1),
+            layer_norm_eps: 1e-5,
+        }
+    }
+
+    /// Approximate parameter count (weights only — biases and LN
+    /// scales/biases are tiny rounding terms). Used by tests + logging
+    /// to confirm the architecture lands at the expected size.
+    #[must_use]
+    pub fn approx_param_count(&self) -> usize {
+        let embed = self.vocab_size * self.d_model;
+        let qkv = self.d_model * 3 * self.d_model;
+        let attn_out = self.d_model * self.d_model;
+        let fc1 = self.d_model * self.d_ff;
+        let fc2 = self.d_ff * self.d_model;
+        let ln = 2 * self.d_model; // gamma + beta
+        let block = qkv + attn_out + fc1 + fc2 + 2 * ln;
+        let final_ln = ln;
+        let bio_head = self.d_model * self.num_bio_labels;
+        let country_head = self.d_model * self.n_countries;
+        embed + self.n_layers * block + final_ln + bio_head + country_head
+    }
+
     pub fn validate(&self) -> CResult<()> {
         if self.n_heads == 0 {
             return Err(candle_core::Error::Msg("n_heads must be > 0".to_string()));
@@ -457,6 +517,64 @@ mod tests {
         // No NaN.
         let v = bio.flatten_all().unwrap().to_vec1::<f32>().unwrap();
         assert!(v.iter().all(|x| x.is_finite()), "NaN/inf in bio logits");
+    }
+
+    #[test]
+    fn production_config_validates_and_has_expected_shape() {
+        let cfg = ModelConfig::production(5);
+        assert!(cfg.validate().is_ok());
+        assert_eq!(cfg.d_model, 128);
+        assert_eq!(cfg.n_heads, 8);
+        assert_eq!(cfg.n_layers, 4);
+        assert_eq!(cfg.d_ff, 512);
+        assert_eq!(cfg.n_countries, 5);
+        assert_eq!(cfg.head_dim(), 16);
+    }
+
+    #[test]
+    fn production_config_param_count_in_expected_range() {
+        let cfg = ModelConfig::production(5);
+        let pc = cfg.approx_param_count();
+        // ~825k params for d_model=128 / n_layers=4 / vocab=260.
+        // The Fork A+ brief targeted "~2.5M params" but with byte-vocab
+        // the natural footprint at this depth is ~0.8 M. We assert the
+        // shape lands in the right order of magnitude (between 500k
+        // and 1.5M) — the brief number was wrong, the architecture is
+        // right.
+        assert!(
+            (500_000..=1_500_000).contains(&pc),
+            "production param count {pc} out of expected range",
+        );
+    }
+
+    #[test]
+    fn production_config_forward_shape() {
+        let (varmap, device) = cpu_vb_and_map();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+        let cfg = ModelConfig::production(5);
+        let model = TaggerModel::new(cfg, vb).unwrap();
+        let b = 2usize;
+        let t = 32usize;
+        let ids = Tensor::zeros((b, t), DType::U32, &device).unwrap();
+        let mask = Tensor::ones((b, t), DType::U32, &device).unwrap();
+        let (bio, country) = model.forward(&ids, &mask).unwrap();
+        assert_eq!(bio.dims(), &[b, t, NUM_BIO_LABELS]);
+        assert_eq!(country.dims(), &[b, 5]);
+    }
+
+    #[test]
+    fn production_config_country_head_scales_with_n_countries() {
+        for n in [1, 3, 5, 8] {
+            let cfg = ModelConfig::production(n);
+            assert_eq!(cfg.n_countries, n);
+            let (varmap, device) = cpu_vb_and_map();
+            let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+            let model = TaggerModel::new(cfg, vb).unwrap();
+            let ids = Tensor::zeros((1, 8), DType::U32, &device).unwrap();
+            let mask = Tensor::ones((1, 8), DType::U32, &device).unwrap();
+            let (_bio, country) = model.forward(&ids, &mask).unwrap();
+            assert_eq!(country.dims(), &[1, n]);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Items 1–6 + 9 of the Fork A+ deliverable list for [#192](https://github.com/butterfly-osm/butterfly-osm/issues/192) — production-ready engineering for the byte-level transformer tagger. **Items 7 (Belgium training to convergence) and 8 (bench vs Nominatim) are deferred** to a follow-up — task #80 stays in_progress.

## What's in this PR

- **Corpus-format bridge** — `read_jsonl_corpus` auto-detects `spans` (legacy) and `bio_labels` (corpus-gen) per-record. UNIT labels (9, 10) fold to O. Length mismatch is rejected — no silent truncation.
- **Multi-country country head** — `CountryVocab` (lex-sorted, dedup, case-insensitive) plumbed through `ModelConfig.n_countries`, the country head's output dimension, the safetensors sidecar, and the inference path. Replaces the hardcoded BE→0 mapping.
- **Multi-country corpus-gen** — Morphology TOML packs (BE, FR, NL, DE, US, GB) under `geocode-training/corpus-gen/morphology/`. `canary.rs` takes (source_pack, target_pack) and zips marker substrings to rewrite streets cross-country. `augment.rs` reads abbreviation rules from the source pack — no more hardcoded match arms.
- **Codex review #164 fixes** — N=8 default augmentations (was 10); ambiguity-aware country-loss masking (drop_postcode/drop_city → country-loss weight 0); provenance-based labeling (`render_canonical` records byte-range `Span`s, projects to BIO via `bio_from_spans`).
- **Production architecture** — `ModelConfig::production(n_countries)` at `d_model=128, n_heads=8, n_layers=4, d_ff=512, vocab=260, max_seq=128`. ~825k fp32 params (~3.3 MB safetensors at n=8). The 2.5M target in the brief assumed a larger embedding/vocab; ~825k is the natural footprint at byte-level + d_model=128.
- **Training-loop hyperparameters** — `--batch-size`, `--learning-rate`, `--lr-schedule {cosine,linear,constant}`, `--weight-decay`, `--gradient-clip`, `--warmup-steps`. Cosine annealing wrapper + linear warmup ramp. Global gradient L2-norm clipping. Non-finite gradient norm aborts training.
- **Multi-country runbook** — `geocode-research/MULTI_COUNTRY_TRAINING.md` documents the operator workflow: PBF fetch → per-country corpora → shuffle/concat → train → bench per-shard.

## Tests

- `geocode/`: 32 tagger tests (was 19) — forward shape, parameter count, sidecar round-trip, country-head scaling, ambiguity masking, BIO format auto-detection
- `geocode-training/corpus-gen/`: 7 tests (was 0) — morphology pack loading, registry, canary cross-country rewrite
- Workspace clippy + fmt clean

## What's deferred (items 7, 8)

The training execution itself and the Nominatim re-bench were not run in this PR. The brief's truncated final message ("Let me wait for more epochs") indicates training was running when the agent was rate-limited. Both will land in a follow-up PR running off this merged foundation. Task #80 (Train production neural parser on all-countries corpus) stays in_progress.

## Test plan

- [x] cargo check -p butterfly-geocode clean
- [x] cargo test -p butterfly-geocode --lib tagger:: — 32/32 pass
- [x] cd geocode-training/corpus-gen && cargo test — 7/7 pass
- [ ] Training to convergence on Belgium + multi-country corpus (deferred, follow-up)
- [ ] Bench vs Nominatim on the trained model (deferred, follow-up)