### PR TITLE
fix(geocode): JSONL telemetry logs resolved device not preference (Copilot #203)

### DIFF
--- a/geocode/src/tagger/training.rs
+++ b/geocode/src/tagger/training.rs
@@ -929,7 +929,12 @@ pub fn train_and_save_with_outcome<P: AsRef<Path>>(
                 "plateau_streak": m.plateau_streak,
                 "best_eval_loss": m.best_eval_loss,
                 "global_step": global_step,
-                "device": format!("{:?}", train_cfg.device_pref),
+                "device": match &device {
+                    candle_core::Device::Cpu => "cpu",
+                    candle_core::Device::Cuda(_) => "cuda",
+                    candle_core::Device::Metal(_) => "metal",
+                },
+                "device_pref": format!("{:?}", train_cfg.device_pref),
                 "n_countries": cfg.n_countries,
                 "d_model": cfg.d_model,
                 "n_layers": cfg.n_layers,


### PR DESCRIPTION
Address Copilot review on PR #203. Telemetry was logging the user-supplied preference (e.g. 'Auto') instead of the resolved backend. Downstream run-comparison was unable to distinguish whether 'Auto' resolved to CUDA or fell back to CPU.

Fix: log the resolved device ('cpu' | 'cuda' | 'metal') as 'device', and preserve the original preference as 'device_pref' for context.

cargo check clean. No behaviour change in the trainer itself, only telemetry semantics.