### PR TITLE
perf(corpus-gen): hoist canary rewrite_pairs out of per-record loop (Copilot #199)

### DIFF
--- a/geocode-training/corpus-gen/src/canary.rs
+++ b/geocode-training/corpus-gen/src/canary.rs
@@ -94,23 +94,35 @@ fn rewrite_street(s: &str, pairs: &[(String, String)]) -> Option<String> {
     None
 }
 
+/// Compute the (source, target) substitution pairs once per canary
+/// target morphology. Hoist this out of the per-record loop in callers
+/// — it allocates+sorts O(markers) on every call.
+pub fn build_rewrite_pairs(source: &Morphology, target: &Morphology) -> Vec<(String, String)> {
+    rewrite_pairs(source, target)
+}
+
 /// Rewrite a single gold record from the source country's idiom into
 /// the target country's idiom. Returns `None` if no marker matched —
 /// the record is just not relevant for this canary pair.
+///
+/// `pairs` is the precomputed substitution table from
+/// [`build_rewrite_pairs`]. Callers MUST hoist that out of any per-record
+/// loop, otherwise canary generation is O(records × markers) when it
+/// could be O(records + markers) per target.
 pub fn rewrite_with(
     g: &GoldRecord,
-    source: &Morphology,
-    target: &Morphology,
+    source_iso2: &str,
+    target_iso2: &str,
+    pairs: &[(String, String)],
     _rng: &mut ChaCha20Rng,
 ) -> Option<TrainRecord> {
-    let pairs = rewrite_pairs(source, target);
-    let new_street = rewrite_street(g.street.as_deref()?, &pairs)?;
+    let new_street = rewrite_street(g.street.as_deref()?, pairs)?;
     let mut g2 = g.clone();
     g2.street = Some(new_street);
     let kind = format!(
         "canary_{}_as_{}",
-        source.country.iso2.to_lowercase(),
-        target.country.iso2.to_lowercase()
+        source_iso2.to_lowercase(),
+        target_iso2.to_lowercase()
     );
     Some(rendered_record(&g2, &kind))
 }
@@ -155,7 +167,8 @@ mod tests {
             lon: 5.0,
         };
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let out = rewrite_with(&g, &be, &fr, &mut rng).unwrap();
+        let pairs = build_rewrite_pairs(&be, &fr);
+        let out = rewrite_with(&g, &be.country.iso2, &fr.country.iso2, &pairs, &mut rng).unwrap();
         assert_eq!(out.country, "BE", "country label must stay as source");
         assert!(
             !out.text.contains("straat"),
@@ -181,7 +194,8 @@ mod tests {
             lon: 0.0,
         };
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        assert!(rewrite_with(&g, &be, &fr, &mut rng).is_none());
+        let pairs = build_rewrite_pairs(&be, &fr);
+        assert!(rewrite_with(&g, &be.country.iso2, &fr.country.iso2, &pairs, &mut rng).is_none());
     }
 }
 

--- a/geocode-training/corpus-gen/src/main.rs
+++ b/geocode-training/corpus-gen/src/main.rs
@@ -130,6 +130,20 @@ fn main() -> Result<()> {
     let mut written = 0usize;
     let mut canary_written = 0usize;
 
+    // Hoist canary substitution-pair tables out of the per-record loop —
+    // rewrite_pairs allocates+sorts O(markers) per call, so without
+    // hoisting it is O(records × targets × markers) when it could be
+    // O(targets × markers + records × targets).
+    let canary_pair_tables: Vec<(String, Vec<(String, String)>)> = canary_targets
+        .iter()
+        .map(|tgt| {
+            (
+                tgt.country.iso2.clone(),
+                canary::build_rewrite_pairs(&source_morph, tgt),
+            )
+        })
+        .collect();
+
     // Fixed canary fraction — every Nth gold record gets the cross-shard rewrite
     // and is written to the canary file ONLY (it is a held-out test set, not
     // training data).
@@ -138,8 +152,14 @@ fn main() -> Result<()> {
     for (i, g) in golds.iter().enumerate() {
         // Skip the canary stride from the training corpus and route them to canary instead.
         if i % canary_stride == 0 {
-            for tgt in &canary_targets {
-                if let Some(record) = canary::rewrite_with(g, &source_morph, tgt, &mut rng) {
+            for (target_iso, pairs) in &canary_pair_tables {
+                if let Some(record) = canary::rewrite_with(
+                    g,
+                    &source_morph.country.iso2,
+                    target_iso,
+                    pairs,
+                    &mut rng,
+                ) {
                     canary_writer.write(&record)?;
                     canary_written += 1;
                 }


### PR DESCRIPTION
Addresses a Copilot review finding on PR #199. Tests pass.

## Problem

`rewrite_with(g, source, target, rng)` called `rewrite_pairs(source, target)` on every gold record × every canary target. For BE-as-{FR,NL,DE,US,GB} on a 100k-gold corpus that's ~500k unnecessary allocations + sorts on the hot loop.

## Fix

Hoist pair-table construction out of the loop. Add `build_rewrite_pairs(source, target) -> Vec<(String, String)>` as the public hoist point. Change `rewrite_with` signature to take precomputed `pairs: &[(String, String)]` and pre-formatted iso2 strings.

Caller computes the pair table once per target before iterating golds.

## Test plan

- [x] cargo test in geocode-training/corpus-gen — 7/7 pass
- [x] Two existing canary tests updated for the new signature, pass green