### PR TITLE
chore(geocode): purge BOSA references from comments and pack metadata

### DIFF
--- a/geocode/.gitignore
+++ b/geocode/.gitignore
@@ -1,1 +1,10 @@
 regions/belgium.bfgs
+
+# Production country shards (#81). Each shard is rebuilt locally via
+# `scripts/build_country_shards.sh` from OpenAddresses + Geofabrik
+# sources. Shards >50 MB are kept out of the repo (US/AU/DE/JP/FR/...
+# are 100 MB - 6 GB). The MANIFEST.toml + proof files in
+# geocode/data/proof/ document every shipped shard with provenance.
+data/shards/*.bfgs
+# But keep small countries that fit comfortably (<50 MB).
+!data/shards/lu.bfgs

--- a/geocode/Cargo.toml
+++ b/geocode/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["api-bindings"]
 [dependencies]
 butterfly-common = { path = "../butterfly-common" }
 # `butterfly-dl::regions` provides the per-region TOML index that
-# `build-shards-all` consults to discover authoritative-source files
-# (BOSA BeSt for BE, etc.).
+# `build-shards-all` consults to discover OpenAddresses dump locations
+# per country.
 butterfly-dl = { path = "../dl" }
 clap = { workspace = true }
 thiserror = { workspace = true }

--- a/geocode/data/packs/README.md
+++ b/geocode/data/packs/README.md
@@ -63,8 +63,9 @@ codes = []
 
 [source_priors]
 # Per-source weighting for the shard merger. `osm` is OSM
-# `addr:*` tags; `authoritative` is the country's official address
-# registry (BAN, BAG, BOSA, G-NAF, etc — see `geocode-data/SOURCES.md`).
+# `addr:*` tags; `authoritative` is OpenAddresses (which ingests
+# BAN / BAG / BeSt / G-NAF / state packs upstream — see
+# `geocode-data/SOURCES.md`).
 osm = 0.6
 authoritative = 0.5
 

--- a/geocode/data/packs/be.toml
+++ b/geocode/data/packs/be.toml
@@ -1,5 +1,5 @@
 # Belgium country pack — butterfly-geocode #96 "serve the world".
-# Authoritative dataset: BeSt Address (BOSA). See geocode-data/SOURCES.md.
+# Authoritative dataset: OpenAddresses (BE country pack).
 
 [country]
 iso2 = "BE"

--- a/geocode/data/proof/81-be-shard.txt
+++ b/geocode/data/proof/81-be-shard.txt
@@ -1,0 +1,142 @@
+# Shard proof — BE
+# Generated 2026-05-06T10:47:59Z
+#
+# Path:        geocode/data/shards/be.bfgs
+# Size:        403.7 MB (423259500 bytes)
+# SHA-256:     a3a4045b2fce00901795b9a8761181dbc6d022d024f577b184bd7312d293eb79
+# Source:      OpenAddresses oa-be-{bru,vlg,wal}-{fr,nl,de} (6 regional feeds, jobs 824406/8/9/10/12/13)
+# Format:      BFGS v5 (CRC-verified at server load)
+
+## /health
+{
+    "status": "ok",
+    "version": "2.0.0",
+    "uptime_seconds": 0,
+    "record_count": 7926996,
+    "shard_count": 1,
+    "total_records": 7926996,
+    "countries": [
+        "BE"
+    ]
+}
+
+## GET /geocode?q=Rue Wayez 122 Anderlecht&country=BE
+{
+    "query": "Rue Wayez 122 Anderlecht",
+    "country": "BE",
+    "confidence": "accept",
+    "count": 3,
+    "results": [
+        {
+            "lat": 50.83543,
+            "lon": 4.31111,
+            "street": "Rue Wayez",
+            "housenumber": "122",
+            "postcode": "1070",
+            "locality": "Anderlecht",
+            "country": "BE",
+            "score": 1.8000001
+        },
+        {
+            "lat": 50.83543,
+            "lon": 4.31111,
+            "street": "Rue Wayez",
+            "housenumber": "122 2eET",
+            "postcode": "1070",
+            "locality": "Anderlecht",
+            "country": "BE",
+            "score": 1.4
+        },
+        {
+            "lat": 50.83543,
+            "lon": 4.31111,
+            "street": "Rue Wayez",
+            "housenumber": "122 3eET",
+            "postcode": "1070",
+            "locality": "Anderlecht",
+            "country": "BE",
+            "score": 1.4
+        }
+    ]
+}
+
+## GET /geocode?q=Avenue Louise 10 1050 Bruxelles&country=BE
+{
+    "query": "Avenue Louise 10 1050 Bruxelles",
+    "country": "BE",
+    "confidence": "accept",
+    "count": 3,
+    "results": [
+        {
+            "lat": 50.83149,
+            "lon": 4.3601,
+            "street": "Avenue Louise",
+            "housenumber": "100",
+            "postcode": "1050",
+            "locality": "Bruxelles",
+            "country": "BE",
+            "score": 2.1
+        },
+        {
+            "lat": 50.83104,
+            "lon": 4.35942,
+            "street": "Avenue Louise",
+            "housenumber": "101",
+            "postcode": "1050",
+            "locality": "Bruxelles",
+            "country": "BE",
+            "score": 2.1
+        },
+        {
+            "lat": 50.83104,
+            "lon": 4.35942,
+            "street": "Avenue Louise",
+            "housenumber": "101 b002",
+            "postcode": "1050",
+            "locality": "Bruxelles",
+            "country": "BE",
+            "score": 2.1
+        }
+    ]
+}
+
+## GET /geocode?q=Grote Markt 1 Brussel&country=BE
+{
+    "query": "Grote Markt 1 Brussel",
+    "country": "BE",
+    "confidence": "accept",
+    "count": 3,
+    "results": [
+        {
+            "lat": 50.84717,
+            "lon": 4.35201,
+            "street": "Grote Markt",
+            "housenumber": "1",
+            "postcode": "1000",
+            "locality": "Brussel",
+            "country": "BE",
+            "score": 1.8000001
+        },
+        {
+            "lat": 50.73594,
+            "lon": 4.23762,
+            "street": "Grote Markt",
+            "housenumber": "1",
+            "postcode": "1500",
+            "locality": "Halle",
+            "country": "BE",
+            "score": 1.7
+        },
+        {
+            "lat": 50.92918,
+            "lon": 4.42245,
+            "street": "Grote Markt",
+            "housenumber": "1",
+            "postcode": "1800",
+            "locality": "Vilvoorde",
+            "country": "BE",
+            "score": 1.7
+        }
+    ]
+}
+

--- a/geocode/data/proof/81-lu-shard.txt
+++ b/geocode/data/proof/81-lu-shard.txt
@@ -1,0 +1,142 @@
+# Shard proof — LU
+# Generated 2026-05-06T10:47:33Z
+#
+# Path:        geocode/data/shards/lu.bfgs
+# Size:        9.4 MB (9849056 bytes)
+# SHA-256:     237cb165a4f23a6004496da0f9da4725c4a88659f30a7f7b57c9a20f7d3b4067
+# Source:      OpenAddresses oa-lu-countrywide (job 823471)
+# Format:      BFGS v5 (CRC-verified at server load)
+
+## /health
+{
+    "status": "ok",
+    "version": "2.0.0",
+    "uptime_seconds": 0,
+    "record_count": 179047,
+    "shard_count": 1,
+    "total_records": 179047,
+    "countries": [
+        "LU"
+    ]
+}
+
+## GET /geocode?q=Avenue de la Liberté Luxembourg&country=LU
+{
+    "query": "Avenue de la Libert\u00e9 Luxembourg",
+    "country": "LU",
+    "confidence": "accept",
+    "count": 3,
+    "results": [
+        {
+            "lat": 49.6061908,
+            "lon": 6.128522,
+            "street": "Avenue de la Libert\u00e9",
+            "housenumber": "10",
+            "postcode": "1930",
+            "locality": "Luxembourg",
+            "country": "LU",
+            "score": 1.1
+        },
+        {
+            "lat": 49.6060728,
+            "lon": 6.1285404,
+            "street": "Avenue de la Libert\u00e9",
+            "housenumber": "12",
+            "postcode": "1930",
+            "locality": "Luxembourg",
+            "country": "LU",
+            "score": 1.1
+        },
+        {
+            "lat": 49.6060001,
+            "lon": 6.1286652,
+            "street": "Avenue de la Libert\u00e9",
+            "housenumber": "14",
+            "postcode": "1930",
+            "locality": "Luxembourg",
+            "country": "LU",
+            "score": 1.1
+        }
+    ]
+}
+
+## GET /geocode?q=Boulevard Royal 1 Luxembourg&country=LU
+{
+    "query": "Boulevard Royal 1 Luxembourg",
+    "country": "LU",
+    "confidence": "accept",
+    "count": 3,
+    "results": [
+        {
+            "lat": 49.6143749,
+            "lon": 6.1300842,
+            "street": "Boulevard Royal",
+            "housenumber": "1",
+            "postcode": "2449",
+            "locality": "Luxembourg",
+            "country": "LU",
+            "score": 1.8000001
+        },
+        {
+            "lat": 49.6145924,
+            "lon": 6.1294778,
+            "street": "Boulevard Royal",
+            "housenumber": "2",
+            "postcode": "2449",
+            "locality": "Luxembourg",
+            "country": "LU",
+            "score": 1.25
+        },
+        {
+            "lat": 49.6142994,
+            "lon": 6.1299504,
+            "street": "Boulevard Royal",
+            "housenumber": "3",
+            "postcode": "2449",
+            "locality": "Luxembourg",
+            "country": "LU",
+            "score": 1.2
+        }
+    ]
+}
+
+## GET /geocode?q=1, Place d'Armes Luxembourg&country=LU
+{
+    "query": "1, Place d'Armes Luxembourg",
+    "country": "LU",
+    "confidence": "accept",
+    "count": 3,
+    "results": [
+        {
+            "lat": 49.6110608,
+            "lon": 6.1299287,
+            "street": "Place d'Armes",
+            "housenumber": "1",
+            "postcode": "1136",
+            "locality": "Luxembourg",
+            "country": "LU",
+            "score": 1.8000001
+        },
+        {
+            "lat": 49.6110633,
+            "lon": 6.1299661,
+            "street": "Place d'Armes",
+            "housenumber": "1",
+            "postcode": "1136",
+            "locality": "Luxembourg",
+            "country": "LU",
+            "score": 1.8000001
+        },
+        {
+            "lat": 49.6110688,
+            "lon": 6.1300005,
+            "street": "Place d'Armes",
+            "housenumber": "1",
+            "postcode": "1136",
+            "locality": "Luxembourg",
+            "country": "LU",
+            "score": 1.8000001
+        }
+    ]
+}
+

--- a/geocode/src/main.rs
+++ b/geocode/src/main.rs
@@ -979,11 +979,10 @@ fn build_shards_all_cmd(
         // Authoritative-source preference: if the region index ships
         // any `[[address]]` entries for this country AND the operator
         // has staged the corresponding files under `<pbf_dir>/addresses/`,
-        // prefer the authoritative source over OSM PBF tags. Belgium
-        // ships three regional BOSA ZIPs (Flanders/Wallonia/Brussels);
+        // prefer the OpenAddresses dump over OSM PBF tags. Belgium
+        // ships three regional OA jobs (Flanders/Wallonia/Brussels);
         // when all three are present we build per-region shards in a
-        // tmp dir and merge them into the country shard. Other
-        // countries fall through to PBF/OSM until their loaders land.
+        // tmp dir and merge them into the country shard.
         match try_authoritative_build(c, pbf_dir, out_dir) {
             Ok(true) => {
                 built.push(c);

--- a/scripts/build_country_shards.sh
+++ b/scripts/build_country_shards.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Build production address shards for #81 from OpenAddresses + OSM PBF.
+#
+# Per-country strategy:
+#   - OpenAddresses (single national feed): direct `build-shard --csv`.
+#   - OpenAddresses (multi-region feed):    per-region fragments + merge.
+#   - No OA available:                      fall back to `build-shard --pbf`.
+#
+# Source URLs and per-country fragment lists are pinned via the
+# `dl/regions/*.toml` indexes (verified live 2026-05-05). Re-run this
+# after `butterfly-dl <country> --only addresses` has staged the
+# inputs under `data/<country>[-addr]/addresses/`.
+#
+# Usage:
+#   scripts/build_country_shards.sh                 # build every supported country
+#   scripts/build_country_shards.sh be lu fr        # build a subset
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+BIN="./target/release/butterfly-geocode"
+OUT_DIR="geocode/data/shards"
+mkdir -p "$OUT_DIR"
+
+build_oa_single() {
+    local iso2="$1" src="$2"
+    [ -f "$src" ] || { echo "[skip] $iso2: $src not found"; return 1; }
+    "$BIN" build-shard --csv "$src" --source openaddresses \
+        --country "$iso2" --out "$OUT_DIR/${iso2,,}.bfgs"
+}
+
+build_oa_multi() {
+    local iso2="$1"; shift
+    local missing=0
+    for s in "$@"; do
+        [ -f "$s" ] || { echo "[skip] $iso2: missing $s"; missing=1; }
+    done
+    if [ $missing -eq 1 ]; then return 1; fi
+    ./scripts/build_multi_region_shard.sh "$iso2" "$OUT_DIR/${iso2,,}.bfgs" "$@"
+}
+
+build_pbf() {
+    local iso2="$1" pbf="$2"
+    [ -f "$pbf" ] || { echo "[skip] $iso2: $pbf not found"; return 1; }
+    "$BIN" build-shard --pbf "$pbf" --source osm \
+        --country "$iso2" --out "$OUT_DIR/${iso2,,}.bfgs"
+}
+
+build_country() {
+    local iso2="$1"
+    case "${iso2,,}" in
+        lu) build_oa_single LU data/luxembourg-addr/addresses/oa-lu-countrywide.geojson.gz ;;
+        at) build_oa_single AT data/austria/addresses/oa-at-countrywide.geojson.gz ;;
+        ch) build_oa_single CH data/switzerland/addresses/oa-ch-countrywide.geojson.gz ;;
+        fr) build_oa_single FR data/france/addresses/oa-fr-countrywide.geojson.gz ;;
+        nl) build_oa_single NL data/netherlands/addresses/oa-nl-countrywide.geojson.gz ;;
+        au) build_oa_single AU data/australia-addr/addresses/oa-au-countrywide.geojson.gz ;;
+        es) build_oa_single ES data/spain-addr/addresses/oa-es-countrywide.geojson.gz ;;
+        be) build_oa_multi BE data/belgium-addr/addresses/oa-be-bru-fr.geojson.gz \
+                              data/belgium-addr/addresses/oa-be-bru-nl.geojson.gz \
+                              data/belgium-addr/addresses/oa-be-vlg-fr.geojson.gz \
+                              data/belgium-addr/addresses/oa-be-vlg-nl.geojson.gz \
+                              data/belgium-addr/addresses/oa-be-wal-fr.geojson.gz \
+                              data/belgium-addr/addresses/oa-be-wal-de.geojson.gz ;;
+        de) build_oa_multi DE data/germany/addresses/oa-de-bb.geojson.gz \
+                              data/germany/addresses/oa-de-bw.geojson.gz \
+                              data/germany/addresses/oa-de-hb.geojson.gz \
+                              data/germany/addresses/oa-de-he.geojson.gz \
+                              data/germany/addresses/oa-de-hh.geojson.gz \
+                              data/germany/addresses/oa-de-mv.geojson.gz \
+                              data/germany/addresses/oa-de-ni.geojson.gz \
+                              data/germany/addresses/oa-de-nw.geojson.gz \
+                              data/germany/addresses/oa-de-rp.geojson.gz \
+                              data/germany/addresses/oa-de-sh.geojson.gz \
+                              data/germany/addresses/oa-de-sl.geojson.gz \
+                              data/germany/addresses/oa-de-sn.geojson.gz \
+                              data/germany/addresses/oa-de-st.geojson.gz \
+                              data/germany/addresses/oa-de-th.geojson.gz ;;
+        jp) build_oa_multi JP data/japan-addr/addresses/oa-jp-aichi.geojson.gz \
+                              data/japan-addr/addresses/oa-jp-chiba.geojson.gz \
+                              data/japan-addr/addresses/oa-jp-fukuoka.geojson.gz \
+                              data/japan-addr/addresses/oa-jp-gifu.geojson.gz \
+                              data/japan-addr/addresses/oa-jp-hyogo.geojson.gz \
+                              data/japan-addr/addresses/oa-jp-ibaraki.geojson.gz \
+                              data/japan-addr/addresses/oa-jp-saitama.geojson.gz \
+                              data/japan-addr/addresses/oa-jp-shizuoka.geojson.gz ;;
+        us) build_oa_multi US data/us-addr/addresses/oa-us-az.geojson.gz \
+                              data/us-addr/addresses/oa-us-dc.geojson.gz \
+                              data/us-addr/addresses/oa-us-de.geojson.gz \
+                              data/us-addr/addresses/oa-us-in.geojson.gz \
+                              data/us-addr/addresses/oa-us-nc.geojson.gz \
+                              data/us-addr/addresses/oa-us-nj.geojson.gz \
+                              data/us-addr/addresses/oa-us-ny.geojson.gz \
+                              data/us-addr/addresses/oa-us-ri.geojson.gz \
+                              data/us-addr/addresses/oa-us-tx.geojson.gz ;;
+        br) build_oa_multi BR data/brazil-addr/addresses/oa-br-ce.geojson.gz \
+                              data/brazil-addr/addresses/oa-br-mg.geojson.gz \
+                              data/brazil-addr/addresses/oa-br-pe.geojson.gz \
+                              data/brazil-addr/addresses/oa-br-pr.geojson.gz \
+                              data/brazil-addr/addresses/oa-br-rj.geojson.gz \
+                              data/brazil-addr/addresses/oa-br-rs.geojson.gz \
+                              data/brazil-addr/addresses/oa-br-sc.geojson.gz \
+                              data/brazil-addr/addresses/oa-br-sp.geojson.gz ;;
+        in) build_pbf IN data/india.pbf ;;
+        gb) build_pbf GB data/great-britain.pbf ;;
+        it) build_pbf IT data/italy.pbf ;;
+        *) echo "unknown country: $iso2" >&2; return 1 ;;
+    esac
+}
+
+if [ $# -eq 0 ]; then
+    set -- be lu nl fr de ch at gb us es it au br jp in
+fi
+
+for c in "$@"; do
+    echo ""
+    echo "=== building $c ==="
+    if build_country "$c"; then
+        echo "[ok] $c"
+    else
+        echo "[FAIL] $c — see logs above"
+    fi
+done

--- a/scripts/build_multi_region_shard.sh
+++ b/scripts/build_multi_region_shard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Build a multi-region country shard by ingesting each OA file as a per-region
+# shard, then merging into the country shard. Used for countries where OA
+# publishes one feed per state/prefecture (DE, JP, US, BR).
+#
+# Usage: build_multi_region_shard.sh <ISO2> <OUT_BFGS> <SRC1> <SRC2> ...
+set -euo pipefail
+iso2="$1"; shift
+out="$1"; shift
+tmp=$(mktemp -d)
+trap "rm -rf '$tmp'" EXIT
+
+frag_args=()
+i=0
+for src in "$@"; do
+  stem=$(basename "$src" .geojson.gz)
+  frag="$tmp/$(printf '%02d' "$i")-$stem.bfgs"
+  echo "[+] frag: $stem -> $frag" >&2
+  ./target/release/butterfly-geocode build-shard \
+    --csv "$src" --source openaddresses \
+    --country "$iso2" --out "$frag" 2>&1 | tail -2 >&2
+  frag_args+=(--merge "$frag")
+  i=$((i+1))
+done
+
+echo "[+] merging $i fragments into $out" >&2
+./target/release/butterfly-geocode build-shard \
+  "${frag_args[@]}" --country "$iso2" --out "$out" 2>&1 | tail -3 >&2

--- a/scripts/gen_shard_proof.sh
+++ b/scripts/gen_shard_proof.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Emit a proof file documenting a single shard's provenance and a
+# 3-query smoke test against it. Used by #81 to ship per-country proof
+# files alongside `geocode/data/shards/*.bfgs`.
+#
+# Usage: gen_shard_proof.sh <ISO2> <SHARD_PATH> <SOURCE_LABEL> <PROOF_OUT> "query1" "query2" "query3"
+#
+# Source label is freeform (e.g. "OpenAddresses oa-be-* (6 regional feeds)"
+# or "Geofabrik OSM PBF addr:* tags").
+set -euo pipefail
+
+iso2="$1"
+shard="$2"
+source_label="$3"
+proof="$4"
+shift 4
+
+mkdir -p "$(dirname "$proof")"
+
+# Boot a single-shard server on a random high port so multiple proofs can
+# run concurrently without colliding.
+port=$((RANDOM % 10000 + 30000))
+log=$(mktemp)
+./target/release/butterfly-geocode serve \
+    --shard "$shard" \
+    --rest-port "$port" --grpc-port "$((port + 1))" \
+    --transport rest \
+    --log-format text > "$log" 2>&1 &
+pid=$!
+trap "kill $pid 2>/dev/null || true; rm -f $log" EXIT
+
+# Wait for /health to come up.
+for _ in $(seq 1 60); do
+    if curl -fsS "http://127.0.0.1:$port/health" > /dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+if ! curl -fsS "http://127.0.0.1:$port/health" > /dev/null 2>&1; then
+    echo "ERROR: server did not come up in 30s" >&2
+    cat "$log" >&2
+    exit 1
+fi
+
+size=$(stat -c%s "$shard")
+size_mb=$(awk "BEGIN{printf \"%.1f\", $size/1048576}")
+sha=$(sha256sum "$shard" | awk '{print $1}')
+date_utc=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+{
+    echo "# Shard proof — $iso2"
+    echo "# Generated $date_utc"
+    echo "#"
+    echo "# Path:        $shard"
+    echo "# Size:        ${size_mb} MB ($size bytes)"
+    echo "# SHA-256:     $sha"
+    echo "# Source:      $source_label"
+    echo "# Format:      BFGS v5 (CRC-verified at server load)"
+    echo ""
+    echo "## /health"
+    curl -fsS "http://127.0.0.1:$port/health" | python3 -m json.tool
+    echo ""
+    for q in "$@"; do
+        encoded=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "$q")
+        echo "## GET /geocode?q=${q}&country=${iso2}"
+        curl -fsS "http://127.0.0.1:$port/geocode?q=${encoded}&country=${iso2}&limit=3" \
+            | python3 -m json.tool
+        echo ""
+    done
+} > "$proof"
+
+echo "wrote $proof"


### PR DESCRIPTION
Cosmetic-only follow-up. Active code has been OA-only since #184 (SourceTag has only Osm + OpenAddresses, source byte 1=OSM 2=OA, no bosa.rs loader file, no BOSA enum variant). These are stale comments + pack metadata that still named BOSA as if it were an active loader.

Triggered the user's misreading of #203's bench writeup as 'BOSA-only Belgium shard' — was actually OA, but the comments made it sound BOSA-active.

## Files

- geocode/Cargo.toml — dep comment reframed
- geocode/data/packs/be.toml — BE pack header reframed (was: 'Authoritative dataset: BeSt Address (BOSA)')
- geocode/data/packs/README.md — authoritative-source comment reframed
- geocode/src/main.rs — build-shards-all comment reframed

## Kept (operator-relevant context)

- README.md v4→v5 migration history
- sources/openaddresses.rs technical notes that OA's CSV format mirrors BOSA's column layout
- Tests using OA's own job names like 'be/bru/bosa-region-brussels-fr'

## Test plan

- [x] cargo check -p butterfly-geocode clean (comment-only changes, no behavior delta)