### PR TITLE
docs(route): fix stale snap doc comments (Copilot #200)

### DIFF
--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -436,9 +436,11 @@ pub async fn route_handler(
     // nodes (one per direction of travel) are present at the same
     // polyline vertex. We collect the top-K candidates per role, try
     // (src, dst) combinations in expected-best order, and pick the
-    // first pair that produces a valid route. K is small (4) and the
-    // fallback only runs when the primary candidate fails — typical
-    // queries pay one P2P query, pathological pairs pay up to 16.
+    // first pair that produces a valid route. K is SNAP_K (defined
+    // below — 64 at the time of this fix) and the fallback only runs
+    // when the primary candidate fails. Typical healthy queries pay
+    // one P2P query; pathological pairs pay up to MAX_FALLBACK_COMBOS
+    // (400) — see the SNAP_K block below for the empirical sweep.
     let src_role_filter = SnapRole::Src.role_filter(mode_data);
     let dst_role_filter = SnapRole::Dst.role_filter(mode_data);
 

--- a/route/src/server/types.rs
+++ b/route/src/server/types.rs
@@ -21,15 +21,18 @@ pub struct ErrorResponse {
 /// exists. The server picks the per-mode role bitset to apply based
 /// on this enum.
 ///
-/// `Either` (the legacy default) keeps the historical behaviour for
-/// API back-compat where a caller didn't say which role they meant
-/// (e.g. `/isochrone` from a single point — that point is *always*
-/// a source, but historically went through the unfiltered snap).
+/// `Src` is the current Rust default (via `#[default]`) and the
+/// `/nearest` HTTP default (via `#[serde(default)]` on the request
+/// struct), matching what most callers want. `Either` is the legacy
+/// *behaviour* — the unfiltered snap that was the only option before
+/// #197 — kept available for callers that explicitly want it (e.g.
+/// `/isochrone` from a single point, where that point is *always* a
+/// source but historically went through the unfiltered snap).
 /// Practical usage:
 ///   - `/route` source point → `Src`
 ///   - `/route` destination point → `Dst`
-///   - `/nearest` defaults to `Src` for back-compat with the OSRM
-///     shape, with `role=src|dst|either` as a query parameter.
+///   - `/nearest` defaults to `Src` (current default), with
+///     `role=src|dst|either` as a query parameter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, ToSchema, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum SnapRole {


### PR DESCRIPTION
Doc-only Copilot fixes on PR #200. No behaviour change.

- route/src/server/route.rs: snap-K opening comment said "K is small (4) ... up to 16" but actual code uses SNAP_K=64 / MAX_FALLBACK_COMBOS=400. Corrected to point at the constants + empirical sweep already documented below.
- route/src/server/types.rs: SnapRole rustdoc said "Either (the legacy default)" but Src is `#[default]` on the enum and `#[serde(default)]` on /nearest. Clarified that Src is the current default; Either is the legacy *behaviour* (unfiltered snap) kept for explicit opt-in.

cargo check -p butterfly-route clean. No source semantics touched.