### PR TITLE
fix(route): #197 matrix gap — apply role filter + K-best fallback to all snap sites

### DIFF
--- a/bench/route/results/2026-05-22-post-snap-kbest/REPORT.md
+++ b/bench/route/results/2026-05-22-post-snap-kbest/REPORT.md
@@ -1,0 +1,80 @@
+# Matrix benchmark — post snap-K-best + SCC role masks (2026-05-22)
+
+Branch: `route-verify-belgium-latest` (PR #232)
+
+Belgium artifact: `data/belgium/baseline.butterfly` (Apr-26 build, same as previous runs).
+
+## Algorithm bench — `butterfly-bench bucket-m2m --parallel`
+
+In-process bucket many-to-many CCH. No HTTP, no serialization.
+
+| Size | Cells | Time | Throughput | Fwd vis | Bwd vis | Joins |
+|------|-------|------|------------|---------|---------|-------|
+| 10×10 | 100 | 18.6 ms | 5 365 c/s | 2 313 | 2 257 | 91 K |
+| 25×25 | 625 | 51.5 ms | 12 K c/s | 2 451 | 2 427 | 362 K |
+| 50×50 | 2 500 | 11.5 ms | 216 K c/s | 2 465 | 2 186 | 1.4 M |
+| 100×100 | 10 K | 26.0 ms | 385 K c/s | 2 493 | 2 313 | 6.0 M |
+| 500×500 | 250 K | 115.1 ms | 2.2 M c/s | 2 436 | 2 319 | 149 M |
+| 1000×1000 | 1 M | 270.8 ms | 3.7 M c/s | 2 415 | 2 335 | 598 M |
+| 2000×2000 | 4 M | 830.8 ms | 4.8 M c/s | 2 390 | 2 337 | 2.4 B |
+| 5000×5000 | 25 M | 4 815 ms | 5.2 M c/s | 2 396 | 7 022 | 14.8 B |
+| 10000×10000 | 100 M | 18 091 ms | 5.5 M c/s | 2 399 | 11 718 | 59 B |
+
+Correctness validation (5×5 vs P2P): all 25 queries match.
+
+## Flight gRPC `matrix` action — clustered city coords
+
+End-to-end via Arrow Flight gRPC. Clustered means coords perturbed
+within ±0.1° of 5 Belgium cities (Brussels, Antwerp, Ghent, Liège,
+Charleroi) — 100 % snappable.
+
+Initial run was serial-snap in `do_matrix`; revised run parallelised
+the per-coord K-best snap via `rayon::par_iter`. Both runs included
+for transparency. **Use the parallel-snap numbers as the current
+baseline.**
+
+| Size | Cells | Serial snap | Parallel snap | Throughput | Speedup |
+|------|-------|-------------|---------------|------------|---------|
+| 1k × 1k | 1 M | 5.47 s | **3.61 s** | 277 K c/s | 1.5× |
+| 5k × 5k | 25 M | 24.27 s | **14.88 s** | 1.7 M c/s | 1.6× |
+| 10k × 10k | 100 M | 52.76 s | **35.52 s** | 2.8 M c/s | 1.5× |
+| 25k × 25k | 625 M | 221.9 s (3.7 min) | **172.6 s (2.88 min)** | 3.6 M c/s | 1.3× |
+| 50k × 50k | 2.5 B | 656.4 s (10.94 min) | **576.7 s (9.61 min)** | 4.3 M c/s | 1.14× |
+
+All matrices were 100 % finite (clustered city coords, so every cell
+snaps inside the Belgium road network).
+
+## Historical comparison (from CLAUDE.md)
+
+The previous matrix-stream baselines used the REST `/table/stream`
+endpoint (now removed; superseded by Flight gRPC `matrix`):
+
+| Size | Previous (`/table/stream`) | Now (Flight `matrix`) |
+|------|----------------------------|------------------------|
+| 10k × 10k | 24 s | **35.5 s** |
+| 50k × 50k | 9.5 min | **9.61 min** (parity) |
+
+Notes:
+- The Flight numbers include the full Arrow Flight gRPC roundtrip
+  (handshake, stream RPC framing) which the historical `/table/stream`
+  HTTP numbers don't include. The in-process bucket-m2m bench is the
+  closest apples-to-apples (5.5 M c/s = 18 s at 10k × 10k, ~25 % faster
+  than the historical 24 s figure).
+- 50k × 50k is at parity with the historical figure, with the matrix
+  now mathematically equal to running 2.5 B independent P2P queries
+  thanks to the connectivity-aware role masks + K-best fallback
+  (correctness improvement landed in commits `772ff1a` and `b2992cb`).
+
+## How to run
+
+```bash
+# Algorithm bench
+./target/release/butterfly-bench bucket-m2m --data-dir ./data/belgium \
+  --sizes 10,25,50,100,500,1000,2000,5000,10000 --parallel
+
+# Flight matrix end-to-end
+python3 -m venv .venv-bench
+.venv-bench/bin/pip install pyarrow
+.venv-bench/bin/python /tmp/bench_flight_v2.py 1000 5000 10000 --clustered
+.venv-bench/bin/python /tmp/bench_flight_v2.py 25000 50000 --clustered
+```

--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -1018,7 +1018,8 @@ fn load_phast(data_dir: &Path, mode: &str) -> anyhow::Result<PhastEngine> {
         data_dir,
         &[
             format!("cch.{}.topo", mode),
-            format!("step7-rank-aligned/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
             format!("step7-belgium-fixed/cch.{}.topo", mode),
         ],
     )
@@ -1028,7 +1029,8 @@ fn load_phast(data_dir: &Path, mode: &str) -> anyhow::Result<PhastEngine> {
         data_dir,
         &[
             format!("cch.w.{}.u32", mode),
-            format!("step8-rank-aligned/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
             format!("step8-belgium-fixed/cch.w.{}.u32", mode),
         ],
     )
@@ -1039,6 +1041,7 @@ fn load_phast(data_dir: &Path, mode: &str) -> anyhow::Result<PhastEngine> {
         &[
             format!("order.{}.ebg", mode),
             format!("step6/order.{}.ebg", mode),
+            format!("step6-roadclass/order.{}.ebg", mode),
             format!("step6-belgium-fixed/order.{}.ebg", mode),
         ],
     )
@@ -1384,7 +1387,8 @@ fn load_batched_phast(data_dir: &Path, mode: &str) -> anyhow::Result<BatchedPhas
         data_dir,
         &[
             format!("cch.{}.topo", mode),
-            format!("step7-rank-aligned/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
             format!("step7-belgium-fixed/cch.{}.topo", mode),
         ],
     )
@@ -1394,7 +1398,8 @@ fn load_batched_phast(data_dir: &Path, mode: &str) -> anyhow::Result<BatchedPhas
         data_dir,
         &[
             format!("cch.w.{}.u32", mode),
-            format!("step8-rank-aligned/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
             format!("step8-belgium-fixed/cch.w.{}.u32", mode),
         ],
     )
@@ -1405,6 +1410,7 @@ fn load_batched_phast(data_dir: &Path, mode: &str) -> anyhow::Result<BatchedPhas
         &[
             format!("order.{}.ebg", mode),
             format!("step6/order.{}.ebg", mode),
+            format!("step6-roadclass/order.{}.ebg", mode),
             format!("step6-belgium-fixed/order.{}.ebg", mode),
         ],
     )
@@ -1626,7 +1632,7 @@ fn run_batched_isochrone_bench(
         data_dir,
         &[
             format!("cch.{}.topo", mode),
-            format!("step7-rank-aligned/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
             format!("step7/cch.{}.topo", mode),
             format!("step7-new/cch.{}.topo", mode),
         ],
@@ -1637,7 +1643,7 @@ fn run_batched_isochrone_bench(
         data_dir,
         &[
             format!("cch.w.{}.u32", mode),
-            format!("step8-rank-aligned/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
             format!("step8/cch.w.{}.u32", mode),
             format!("step8-new/cch.w.{}.u32", mode),
         ],
@@ -2967,7 +2973,7 @@ fn run_bucket_m2m_bench(
         data_dir,
         &[
             format!("cch.{}.topo", mode),
-            format!("step7-rank-aligned/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
             format!("step7/cch.{}.topo", mode),
         ],
     )
@@ -2977,7 +2983,7 @@ fn run_bucket_m2m_bench(
         data_dir,
         &[
             format!("cch.w.{}.u32", mode),
-            format!("step8-rank-aligned/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
             format!("step8/cch.w.{}.u32", mode),
         ],
     )
@@ -3507,7 +3513,7 @@ fn run_e2e_isochrone_bench(
         data_dir,
         &[
             format!("cch.{}.topo", mode),
-            format!("step7-rank-aligned/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.{}.topo", mode))?;
@@ -3516,7 +3522,7 @@ fn run_e2e_isochrone_bench(
         data_dir,
         &[
             format!("cch.w.{}.u32", mode),
-            format!("step8-rank-aligned/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.w.{}.u32", mode))?;
@@ -3795,7 +3801,7 @@ fn run_pathological_origins_bench(data_dir: &Path, mode: &str) -> anyhow::Result
         data_dir,
         &[
             format!("cch.{}.topo", mode),
-            format!("step7-rank-aligned/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.{}.topo", mode))?;
@@ -3804,7 +3810,7 @@ fn run_pathological_origins_bench(data_dir: &Path, mode: &str) -> anyhow::Result
         data_dir,
         &[
             format!("cch.w.{}.u32", mode),
-            format!("step8-rank-aligned/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.w.{}.u32", mode))?;
@@ -3999,7 +4005,7 @@ fn run_bulk_pipeline_bench(
         data_dir,
         &[
             format!("cch.{}.topo", mode),
-            format!("step7-rank-aligned/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.{}.topo", mode))?;
@@ -4007,7 +4013,7 @@ fn run_bulk_pipeline_bench(
         data_dir,
         &[
             format!("cch.w.{}.u32", mode),
-            format!("step8-rank-aligned/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.w.{}.u32", mode))?;
@@ -4180,7 +4186,7 @@ fn run_monotonicity_test(
         data_dir,
         &[
             format!("cch.{}.topo", mode),
-            format!("step7-rank-aligned/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.{}.topo", mode))?;
@@ -4188,7 +4194,7 @@ fn run_monotonicity_test(
         data_dir,
         &[
             format!("cch.w.{}.u32", mode),
-            format!("step8-rank-aligned/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.w.{}.u32", mode))?;
@@ -4266,7 +4272,7 @@ fn run_detail_compare(data_dir: &Path, mode: &str, threshold_min: u32) -> anyhow
         data_dir,
         &[
             format!("cch.{}.topo", mode),
-            format!("step7-rank-aligned/cch.{}.topo", mode),
+            format!("step7/cch.{}.topo", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.{}.topo", mode))?;
@@ -4274,7 +4280,7 @@ fn run_detail_compare(data_dir: &Path, mode: &str, threshold_min: u32) -> anyhow
         data_dir,
         &[
             format!("cch.w.{}.u32", mode),
-            format!("step8-rank-aligned/cch.w.{}.u32", mode),
+            format!("step8/cch.w.{}.u32", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.w.{}.u32", mode))?;

--- a/route/src/server/avoid.rs
+++ b/route/src/server/avoid.rs
@@ -5,14 +5,147 @@
 //!
 //! The R-tree spatial index provides O(log n) bounding-box prefiltering,
 //! followed by O(v) ray-casting point-in-polygon for each candidate edge.
+//!
+//! Recustomization is expensive (~30 s on Belgium even for a tiny polygon
+//! because the bottom-up rebuilds every shortcut weight). To make repeat
+//! queries cheap, we cache the recustomized weights keyed by
+//! (mode, polygon_hash, exclude_mask). Cache capacity is bounded so
+//! memory stays predictable — each entry is ~100-200 MB on Belgium. See
+//! `AvoidWeightCache` below.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
 use geo::{Contains, Coord, Point, Polygon};
+use parking_lot::RwLock;
 
 use crate::formats::cch_weights::CchWeights;
 
 use super::exclude::{self, ExcludeWeights};
 use super::snap_index::PackedSnapIndex;
 use super::state::{ModeData, ServerState};
+
+/// Default LRU capacity. Each full entry is ~100-200 MB on Belgium, so 8
+/// entries cap memory at ~1.6 GB. Override at boot via the
+/// `BUTTERFLY_AVOID_CACHE_CAP` env var.
+pub const DEFAULT_AVOID_CACHE_CAP: usize = 8;
+
+/// Cache key for a recustomized weight set. The polygon hash collapses
+/// the polygon JSON to 64 bits; clients querying with byte-identical
+/// JSON hit the cache. Different polygons hash to different keys, so
+/// there is no risk of returning the wrong weights — at worst we miss.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct AvoidKey {
+    mode_idx: u8,
+    exclude_mask: u8,
+    polygon_hash: u64,
+}
+
+/// Value cached for an `AvoidKey`. Holds the full weight set (time +
+/// distance + flat adjacencies) plus the avoid flags so /route, /table,
+/// /isochrone, /trip can all reuse the same recustomization.
+pub struct AvoidEntry {
+    pub weights: ExcludeWeights,
+    pub flags: Vec<u8>,
+}
+
+struct AvoidCacheInner {
+    map: HashMap<AvoidKey, (Arc<AvoidEntry>, u64)>, // (entry, last-touched generation)
+    generation: u64,
+    capacity: usize,
+    hits: u64,
+    misses: u64,
+}
+
+/// Bounded LRU keyed by (mode, polygon_hash, exclude_mask). Single
+/// `RwLock` for the whole cache — reads are an `Arc::clone` so the
+/// lock is released quickly. Writes do an O(capacity) scan for the
+/// least-recently-used slot when full.
+pub struct AvoidWeightCache {
+    inner: RwLock<AvoidCacheInner>,
+}
+
+impl AvoidWeightCache {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: RwLock::new(AvoidCacheInner {
+                map: HashMap::with_capacity(capacity.max(1)),
+                generation: 0,
+                capacity: capacity.max(1),
+                hits: 0,
+                misses: 0,
+            }),
+        }
+    }
+
+    fn get(&self, key: &AvoidKey) -> Option<Arc<AvoidEntry>> {
+        // Fast path: read lock + key presence check.
+        let present = self.inner.read().map.contains_key(key);
+        if !present {
+            return None;
+        }
+        // Slow path: write lock so we can bump the LRU generation
+        // stamp atomically with the read.
+        let mut inner = self.inner.write();
+        let new_gen = inner.generation.wrapping_add(1);
+        if let Some((entry, gen_stamp)) = inner.map.get_mut(key) {
+            *gen_stamp = new_gen;
+            let entry_clone = Arc::clone(entry);
+            inner.generation = new_gen;
+            inner.hits += 1;
+            return Some(entry_clone);
+        }
+        None
+    }
+
+    fn insert(&self, key: AvoidKey, entry: Arc<AvoidEntry>) {
+        let mut inner = self.inner.write();
+        inner.misses += 1;
+        // Evict LRU if at capacity and the new key isn't already present.
+        if !inner.map.contains_key(&key)
+            && inner.map.len() >= inner.capacity
+            && let Some(victim) = inner
+                .map
+                .iter()
+                .min_by_key(|(_, (_, g))| *g)
+                .map(|(k, _)| *k)
+        {
+            inner.map.remove(&victim);
+        }
+        inner.generation = inner.generation.wrapping_add(1);
+        let gen_stamp = inner.generation;
+        inner.map.insert(key, (entry, gen_stamp));
+    }
+
+    /// (hits, misses, current size, capacity) — surfaced for the
+    /// /health endpoint or operational visibility.
+    pub fn stats(&self) -> (u64, u64, usize, usize) {
+        let inner = self.inner.read();
+        (inner.hits, inner.misses, inner.map.len(), inner.capacity)
+    }
+}
+
+impl Default for AvoidWeightCache {
+    fn default() -> Self {
+        let cap = std::env::var("BUTTERFLY_AVOID_CACHE_CAP")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_AVOID_CACHE_CAP);
+        Self::new(cap)
+    }
+}
+
+/// Hash a raw avoid_polygons JSON string. Byte-identical inputs
+/// collapse to the same hash. Different polygons or different
+/// floating-point precision produce different hashes; this is by
+/// design — clients that want cache hits should canonicalize their
+/// polygon serialization.
+fn hash_polygon_json(s: &str) -> u64 {
+    let mut h = rustc_hash::FxHasher::default();
+    s.as_bytes().hash(&mut h);
+    h.finish()
+}
 
 /// Bit flag for avoid-polygon edges (bit 3, distinct from toll/ferry/motorway bits 0-2).
 const AVOID_BIT: u8 = 8;
@@ -214,54 +347,42 @@ fn prepare_avoid_flags(
     Ok((avoid_flags, poly_count, avoided_count))
 }
 
-/// Compute time-only avoid weights for P2P route queries.
+/// Compute (or read from cache) the FULL avoid-weight set for a
+/// `(mode, polygon_hash, exclude_mask)` key. The full set is
+/// shareable between /route, /table, /isochrone, /trip — first caller
+/// pays the ~30 s recustomization cost; subsequent callers on the same
+/// key return in ~µs.
 ///
-/// Skips distance recustomization and flat adjacency builds (~2x faster).
-/// Returns (time_weights, avoid_flags) for use with `CchQuery::with_custom_weights`.
-pub fn compute_avoid_weights_time_only(
+/// Concurrent identical misses both compute and the second insertion
+/// silently overwrites — we accept the duplicate work in exchange for
+/// dead-simple lock semantics (no per-key Mutex / OnceCell).
+fn get_or_compute_avoid_entry(
     state: &ServerState,
     mode_data: &ModeData,
+    mode_idx: u8,
     avoid_json: &str,
     exclude_mask: Option<u8>,
-) -> Result<(CchWeights, Vec<u8>), String> {
-    let start = std::time::Instant::now();
+) -> Result<Arc<AvoidEntry>, String> {
+    let polygon_hash = hash_polygon_json(avoid_json);
+    let key = AvoidKey {
+        mode_idx,
+        exclude_mask: exclude_mask.unwrap_or(0),
+        polygon_hash,
+    };
 
+    if let Some(entry) = state.avoid_cache.get(&key) {
+        tracing::debug!(
+            mode_idx,
+            exclude_mask = key.exclude_mask,
+            polygon_hash,
+            "avoid weights cache HIT"
+        );
+        return Ok(entry);
+    }
+
+    let start = std::time::Instant::now();
     let (avoid_flags, poly_count, avoided_count) =
         prepare_avoid_flags(state, avoid_json, exclude_mask)?;
-
-    let time_weights = exclude::compute_exclude_weights_time_only(
-        &mode_data.cch_topo,
-        &mode_data.cch_weights,
-        &avoid_flags,
-        AVOID_BIT,
-        &mode_data.filtered_to_original,
-    );
-
-    tracing::info!(
-        polygons = poly_count,
-        avoided_edges = avoided_count,
-        elapsed_ms = start.elapsed().as_millis(),
-        "computed avoid weights (time-only)"
-    );
-
-    Ok((time_weights, avoid_flags))
-}
-
-/// Compute full avoid weights (time + distance + flat adjacencies).
-///
-/// For PHAST-based endpoints (isochrones, matrices, trip).
-/// If `exclude_mask` is also specified, both avoid and exclude flags are merged.
-pub fn compute_avoid_weights(
-    state: &ServerState,
-    mode_data: &ModeData,
-    avoid_json: &str,
-    exclude_mask: Option<u8>,
-) -> Result<(ExcludeWeights, Vec<u8>), String> {
-    let start = std::time::Instant::now();
-
-    let (avoid_flags, poly_count, avoided_count) =
-        prepare_avoid_flags(state, avoid_json, exclude_mask)?;
-
     let weights = exclude::compute_exclude_weights(
         &mode_data.cch_topo,
         &mode_data.cch_weights,
@@ -270,15 +391,79 @@ pub fn compute_avoid_weights(
         AVOID_BIT,
         &mode_data.filtered_to_original,
     );
-
     tracing::info!(
+        mode_idx,
         polygons = poly_count,
         avoided_edges = avoided_count,
         elapsed_ms = start.elapsed().as_millis(),
-        "computed avoid weights"
+        "computed avoid weights (cache MISS, stored)"
     );
 
-    Ok((weights, avoid_flags))
+    let entry = Arc::new(AvoidEntry {
+        weights,
+        flags: avoid_flags,
+    });
+    state.avoid_cache.insert(key, Arc::clone(&entry));
+    Ok(entry)
+}
+
+/// Compute time-only avoid weights for P2P route queries.
+///
+/// Backed by the shared `AvoidWeightCache`. The cache stores full
+/// `ExcludeWeights`; this function clones the time field. /route pays
+/// a ~1.2× upfront cost vs a hypothetical time-only cache but in
+/// exchange any subsequent /table or /isochrone on the same polygon
+/// gets the same cache hit.
+pub fn compute_avoid_weights_time_only(
+    state: &ServerState,
+    mode_data: &ModeData,
+    avoid_json: &str,
+    exclude_mask: Option<u8>,
+) -> Result<(CchWeights, Vec<u8>), String> {
+    let mode_idx = mode_index_in_state(state, mode_data)? as u8;
+    let entry = get_or_compute_avoid_entry(state, mode_data, mode_idx, avoid_json, exclude_mask)?;
+    Ok((entry.weights.time_weights.clone(), entry.flags.clone()))
+}
+
+/// Compute full avoid weights (time + distance + flat adjacencies).
+///
+/// For PHAST-based endpoints (isochrones, matrices, trip). Backed by
+/// the shared `AvoidWeightCache`. If `exclude_mask` is also specified,
+/// both avoid and exclude flags are merged before recustomization.
+pub fn compute_avoid_weights(
+    state: &ServerState,
+    mode_data: &ModeData,
+    avoid_json: &str,
+    exclude_mask: Option<u8>,
+) -> Result<(ExcludeWeights, Vec<u8>), String> {
+    let mode_idx = mode_index_in_state(state, mode_data)? as u8;
+    let entry = get_or_compute_avoid_entry(state, mode_data, mode_idx, avoid_json, exclude_mask)?;
+    // The cached ExcludeWeights is shared via Arc; consumers that
+    // need an owned value pay a deep clone here. The 100-200 MB clone
+    // is still cheap vs the 30 s recustomization it replaces.
+    let owned: ExcludeWeights = ExcludeWeights {
+        time_weights: entry.weights.time_weights.clone(),
+        dist_weights: entry.weights.dist_weights.clone(),
+        time_up_flat: entry.weights.time_up_flat.clone(),
+        time_down_flat: entry.weights.time_down_flat.clone(),
+        time_down_fwd_flat: entry.weights.time_down_fwd_flat.clone(),
+        dist_up_flat: entry.weights.dist_up_flat.clone(),
+        dist_down_flat: entry.weights.dist_down_flat.clone(),
+        dist_down_fwd_flat: entry.weights.dist_down_fwd_flat.clone(),
+    };
+    Ok((owned, entry.flags.clone()))
+}
+
+/// Look up the mode index by comparing the `ModeData` pointer against
+/// the state's mode list. Avoids threading an explicit index through
+/// the existing call sites.
+fn mode_index_in_state(state: &ServerState, mode_data: &ModeData) -> Result<usize, String> {
+    for (i, m) in state.modes.iter().enumerate() {
+        if std::ptr::eq(m, mode_data) {
+            return Ok(i);
+        }
+    }
+    Err("internal error: ModeData not registered in ServerState".to_string())
 }
 
 /// Parse an optional avoid_polygons parameter.

--- a/route/src/server/catchment.rs
+++ b/route/src/server/catchment.rs
@@ -281,8 +281,15 @@ fn route_between(
     src: (f64, f64),
     dst: (f64, f64),
 ) -> Vec<(f64, f64)> {
-    let src_snap = state.snap_index.snap(src.0, src.1, mode.0);
-    let dst_snap = state.snap_index.snap(dst.0, dst.1, mode.0);
+    // #197 directional snap: src needs outbound, dst needs inbound.
+    let src_role = super::types::SnapRole::Src.role_filter(mode_data);
+    let dst_role = super::types::SnapRole::Dst.role_filter(mode_data);
+    let src_snap = state
+        .snap_index
+        .snap_filtered_role(src.0, src.1, mode.0, None, src_role);
+    let dst_snap = state
+        .snap_index
+        .snap_filtered_role(dst.0, dst.1, mode.0, None, dst_role);
 
     let (src_orig, dst_orig) = match (src_snap, dst_snap) {
         (Some(s), Some(d)) => (s, d),
@@ -340,7 +347,12 @@ pub fn isochrone_hull(
     let mode_data = state.get_mode(mode);
     let mode_name = &state.mode_names[mode.index()];
 
-    let orig_id = match state.snap_index.snap(store_lon, store_lat, mode.0) {
+    // Catchment hull is a depart-isochrone: store acts as source.
+    let store_role = super::types::SnapRole::Src.role_filter(mode_data);
+    let orig_id = match state
+        .snap_index
+        .snap_filtered_role(store_lon, store_lat, mode.0, None, store_role)
+    {
         Some(id) => id,
         None => return Vec::new(),
     };
@@ -774,12 +786,21 @@ pub async fn catchment_handler(
         Vec::new()
     };
 
+    // #197 directional snap: store is the source for the 1-to-N matrix,
+    // clients are destinations. Cache the bitsets once outside the loop.
+    let store_role = super::types::SnapRole::Src.role_filter(mode_data);
+    let client_role = super::types::SnapRole::Dst.role_filter(mode_data);
+
     // For each store: compute 1-to-N matrix via Bucket M2M, then catchment
     for store_input in &req.stores {
-        // Snap store
-        let store_snap = state
-            .snap_index
-            .snap(store_input.lon, store_input.lat, mode.0);
+        // Snap store as source
+        let store_snap = state.snap_index.snap_filtered_role(
+            store_input.lon,
+            store_input.lat,
+            mode.0,
+            None,
+            store_role,
+        );
         let store_orig = match store_snap {
             Some(id) => id,
             None => continue, // Skip unsnappable stores
@@ -818,7 +839,11 @@ pub async fn catchment_handler(
                     continue;
                 }
             }
-            if let Some(orig_id) = state.snap_index.snap(c.lon, c.lat, mode.0) {
+            if let Some(orig_id) =
+                state
+                    .snap_index
+                    .snap_filtered_role(c.lon, c.lat, mode.0, None, client_role)
+            {
                 let rank = mode_data.orig_to_rank[orig_id as usize];
                 if rank != u32::MAX {
                     client_ranks.push(rank);

--- a/route/src/server/catchment.rs
+++ b/route/src/server/catchment.rs
@@ -281,31 +281,43 @@ fn route_between(
     src: (f64, f64),
     dst: (f64, f64),
 ) -> Vec<(f64, f64)> {
-    // #197 directional snap: src needs outbound, dst needs inbound.
-    let src_role = super::types::SnapRole::Src.role_filter(mode_data);
-    let dst_role = super::types::SnapRole::Dst.role_filter(mode_data);
-    let src_snap = state
-        .snap_index
-        .snap_filtered_role(src.0, src.1, mode.0, None, src_role);
-    let dst_snap = state
-        .snap_index
-        .snap_filtered_role(dst.0, dst.1, mode.0, None, dst_role);
+    // K-best snap + combo fallback (#197); src needs has_outbound and
+    // dst needs has_inbound, both connectivity-aware after the SCC
+    // role-mask change.
+    const SNAP_K: usize = 64;
+    let src_snap = super::snap_kbest::snap_k_pair_role(
+        state,
+        mode_data,
+        mode,
+        src.0,
+        src.1,
+        super::types::SnapRole::Src,
+        None,
+        SNAP_K,
+    );
+    let dst_snap = super::snap_kbest::snap_k_pair_role(
+        state,
+        mode_data,
+        mode,
+        dst.0,
+        dst.1,
+        super::types::SnapRole::Dst,
+        None,
+        SNAP_K,
+    );
 
-    let (src_orig, dst_orig) = match (src_snap, dst_snap) {
-        (Some(s), Some(d)) => (s, d),
-        _ => return vec![src, dst],
-    };
-
-    let src_rank = mode_data.orig_to_rank[src_orig as usize];
-    let dst_rank = mode_data.orig_to_rank[dst_orig as usize];
-
-    if src_rank == u32::MAX || dst_rank == u32::MAX {
+    if src_snap.ranks.is_empty() || dst_snap.ranks.is_empty() {
         return vec![src, dst];
     }
 
     let query = CchQuery::new(state, mode);
-    let result = match query.query(src_rank, dst_rank) {
-        Some(r) => r,
+    let (src_rank, dst_rank, result) = match super::snap_kbest::p2p_with_kbest_fallback(
+        &query,
+        &src_snap.ranks,
+        &dst_snap.ranks,
+        super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
+    ) {
+        Some(triple) => triple,
         None => return vec![src, dst],
     };
 
@@ -791,24 +803,27 @@ pub async fn catchment_handler(
     let store_role = super::types::SnapRole::Src.role_filter(mode_data);
     let client_role = super::types::SnapRole::Dst.role_filter(mode_data);
 
-    // For each store: compute 1-to-N matrix via Bucket M2M, then catchment
+    // For each store: compute 1-to-N matrix via Bucket M2M, then catchment.
+    // K-best snap + per-cell P2P fallback rescues INF cells the same
+    // way /table POST does — see snap_kbest.rs.
+    const SNAP_K: usize = 64;
     for store_input in &req.stores {
-        // Snap store as source
-        let store_snap = state.snap_index.snap_filtered_role(
+        // K-best snap store as source.
+        let store_snap = super::snap_kbest::snap_k_pair_role(
+            &state,
+            mode_data,
+            mode,
             store_input.lon,
             store_input.lat,
-            mode.0,
+            super::types::SnapRole::Src,
             None,
-            store_role,
+            SNAP_K,
         );
-        let store_orig = match store_snap {
-            Some(id) => id,
+        let store_rank = match store_snap.primary_rank() {
+            Some(r) => r,
             None => continue, // Skip unsnappable stores
         };
-        let store_rank = mode_data.orig_to_rank[store_orig as usize];
-        if store_rank == u32::MAX {
-            continue;
-        }
+        let _ = (store_role, client_role); // legacy bindings no longer used
 
         // Determine this store's effective radius (km) when requested. For
         // `Auto`, we compute p95 × 1.1 over the Euclidean distances from the
@@ -825,11 +840,11 @@ pub async fn catchment_handler(
         };
         let effective_radius_m: Option<f64> = effective_radius_km.map(|km| km * 1000.0);
 
-        // Snap all clients. When a radius is active, clients farther than
-        // `effective_radius_m` from the store are dropped BEFORE the M2M
-        // call so the routing layer does proportionally less work. This is
-        // the "true" speedup path — no mask-at-emit is needed because the
-        // filtered list is the list that gets routed.
+        // Snap all clients (K-best). When a radius is active, clients farther
+        // than `effective_radius_m` from the store are dropped BEFORE the
+        // M2M call so the routing layer does proportionally less work.
+        let mut client_snaps: Vec<super::snap_kbest::KBestSnap> =
+            Vec::with_capacity(req.clients.len());
         let mut client_ranks: Vec<u32> = Vec::with_capacity(req.clients.len());
         let mut client_valid: Vec<usize> = Vec::with_capacity(req.clients.len());
         for (ci, c) in req.clients.iter().enumerate() {
@@ -839,16 +854,20 @@ pub async fn catchment_handler(
                     continue;
                 }
             }
-            if let Some(orig_id) =
-                state
-                    .snap_index
-                    .snap_filtered_role(c.lon, c.lat, mode.0, None, client_role)
-            {
-                let rank = mode_data.orig_to_rank[orig_id as usize];
-                if rank != u32::MAX {
-                    client_ranks.push(rank);
-                    client_valid.push(ci);
-                }
+            let snap = super::snap_kbest::snap_k_pair_role(
+                &state,
+                mode_data,
+                mode,
+                c.lon,
+                c.lat,
+                super::types::SnapRole::Dst,
+                None,
+                SNAP_K,
+            );
+            if let Some(r) = snap.primary_rank() {
+                client_ranks.push(r);
+                client_valid.push(ci);
+                client_snaps.push(snap);
             }
         }
 
@@ -860,13 +879,37 @@ pub async fn catchment_handler(
         let sources = &[store_rank];
         let targets = &client_ranks;
 
-        let (matrix, _stats) = table_bucket_full_flat(
+        let (mut matrix, _stats) = table_bucket_full_flat(
             n_nodes,
             &mode_data.up_adj_flat,
             &mode_data.down_rev_flat,
             sources,
             targets,
         );
+
+        // Per-cell K-best fallback for INF cells.
+        if matrix.contains(&u32::MAX) {
+            use rayon::prelude::*;
+            let query = super::query::CchQuery::new(&state, mode);
+            let patches: Vec<(usize, u32)> = (0..client_valid.len())
+                .filter(|&ti| matrix[ti] == u32::MAX)
+                .collect::<Vec<_>>()
+                .par_iter()
+                .filter_map(|&ti| {
+                    let dst_ranks = &client_snaps[ti].ranks;
+                    super::snap_kbest::p2p_with_kbest_fallback(
+                        &query,
+                        &store_snap.ranks,
+                        dst_ranks,
+                        super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
+                    )
+                    .map(|(_, _, r)| (ti, r.distance))
+                })
+                .collect();
+            for (ti, dist) in patches {
+                matrix[ti] = dist;
+            }
+        }
 
         // Build Client structs with drive times
         let mut clients_with_dt: Vec<Client> = Vec::new();

--- a/route/src/server/exclude.rs
+++ b/route/src/server/exclude.rs
@@ -319,29 +319,38 @@ fn recustomize_weights_sparse_triangle(
 
     let mut up_weights = vec![u32::MAX; topo.up_targets.len()];
     let mut down_weights = vec![u32::MAX; topo.down_targets.len()];
+    let mut changed_up_edges: Vec<ChangedEdge> = Vec::new();
+    let mut changed_down_edges: Vec<ChangedEdge> = Vec::new();
 
-    // Bottom-up pass
+    // Bottom-up pass — collect changed edges as we go so the triangle
+    // relax pass 1 can iterate only those instead of sweeping every node.
     for rank in 0..n_nodes {
         let u = rank;
 
         // DOWN edges (sorted by target rank)
         for &i in &sorted_down_indices[u] {
             let v = topo.down_targets[i] as usize;
-            if !topo.down_is_shortcut.bit(i) {
+            let new_weight = if !topo.down_is_shortcut.bit(i) {
                 let v_filtered = topo.rank_to_filtered[v] as usize;
                 let v_orig = filtered_to_original[v_filtered] as usize;
-
                 if is_excluded(v_orig) {
-                    down_weights[i] = u32::MAX;
+                    u32::MAX
                 } else {
-                    down_weights[i] = base_weights.down[i];
+                    base_weights.down[i]
                 }
             } else {
                 let m = topo.down_middle[i] as usize;
                 let w_um =
                     find_edge_weight(u, m, &topo.down_offsets, &topo.down_targets, &down_weights);
                 let w_mv = find_edge_weight(m, v, &topo.up_offsets, &topo.up_targets, &up_weights);
-                down_weights[i] = w_um.saturating_add(w_mv);
+                w_um.saturating_add(w_mv)
+            };
+            down_weights[i] = new_weight;
+            if new_weight != base_weights.down[i] {
+                changed_down_edges.push(ChangedEdge {
+                    source: u as u32,
+                    target: v as u32,
+                });
             }
         }
 
@@ -350,24 +359,36 @@ fn recustomize_weights_sparse_triangle(
         let up_end = topo.up_offsets[u + 1] as usize;
         for i in up_start..up_end {
             let v = topo.up_targets[i] as usize;
-            if !topo.up_is_shortcut.bit(i) {
+            let new_weight = if !topo.up_is_shortcut.bit(i) {
                 let v_filtered = topo.rank_to_filtered[v] as usize;
                 let v_orig = filtered_to_original[v_filtered] as usize;
-
                 if is_excluded(v_orig) {
-                    up_weights[i] = u32::MAX;
+                    u32::MAX
                 } else {
-                    up_weights[i] = base_weights.up[i];
+                    base_weights.up[i]
                 }
             } else {
                 let m = topo.up_middle[i] as usize;
                 let w_um =
                     find_edge_weight(u, m, &topo.down_offsets, &topo.down_targets, &down_weights);
                 let w_mv = find_edge_weight(m, v, &topo.up_offsets, &topo.up_targets, &up_weights);
-                up_weights[i] = w_um.saturating_add(w_mv);
+                w_um.saturating_add(w_mv)
+            };
+            up_weights[i] = new_weight;
+            if new_weight != base_weights.up[i] {
+                changed_up_edges.push(ChangedEdge {
+                    source: u as u32,
+                    target: v as u32,
+                });
             }
         }
     }
+
+    tracing::debug!(
+        changed_up_edges = changed_up_edges.len(),
+        changed_down_edges = changed_down_edges.len(),
+        "sparse: bottom-up done, changed-edge set collected"
+    );
 
     // Build reverse DOWN adjacency for triangle relaxation
     let rev_down = build_reverse_down_adj(topo);
@@ -375,10 +396,11 @@ fn recustomize_weights_sparse_triangle(
     // Sparse triangle relaxation: only process dirty nodes
     sparse_triangle_relax(
         topo,
-        base_weights,
         &mut up_weights,
         &mut down_weights,
         &rev_down,
+        &changed_up_edges,
+        &changed_down_edges,
     );
 
     CchWeights {
@@ -389,172 +411,245 @@ fn recustomize_weights_sparse_triangle(
     }
 }
 
-/// Sparse triangle relaxation: only process nodes with changed edges.
+/// A weight that differs from base after the bottom-up customization
+/// pass. Collected during bottom-up so triangle relaxation can iterate
+/// only those edges instead of sweeping every node.
+#[derive(Clone, Copy, Debug)]
+struct ChangedEdge {
+    source: u32,
+    target: u32,
+}
+
+#[inline]
+fn push_dirty_once(dirty: &[AtomicBool], out: &mut Vec<usize>, node: usize) {
+    if !dirty[node].swap(true, Ordering::Relaxed) {
+        out.push(node);
+    }
+}
+
+#[inline]
+fn mark_potential_middles(
+    topo: &CchTopo,
+    dirty: &[AtomicBool],
+    out: &mut Vec<usize>,
+    x: usize,
+    y: usize,
+) {
+    let down_start = topo.down_offsets[x] as usize;
+    let down_end = topo.down_offsets[x + 1] as usize;
+    for &m_u32 in &topo.down_targets[down_start..down_end] {
+        let m = m_u32 as usize;
+        if m == y {
+            continue;
+        }
+        if find_edge_index(m, y, &topo.up_offsets, &topo.up_targets).is_some() {
+            push_dirty_once(dirty, out, m);
+        }
+    }
+}
+
+/// Sparse triangle relaxation. Pass 1's dirty set is bounded by the
+/// changed-edge list collected during bottom-up:
+///   (a) For each changed UP edge x→y: mark the SOURCE x dirty (the
+///       only m whose next-pass iteration reads w_xy as w_my).
+///   (b) For each changed DOWN edge x→y: mark the TARGET y dirty (the
+///       only m whose iteration reads w_xy as w_xm).
+///   (c) For each changed edge (x, y): enumerate potential middles m
+///       (DOWN neighbours of x that have a UP edge to y) and mark
+///       dirty[m]. This catches the "shortcut x→y went INF and the
+///       triangle that rescues it uses an m_alt with unchanged
+///       incident edges" case (#238).
 ///
-/// Initial dirty set: all nodes m where at least one incident edge weight
-/// differs from base. Subsequent passes only process nodes dirtied by updates.
+/// Subsequent passes use **one-sided** propagation. An improved UP
+/// edge x→y is consumed only by triangles centered at x. An improved
+/// DOWN edge x→y is consumed only by triangles centered at y. Marking
+/// both endpoints (as the earlier version did) doubles dirty-set churn
+/// for no correctness benefit.
 fn sparse_triangle_relax(
     topo: &CchTopo,
-    base_weights: &CchWeights,
     up_weights: &mut Vec<u32>,
     down_weights: &mut Vec<u32>,
     rev_down: &ReverseDownAdj,
+    changed_up_edges: &[ChangedEdge],
+    changed_down_edges: &[ChangedEdge],
 ) {
     let n_nodes = topo.n_nodes as usize;
 
-    // Convert to atomic arrays for lock-free parallel relaxation
     let atomic_up: Vec<AtomicU32> = up_weights.drain(..).map(AtomicU32::new).collect();
     let atomic_down: Vec<AtomicU32> = down_weights.drain(..).map(AtomicU32::new).collect();
 
-    // Build initial dirty set: nodes with at least one changed incident edge
     let dirty: Vec<AtomicBool> = (0..n_nodes).map(|_| AtomicBool::new(false)).collect();
 
-    // Check DOWN edges: if weight changed, mark both endpoints as dirty
-    (0..n_nodes).into_par_iter().for_each(|u| {
-        let start = topo.down_offsets[u] as usize;
-        let end = topo.down_offsets[u + 1] as usize;
-        for (aw, bw) in atomic_down[start..end]
-            .iter()
-            .zip(&base_weights.down[start..end])
-        {
-            let w = aw.load(Ordering::Relaxed);
-            if w != *bw {
-                dirty[u].store(true, Ordering::Relaxed);
-                break;
-            }
-        }
-        for (idx, aw) in atomic_down[start..end].iter().enumerate() {
-            let w = aw.load(Ordering::Relaxed);
-            if w != base_weights.down[start + idx] {
-                let m = topo.down_targets[start + idx] as usize;
-                dirty[m].store(true, Ordering::Relaxed);
-            }
-        }
-    });
-    // Check UP edges: if weight changed, mark both endpoints as dirty
-    (0..n_nodes).into_par_iter().for_each(|u| {
-        let up_start = topo.up_offsets[u] as usize;
-        let up_end = topo.up_offsets[u + 1] as usize;
-        for (aw, bw) in atomic_up[up_start..up_end]
-            .iter()
-            .zip(&base_weights.up[up_start..up_end])
-        {
-            let w = aw.load(Ordering::Relaxed);
-            if w != *bw {
-                dirty[u].store(true, Ordering::Relaxed);
-                break;
-            }
-        }
-        for (idx, aw) in atomic_up[up_start..up_end].iter().enumerate() {
-            let w = aw.load(Ordering::Relaxed);
-            if w != base_weights.up[up_start + idx] {
-                let v = topo.up_targets[up_start + idx] as usize;
-                dirty[v].store(true, Ordering::Relaxed);
-            }
-        }
-    });
+    // Build the initial dirty set as an actual Vec (not a bitvector
+    // scan) so subsequent passes don't pay O(n_nodes) to enumerate it.
+    let mut dirty_nodes: Vec<usize> = Vec::new();
 
-    let initial_dirty: usize = dirty.iter().filter(|d| d.load(Ordering::Relaxed)).count();
+    // (a) Per-edge apex marking. For changed UP edges, that's the source;
+    // for changed DOWN edges, that's the target.
+    let from_up: Vec<usize> = changed_up_edges
+        .par_iter()
+        .fold(Vec::new, |mut local, edge| {
+            push_dirty_once(&dirty, &mut local, edge.source as usize);
+            local
+        })
+        .reduce(Vec::new, |mut a, mut b| {
+            a.append(&mut b);
+            a
+        });
+    let from_down: Vec<usize> = changed_down_edges
+        .par_iter()
+        .fold(Vec::new, |mut local, edge| {
+            push_dirty_once(&dirty, &mut local, edge.target as usize);
+            local
+        })
+        .reduce(Vec::new, |mut a, mut b| {
+            a.append(&mut b);
+            a
+        });
+    dirty_nodes.extend(from_up);
+    dirty_nodes.extend(from_down);
+
+    // (b) Potential middles per changed edge. Bounded by O(changed × deg).
+    let middles_up: Vec<usize> = changed_up_edges
+        .par_iter()
+        .fold(Vec::new, |mut local, edge| {
+            mark_potential_middles(
+                topo,
+                &dirty,
+                &mut local,
+                edge.source as usize,
+                edge.target as usize,
+            );
+            local
+        })
+        .reduce(Vec::new, |mut a, mut b| {
+            a.append(&mut b);
+            a
+        });
+    let middles_down: Vec<usize> = changed_down_edges
+        .par_iter()
+        .fold(Vec::new, |mut local, edge| {
+            mark_potential_middles(
+                topo,
+                &dirty,
+                &mut local,
+                edge.source as usize,
+                edge.target as usize,
+            );
+            local
+        })
+        .reduce(Vec::new, |mut a, mut b| {
+            a.append(&mut b);
+            a
+        });
+    dirty_nodes.extend(middles_up);
+    dirty_nodes.extend(middles_down);
+
     tracing::debug!(
-        dirty_nodes = initial_dirty,
+        changed_up_edges = changed_up_edges.len(),
+        changed_down_edges = changed_down_edges.len(),
+        dirty_nodes = dirty_nodes.len(),
         total_nodes = n_nodes,
         "sparse triangle relax: initial dirty set"
     );
 
     let mut pass = 0u32;
-    loop {
+    while !dirty_nodes.is_empty() {
         pass += 1;
 
-        // Collect dirty nodes for this pass
-        let dirty_nodes: Vec<usize> = dirty
-            .iter()
-            .enumerate()
-            .filter(|(_, d)| d.load(Ordering::Relaxed))
-            .map(|(i, _)| i)
-            .collect();
-
-        if dirty_nodes.is_empty() {
-            break;
-        }
-
-        // Clear dirty flags for this pass
+        // Clear dirty flags so the next pass's per-edge marks can
+        // detect "already enqueued for this pass" via swap.
         dirty_nodes
             .par_iter()
             .for_each(|&m| dirty[m].store(false, Ordering::Relaxed));
 
         let pass_updates = AtomicU64::new(0);
 
-        dirty_nodes.par_iter().for_each(|&m| {
-            let rev_start = rev_down.offsets[m] as usize;
-            let rev_end = rev_down.offsets[m + 1] as usize;
+        let next_dirty_nodes: Vec<usize> = dirty_nodes
+            .par_iter()
+            .fold(Vec::new, |mut next_dirty, &m| {
+                let rev_start = rev_down.offsets[m] as usize;
+                let rev_end = rev_down.offsets[m + 1] as usize;
 
-            for i_rev in rev_start..rev_end {
-                let x = rev_down.sources[i_rev] as usize;
-                let edge_idx_xm = rev_down.edge_idx[i_rev];
-                let w_xm = atomic_down[edge_idx_xm].load(Ordering::Relaxed);
+                for i_rev in rev_start..rev_end {
+                    let x = rev_down.sources[i_rev] as usize;
+                    let edge_idx_xm = rev_down.edge_idx[i_rev];
+                    let w_xm = atomic_down[edge_idx_xm].load(Ordering::Relaxed);
 
-                if w_xm == u32::MAX {
-                    continue;
-                }
-
-                let up_start = topo.up_offsets[m] as usize;
-                let up_end = topo.up_offsets[m + 1] as usize;
-
-                for i_my in up_start..up_end {
-                    let y = topo.up_targets[i_my] as usize;
-                    if y == x {
+                    if w_xm == u32::MAX {
                         continue;
                     }
 
-                    let w_my = atomic_up[i_my].load(Ordering::Relaxed);
-                    if w_my == u32::MAX {
-                        continue;
-                    }
+                    let up_start = topo.up_offsets[m] as usize;
+                    let up_end = topo.up_offsets[m + 1] as usize;
 
-                    let new_weight = w_xm.saturating_add(w_my);
-
-                    if y > x {
-                        // UP edge from x to y
-                        if let Some(idx) = find_edge_index(x, y, &topo.up_offsets, &topo.up_targets)
-                        {
-                            let old = atomic_up[idx].fetch_min(new_weight, Ordering::Relaxed);
-                            if new_weight < old {
-                                pass_updates.fetch_add(1, Ordering::Relaxed);
-                                // Both endpoints: x is middle for a→x→y triangles,
-                                // y is middle for x→y→b triangles (as DOWN from y)
-                                dirty[x].store(true, Ordering::Relaxed);
-                                dirty[y].store(true, Ordering::Relaxed);
-                            }
+                    for i_my in up_start..up_end {
+                        let y = topo.up_targets[i_my] as usize;
+                        if y == x {
+                            continue;
                         }
-                    } else {
-                        // DOWN edge from x to y
-                        if let Some(idx) =
+
+                        let w_my = atomic_up[i_my].load(Ordering::Relaxed);
+                        if w_my == u32::MAX {
+                            continue;
+                        }
+
+                        let new_weight = w_xm.saturating_add(w_my);
+
+                        if y > x {
+                            if let Some(idx) =
+                                find_edge_index(x, y, &topo.up_offsets, &topo.up_targets)
+                            {
+                                let old = atomic_up[idx].fetch_min(new_weight, Ordering::Relaxed);
+                                if new_weight < old {
+                                    pass_updates.fetch_add(1, Ordering::Relaxed);
+                                    // Improved UP x→y is consumed only by triangles
+                                    // centered at x. One-sided propagation.
+                                    push_dirty_once(&dirty, &mut next_dirty, x);
+                                }
+                            }
+                        } else if let Some(idx) =
                             find_edge_index(x, y, &topo.down_offsets, &topo.down_targets)
                         {
                             let old = atomic_down[idx].fetch_min(new_weight, Ordering::Relaxed);
                             if new_weight < old {
                                 pass_updates.fetch_add(1, Ordering::Relaxed);
-                                // Both endpoints: y is middle for x→y→b triangles,
-                                // x is middle for a→x→y triangles (as DOWN from x)
-                                dirty[x].store(true, Ordering::Relaxed);
-                                dirty[y].store(true, Ordering::Relaxed);
+                                // Improved DOWN x→y is consumed only by triangles
+                                // centered at y. One-sided propagation.
+                                push_dirty_once(&dirty, &mut next_dirty, y);
                             }
                         }
                     }
                 }
-            }
-        });
+                next_dirty
+            })
+            .reduce(Vec::new, |mut a, mut b| {
+                a.append(&mut b);
+                a
+            });
 
         let pu = pass_updates.into_inner();
         tracing::debug!(
             pass,
             updates = pu,
             dirty_nodes = dirty_nodes.len(),
+            next_dirty_nodes = next_dirty_nodes.len(),
             "sparse triangle relaxation"
         );
-        if pu == 0 || pass >= 50 {
+        if pu == 0 {
             break;
         }
+        if pass >= 50 {
+            tracing::warn!(
+                pass,
+                updates = pu,
+                "sparse triangle relaxation hit 50-pass cap without converging — \
+                 weights may still be improvable; falling through with current state"
+            );
+            break;
+        }
+
+        dirty_nodes = next_dirty_nodes;
     }
 
     *up_weights = atomic_up.into_iter().map(AtomicU32::into_inner).collect();
@@ -803,7 +898,16 @@ fn triangle_relax(
 
         let pu = pass_updates.into_inner();
         tracing::debug!(pass, updates = pu, "exclude triangle relaxation");
-        if pu == 0 || pass >= 50 {
+        if pu == 0 {
+            break;
+        }
+        if pass >= 50 {
+            tracing::warn!(
+                pass,
+                updates = pu,
+                "full triangle relaxation hit 50-pass cap without converging — \
+                 weights may still be improvable; falling through with current state"
+            );
             break;
         }
     }

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -244,71 +244,6 @@ struct MatrixParams {
     radius_km: Option<serde_json::Value>,
 }
 
-/// Snap coordinates to ranks, returning (ranks, valid_indices).
-///
-/// `role` controls the #197 directional snap filter:
-///   * `SnapRole::Src` — sources / origins (must have a mode-valid outbound arc)
-///   * `SnapRole::Dst` — destinations / targets (must have a mode-valid inbound arc)
-///   * `SnapRole::Either` — legacy unfiltered snap (no role constraint)
-fn snap_to_ranks(
-    coords: &[[f64; 2]],
-    state: &ServerState,
-    mode_idx: u8,
-    mode_data: &super::state::ModeData,
-    role: super::types::SnapRole,
-) -> (Vec<u32>, Vec<usize>) {
-    let role_filter = role.role_filter(mode_data);
-    let mut ranks = Vec::with_capacity(coords.len());
-    let mut valid = Vec::with_capacity(coords.len());
-    for (i, [lon, lat]) in coords.iter().enumerate() {
-        if let Some(orig_id) =
-            state
-                .snap_index
-                .snap_filtered_role(*lon, *lat, mode_idx, None, role_filter)
-        {
-            let rank = mode_data.orig_to_rank[orig_id as usize];
-            if rank != u32::MAX {
-                ranks.push(rank);
-                valid.push(i);
-            }
-        }
-    }
-    (ranks, valid)
-}
-
-/// Build a full-length (n = coords.len()) snapped coordinate vector. Points
-/// that fail to snap keep their original lon/lat — they will still be marked
-/// invalid in the matrix, but having them in the vector keeps indexing
-/// straightforward for the Euclidean pre-filter.
-///
-/// `role` controls the #197 directional snap filter (see [`snap_to_ranks`]).
-fn snapped_coords_full(
-    coords: &[[f64; 2]],
-    state: &ServerState,
-    mode_idx: u8,
-    mode_data: &super::state::ModeData,
-    role: super::types::SnapRole,
-) -> Vec<(f64, f64)> {
-    let role_filter = role.role_filter(mode_data);
-    let mut out = Vec::with_capacity(coords.len());
-    for [lon, lat] in coords {
-        if let Some(orig_id) =
-            state
-                .snap_index
-                .snap_filtered_role(*lon, *lat, mode_idx, None, role_filter)
-        {
-            let rank = mode_data.orig_to_rank[orig_id as usize];
-            if rank != u32::MAX {
-                let loc = super::types::get_node_location(state, orig_id);
-                out.push((loc[0], loc[1]));
-                continue;
-            }
-        }
-        out.push((*lon, *lat));
-    }
-    out
-}
-
 /// Build matrix RecordBatch from flat u32 distances.
 #[allow(clippy::too_many_arguments)]
 fn build_matrix_batch(
@@ -376,32 +311,87 @@ fn do_matrix(
     let n_nodes = mode_data.cch_topo.n_nodes as usize;
 
     use super::types::SnapRole;
-    let (sources_rank, valid_src) =
-        snap_to_ranks(&params.sources, state, mode.0, mode_data, SnapRole::Src);
-    let (targets_rank, valid_dst) = snap_to_ranks(
-        &params.destinations,
-        state,
-        mode.0,
-        mode_data,
-        SnapRole::Dst,
-    );
+    // K-best snap candidates per src/dst with directional role + the
+    // SCC-aware connectivity filter (via mode_data.has_outbound /
+    // has_inbound). The first candidate per slot feeds the bucket
+    // M2M primary pass; the rest power the per-cell P2P fallback for
+    // INF cells in the small-matrix branch below.
+    const SNAP_K: usize = 64;
+    let src_kbest: Vec<super::snap_kbest::KBestSnap> = params
+        .sources
+        .iter()
+        .map(|&[lon, lat]| {
+            super::snap_kbest::snap_k_pair_role(
+                state,
+                mode_data,
+                mode,
+                lon,
+                lat,
+                SnapRole::Src,
+                None,
+                SNAP_K,
+            )
+        })
+        .collect();
+    let dst_kbest: Vec<super::snap_kbest::KBestSnap> = params
+        .destinations
+        .iter()
+        .map(|&[lon, lat]| {
+            super::snap_kbest::snap_k_pair_role(
+                state,
+                mode_data,
+                mode,
+                lon,
+                lat,
+                SnapRole::Dst,
+                None,
+                SNAP_K,
+            )
+        })
+        .collect();
+
+    let mut sources_rank = Vec::with_capacity(params.sources.len());
+    let mut valid_src = Vec::with_capacity(params.sources.len());
+    let mut sources_snapped = Vec::with_capacity(params.sources.len());
+    for (i, snap) in src_kbest.iter().enumerate() {
+        if let Some(r) = snap.primary_rank() {
+            sources_rank.push(r);
+            valid_src.push(i);
+            if let Some((_, plon, plat, _)) = snap.primary {
+                sources_snapped.push((plon, plat));
+            } else {
+                let [lon, lat] = params.sources[i];
+                sources_snapped.push((lon, lat));
+            }
+        } else {
+            let [lon, lat] = params.sources[i];
+            sources_snapped.push((lon, lat));
+        }
+    }
+    let mut targets_rank = Vec::with_capacity(params.destinations.len());
+    let mut valid_dst = Vec::with_capacity(params.destinations.len());
+    let mut targets_snapped = Vec::with_capacity(params.destinations.len());
+    for (i, snap) in dst_kbest.iter().enumerate() {
+        if let Some(r) = snap.primary_rank() {
+            targets_rank.push(r);
+            valid_dst.push(i);
+            if let Some((_, plon, plat, _)) = snap.primary {
+                targets_snapped.push((plon, plat));
+            } else {
+                let [lon, lat] = params.destinations[i];
+                targets_snapped.push((lon, lat));
+            }
+        } else {
+            let [lon, lat] = params.destinations[i];
+            targets_snapped.push((lon, lat));
+        }
+    }
 
     if sources_rank.is_empty() || targets_rank.is_empty() {
         let schema = Arc::new(matrix_schema());
         let empty = RecordBatch::new_empty(schema);
         return Ok(Box::pin(stream::once(async move { Ok(empty) })));
     }
-
-    // Full-length snapped coordinates — for the Euclidean pre-filter.
-    let sources_snapped =
-        snapped_coords_full(&params.sources, state, mode.0, mode_data, SnapRole::Src);
-    let targets_snapped = snapped_coords_full(
-        &params.destinations,
-        state,
-        mode.0,
-        mode_data,
-        SnapRole::Dst,
-    );
 
     let radius_param = parse_radius(params.radius_km.as_ref());
     let neighbor_mask: Option<Arc<Vec<Vec<u32>>>> = match radius_param {
@@ -438,11 +428,49 @@ fn do_matrix(
         let up = &mode_data.up_adj_flat;
         let down = &mode_data.down_rev_flat;
 
-        let (matrix, _stats) = if use_parallel {
+        let (mut matrix, _stats) = if use_parallel {
             table_bucket_parallel(n_nodes, up, down, &sources_rank, &targets_rank)
         } else {
             table_bucket_full_flat(n_nodes, up, down, &sources_rank, &targets_rank)
         };
+
+        // Per-cell K-best fallback for INF cells (mirrors /table POST).
+        // With SCC-aware role masks this is now a rare per-cell rescue
+        // for geometric-ambiguity / dynamic-recustomisation pairs.
+        if matrix.contains(&u32::MAX) {
+            use rayon::prelude::*;
+            let query = super::query::CchQuery::new(state, mode);
+
+            // Map back from matrix index (over valid src/dst) to the
+            // original src/dst index so we can look up the K-best ranks.
+            let mut work: Vec<(usize, usize)> = Vec::new();
+            for (i, _) in valid_src.iter().enumerate() {
+                for (j, _) in valid_dst.iter().enumerate() {
+                    if matrix[i * n_valid_dst + j] == u32::MAX {
+                        work.push((i, j));
+                    }
+                }
+            }
+            let patches: Vec<(usize, usize, u32)> = work
+                .par_iter()
+                .filter_map(|&(i, j)| {
+                    let src_orig_idx = valid_src[i];
+                    let dst_orig_idx = valid_dst[j];
+                    let src_ranks = &src_kbest[src_orig_idx].ranks;
+                    let dst_ranks = &dst_kbest[dst_orig_idx].ranks;
+                    super::snap_kbest::p2p_with_kbest_fallback(
+                        &query,
+                        src_ranks,
+                        dst_ranks,
+                        super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
+                    )
+                    .map(|(_, _, r)| (i, j, r.distance))
+                })
+                .collect();
+            for (i, j, dist) in patches {
+                matrix[i * n_valid_dst + j] = dist;
+            }
+        }
 
         let schema = Arc::new(matrix_schema());
         let batch = build_matrix_batch(
@@ -615,6 +643,13 @@ fn do_route_batch(
             let mut dist_arr = Float32Builder::with_capacity(n);
             let mut geom_arr = BinaryBuilder::with_capacity(n, n * 256);
 
+            // K-best snap + bounded combo fallback (mirrors /route).
+            // The connectivity-aware role masks already eliminate most
+            // snap traps; the fallback now only catches same-geometry
+            // directional ambiguity and exclude/avoid edge cases.
+            const SNAP_K: usize = 64;
+            let query = CchQuery::new(&state, mode);
+
             for pair in chunk {
                 let (slon, slat, dlon, dlat) = (pair[0], pair[1], pair[2], pair[3]);
                 src_lon_arr.append_value(slon);
@@ -622,73 +657,70 @@ fn do_route_batch(
                 dst_lon_arr.append_value(dlon);
                 dst_lat_arr.append_value(dlat);
 
-                let src_snap = state.snap_index.snap_filtered_role(
+                let src_snap = super::snap_kbest::snap_k_pair_role(
+                    &state,
+                    mode_data,
+                    mode,
                     slon,
                     slat,
-                    mode.0,
+                    super::types::SnapRole::Src,
                     None,
-                    super::types::SnapRole::Src.role_filter(mode_data),
+                    SNAP_K,
                 );
-                let dst_snap = state.snap_index.snap_filtered_role(
+                let dst_snap = super::snap_kbest::snap_k_pair_role(
+                    &state,
+                    mode_data,
+                    mode,
                     dlon,
                     dlat,
-                    mode.0,
+                    super::types::SnapRole::Dst,
                     None,
-                    super::types::SnapRole::Dst.role_filter(mode_data),
+                    SNAP_K,
                 );
 
-                match (src_snap, dst_snap) {
-                    (Some(src_orig), Some(dst_orig)) => {
-                        let src_rank = mode_data.orig_to_rank[src_orig as usize];
-                        let dst_rank = mode_data.orig_to_rank[dst_orig as usize];
+                if src_snap.ranks.is_empty() || dst_snap.ranks.is_empty() {
+                    dur_arr.append_value(f32::NAN);
+                    dist_arr.append_value(f32::NAN);
+                    geom_arr.append_value(&[] as &[u8]);
+                    continue;
+                }
 
-                        if src_rank == u32::MAX || dst_rank == u32::MAX {
-                            dur_arr.append_value(f32::NAN);
-                            dist_arr.append_value(f32::NAN);
-                            geom_arr.append_value(&[] as &[u8]);
-                            continue;
-                        }
+                match super::snap_kbest::p2p_with_kbest_fallback(
+                    &query,
+                    &src_snap.ranks,
+                    &dst_snap.ranks,
+                    super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
+                ) {
+                    Some((src_rank, dst_rank, result)) => {
+                        let duration_s = result.distance as f64 / 10.0;
 
-                        let query = CchQuery::new(&state, mode);
-                        match query.query(src_rank, dst_rank) {
-                            Some(result) => {
-                                let duration_s = result.distance as f64 / 10.0;
+                        let rank_path = unpack_path(
+                            &mode_data.cch_topo,
+                            &mode_data.cch_weights,
+                            &result.forward_parent,
+                            &result.backward_parent,
+                            src_rank,
+                            dst_rank,
+                            result.meeting_node,
+                        );
+                        let ebg_path: Vec<u32> = rank_path
+                            .iter()
+                            .map(|&rank| {
+                                let filt_id = mode_data.cch_topo.rank_to_filtered[rank as usize];
+                                mode_data.filtered_to_original[filt_id as usize]
+                            })
+                            .collect();
 
-                                let rank_path = unpack_path(
-                                    &mode_data.cch_topo,
-                                    &mode_data.cch_weights,
-                                    &result.forward_parent,
-                                    &result.backward_parent,
-                                    src_rank,
-                                    dst_rank,
-                                    result.meeting_node,
-                                );
-                                let ebg_path: Vec<u32> = rank_path
-                                    .iter()
-                                    .map(|&rank| {
-                                        let filt_id =
-                                            mode_data.cch_topo.rank_to_filtered[rank as usize];
-                                        mode_data.filtered_to_original[filt_id as usize]
-                                    })
-                                    .collect();
+                        let (points, distance_m) =
+                            build_raw_points(&ebg_path, &state.ebg_nodes, &state.edge_geom);
 
-                                let (points, distance_m) =
-                                    build_raw_points(&ebg_path, &state.ebg_nodes, &state.edge_geom);
+                        let wkb = encode_linestring_wkb(&points);
 
-                                let wkb = encode_linestring_wkb(&points);
-
-                                dur_arr.append_value(duration_s as f32);
-                                dist_arr.append_value(distance_m as f32);
-                                geom_arr.append_value(&wkb);
-                            }
-                            None => {
-                                dur_arr.append_value(f32::NAN);
-                                dist_arr.append_value(f32::NAN);
-                                geom_arr.append_value(&[] as &[u8]);
-                            }
-                        }
+                        dur_arr.append_value(duration_s as f32);
+                        dist_arr.append_value(distance_m as f32);
+                        geom_arr.append_value(&wkb);
                     }
-                    _ => {
+                    None => {
                         dur_arr.append_value(f32::NAN);
                         dist_arr.append_value(f32::NAN);
                         geom_arr.append_value(&[] as &[u8]);
@@ -954,38 +986,32 @@ pub fn do_edges_batch(
                         dist_m_b.append_null();
                     };
 
-                // Snap both endpoints on the requested mode's network.
-                // #197: src needs has_outbound, dst needs has_inbound.
-                let src_snap = state.snap_index.snap_filtered_role(
+                // K-best snap + bounded combo fallback for the residual
+                // geometric-ambiguity / dynamic-recustomisation cases.
+                // The connectivity-aware role masks already drop
+                // disconnected-component snap traps before we get here.
+                const SNAP_K: usize = 64;
+                let src_snap = super::snap_kbest::snap_k_pair_role(
+                    &state,
+                    mode_data,
+                    mode,
                     pair[0],
                     pair[1],
-                    mode.0,
+                    super::types::SnapRole::Src,
                     None,
-                    super::types::SnapRole::Src.role_filter(mode_data),
+                    SNAP_K,
                 );
-                let dst_snap = state.snap_index.snap_filtered_role(
+                let dst_snap = super::snap_kbest::snap_k_pair_role(
+                    &state,
+                    mode_data,
+                    mode,
                     pair[2],
                     pair[3],
-                    mode.0,
+                    super::types::SnapRole::Dst,
                     None,
-                    super::types::SnapRole::Dst.role_filter(mode_data),
+                    SNAP_K,
                 );
-                let (Some(src_orig), Some(dst_orig)) = (src_snap, dst_snap) else {
-                    emit_unreachable(
-                        &mut query_idx_b,
-                        &mut target_idx_b,
-                        &mut edge_seq_b,
-                        &mut osm_from_b,
-                        &mut osm_to_b,
-                        &mut dur_ms_b,
-                        &mut dist_m_b,
-                    );
-                    continue;
-                };
-
-                let src_rank = mode_data.orig_to_rank[src_orig as usize];
-                let dst_rank = mode_data.orig_to_rank[dst_orig as usize];
-                if src_rank == u32::MAX || dst_rank == u32::MAX {
+                if src_snap.ranks.is_empty() || dst_snap.ranks.is_empty() {
                     emit_unreachable(
                         &mut query_idx_b,
                         &mut target_idx_b,
@@ -1007,7 +1033,12 @@ pub fn do_edges_batch(
                     &mode_data.down_rev_flat,
                     &mode_data.cch_weights,
                 );
-                let Some(result) = query.query(src_rank, dst_rank) else {
+                let Some((src_rank, dst_rank, result)) = super::snap_kbest::p2p_with_kbest_fallback(
+                    &query,
+                    &src_snap.ranks,
+                    &dst_snap.ranks,
+                    super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
+                ) else {
                     emit_unreachable(
                         &mut query_idx_b,
                         &mut target_idx_b,
@@ -1468,35 +1499,45 @@ async fn do_exchange_catchment(
                 continue;
             }
 
-            // Snap store as source (drive-time FROM store) — #197 Src role.
-            let store_role = super::types::SnapRole::Src.role_filter(mode_data);
-            let client_role = super::types::SnapRole::Dst.role_filter(mode_data);
-            let store_snap = state
-                .snap_index
-                .snap_filtered_role(*slon, *slat, mode.0, None, store_role);
-            let store_orig = match store_snap {
-                Some(id) => id,
+            // K-best snap store as source (#197 Src role).
+            const SNAP_K: usize = 64;
+            let store_snap = super::snap_kbest::snap_k_pair_role(
+                &state,
+                mode_data,
+                mode,
+                *slon,
+                *slat,
+                super::types::SnapRole::Src,
+                None,
+                SNAP_K,
+            );
+            let store_rank = match store_snap.primary_rank() {
+                Some(r) => r,
                 None => continue,
             };
-            let store_rank = mode_data.orig_to_rank[store_orig as usize];
-            if store_rank == u32::MAX {
-                continue;
-            }
 
-            // Snap all clients as destinations — #197 Dst role.
+            // K-best snap all clients as destinations (#197 Dst role).
+            let client_snaps: Vec<super::snap_kbest::KBestSnap> = client_coords
+                .iter()
+                .map(|&(clon, clat)| {
+                    super::snap_kbest::snap_k_pair_role(
+                        &state,
+                        mode_data,
+                        mode,
+                        clon,
+                        clat,
+                        super::types::SnapRole::Dst,
+                        None,
+                        SNAP_K,
+                    )
+                })
+                .collect();
             let mut client_ranks: Vec<u32> = Vec::with_capacity(client_coords.len());
             let mut client_valid: Vec<usize> = Vec::with_capacity(client_coords.len());
-            for (ci, &(clon, clat)) in client_coords.iter().enumerate() {
-                if let Some(orig_id) =
-                    state
-                        .snap_index
-                        .snap_filtered_role(clon, clat, mode.0, None, client_role)
-                {
-                    let rank = mode_data.orig_to_rank[orig_id as usize];
-                    if rank != u32::MAX {
-                        client_ranks.push(rank);
-                        client_valid.push(ci);
-                    }
+            for (ci, snap) in client_snaps.iter().enumerate() {
+                if let Some(r) = snap.primary_rank() {
+                    client_ranks.push(r);
+                    client_valid.push(ci);
                 }
             }
 
@@ -1505,13 +1546,38 @@ async fn do_exchange_catchment(
             }
 
             // 1-to-N matrix
-            let (matrix, _stats) = table_bucket_full_flat(
+            let (mut matrix, _stats) = table_bucket_full_flat(
                 n_nodes,
                 &mode_data.up_adj_flat,
                 &mode_data.down_rev_flat,
                 &[store_rank],
                 &client_ranks,
             );
+
+            // Per-cell K-best fallback for INF cells (mirrors /table POST).
+            if matrix.contains(&u32::MAX) {
+                use rayon::prelude::*;
+                let query = super::query::CchQuery::new(&state, mode);
+                let patches: Vec<(usize, u32)> = (0..client_valid.len())
+                    .filter(|&ti| matrix[ti] == u32::MAX)
+                    .collect::<Vec<_>>()
+                    .par_iter()
+                    .filter_map(|&ti| {
+                        let ci = client_valid[ti];
+                        let dst_ranks = &client_snaps[ci].ranks;
+                        super::snap_kbest::p2p_with_kbest_fallback(
+                            &query,
+                            &store_snap.ranks,
+                            dst_ranks,
+                            super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
+                        )
+                        .map(|(_, _, r)| (ti, r.distance))
+                    })
+                    .collect();
+                for (ti, dist) in patches {
+                    matrix[ti] = dist;
+                }
+            }
 
             let mut clients_with_dt: Vec<super::catchment::Client> = Vec::new();
             for (ti, &ci) in client_valid.iter().enumerate() {

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -317,9 +317,10 @@ fn do_matrix(
     // M2M primary pass; the rest power the per-cell P2P fallback for
     // INF cells in the small-matrix branch below.
     const SNAP_K: usize = 64;
+    use rayon::prelude::*;
     let src_kbest: Vec<super::snap_kbest::KBestSnap> = params
         .sources
-        .iter()
+        .par_iter()
         .map(|&[lon, lat]| {
             super::snap_kbest::snap_k_pair_role(
                 state,
@@ -335,7 +336,7 @@ fn do_matrix(
         .collect();
     let dst_kbest: Vec<super::snap_kbest::KBestSnap> = params
         .destinations
-        .iter()
+        .par_iter()
         .map(|&[lon, lat]| {
             super::snap_kbest::snap_k_pair_role(
                 state,

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -245,16 +245,27 @@ struct MatrixParams {
 }
 
 /// Snap coordinates to ranks, returning (ranks, valid_indices).
+///
+/// `role` controls the #197 directional snap filter:
+///   * `SnapRole::Src` — sources / origins (must have a mode-valid outbound arc)
+///   * `SnapRole::Dst` — destinations / targets (must have a mode-valid inbound arc)
+///   * `SnapRole::Either` — legacy unfiltered snap (no role constraint)
 fn snap_to_ranks(
     coords: &[[f64; 2]],
     state: &ServerState,
     mode_idx: u8,
     mode_data: &super::state::ModeData,
+    role: super::types::SnapRole,
 ) -> (Vec<u32>, Vec<usize>) {
+    let role_filter = role.role_filter(mode_data);
     let mut ranks = Vec::with_capacity(coords.len());
     let mut valid = Vec::with_capacity(coords.len());
     for (i, [lon, lat]) in coords.iter().enumerate() {
-        if let Some(orig_id) = state.snap_index.snap(*lon, *lat, mode_idx) {
+        if let Some(orig_id) =
+            state
+                .snap_index
+                .snap_filtered_role(*lon, *lat, mode_idx, None, role_filter)
+        {
             let rank = mode_data.orig_to_rank[orig_id as usize];
             if rank != u32::MAX {
                 ranks.push(rank);
@@ -269,15 +280,23 @@ fn snap_to_ranks(
 /// that fail to snap keep their original lon/lat — they will still be marked
 /// invalid in the matrix, but having them in the vector keeps indexing
 /// straightforward for the Euclidean pre-filter.
+///
+/// `role` controls the #197 directional snap filter (see [`snap_to_ranks`]).
 fn snapped_coords_full(
     coords: &[[f64; 2]],
     state: &ServerState,
     mode_idx: u8,
     mode_data: &super::state::ModeData,
+    role: super::types::SnapRole,
 ) -> Vec<(f64, f64)> {
+    let role_filter = role.role_filter(mode_data);
     let mut out = Vec::with_capacity(coords.len());
     for [lon, lat] in coords {
-        if let Some(orig_id) = state.snap_index.snap(*lon, *lat, mode_idx) {
+        if let Some(orig_id) =
+            state
+                .snap_index
+                .snap_filtered_role(*lon, *lat, mode_idx, None, role_filter)
+        {
             let rank = mode_data.orig_to_rank[orig_id as usize];
             if rank != u32::MAX {
                 let loc = super::types::get_node_location(state, orig_id);
@@ -356,8 +375,16 @@ fn do_matrix(
     let mode_data = state.get_mode(mode);
     let n_nodes = mode_data.cch_topo.n_nodes as usize;
 
-    let (sources_rank, valid_src) = snap_to_ranks(&params.sources, state, mode.0, mode_data);
-    let (targets_rank, valid_dst) = snap_to_ranks(&params.destinations, state, mode.0, mode_data);
+    use super::types::SnapRole;
+    let (sources_rank, valid_src) =
+        snap_to_ranks(&params.sources, state, mode.0, mode_data, SnapRole::Src);
+    let (targets_rank, valid_dst) = snap_to_ranks(
+        &params.destinations,
+        state,
+        mode.0,
+        mode_data,
+        SnapRole::Dst,
+    );
 
     if sources_rank.is_empty() || targets_rank.is_empty() {
         let schema = Arc::new(matrix_schema());
@@ -366,8 +393,15 @@ fn do_matrix(
     }
 
     // Full-length snapped coordinates — for the Euclidean pre-filter.
-    let sources_snapped = snapped_coords_full(&params.sources, state, mode.0, mode_data);
-    let targets_snapped = snapped_coords_full(&params.destinations, state, mode.0, mode_data);
+    let sources_snapped =
+        snapped_coords_full(&params.sources, state, mode.0, mode_data, SnapRole::Src);
+    let targets_snapped = snapped_coords_full(
+        &params.destinations,
+        state,
+        mode.0,
+        mode_data,
+        SnapRole::Dst,
+    );
 
     let radius_param = parse_radius(params.radius_km.as_ref());
     let neighbor_mask: Option<Arc<Vec<Vec<u32>>>> = match radius_param {
@@ -588,8 +622,20 @@ fn do_route_batch(
                 dst_lon_arr.append_value(dlon);
                 dst_lat_arr.append_value(dlat);
 
-                let src_snap = state.snap_index.snap(slon, slat, mode.0);
-                let dst_snap = state.snap_index.snap(dlon, dlat, mode.0);
+                let src_snap = state.snap_index.snap_filtered_role(
+                    slon,
+                    slat,
+                    mode.0,
+                    None,
+                    super::types::SnapRole::Src.role_filter(mode_data),
+                );
+                let dst_snap = state.snap_index.snap_filtered_role(
+                    dlon,
+                    dlat,
+                    mode.0,
+                    None,
+                    super::types::SnapRole::Dst.role_filter(mode_data),
+                );
 
                 match (src_snap, dst_snap) {
                     (Some(src_orig), Some(dst_orig)) => {
@@ -718,9 +764,23 @@ fn do_isochrone(
     let mode_data = state.get_mode(mode);
     let mode_name = &state.mode_names[mode.index()];
 
+    let is_reverse = params.direction.to_lowercase() == "arrive";
+    // #197 directional snap: depart → center is a source (needs outbound),
+    // arrive → center is a destination (needs inbound).
+    let center_role = if is_reverse {
+        super::types::SnapRole::Dst
+    } else {
+        super::types::SnapRole::Src
+    };
     let orig_id = state
         .snap_index
-        .snap(params.lon, params.lat, mode.0)
+        .snap_filtered_role(
+            params.lon,
+            params.lat,
+            mode.0,
+            None,
+            center_role.role_filter(mode_data),
+        )
         .ok_or_else(|| Status::not_found("Could not snap to road network"))?;
     let origin_rank = mode_data.orig_to_rank[orig_id as usize];
     if origin_rank == u32::MAX {
@@ -728,8 +788,6 @@ fn do_isochrone(
             "Snapped node not accessible for this mode",
         ));
     }
-
-    let is_reverse = params.direction.to_lowercase() == "arrive";
     let max_interval = *params.intervals.iter().max().unwrap();
     let max_threshold_ds = max_interval * 10;
 
@@ -897,8 +955,21 @@ pub fn do_edges_batch(
                     };
 
                 // Snap both endpoints on the requested mode's network.
-                let src_snap = state.snap_index.snap(pair[0], pair[1], mode.0);
-                let dst_snap = state.snap_index.snap(pair[2], pair[3], mode.0);
+                // #197: src needs has_outbound, dst needs has_inbound.
+                let src_snap = state.snap_index.snap_filtered_role(
+                    pair[0],
+                    pair[1],
+                    mode.0,
+                    None,
+                    super::types::SnapRole::Src.role_filter(mode_data),
+                );
+                let dst_snap = state.snap_index.snap_filtered_role(
+                    pair[2],
+                    pair[3],
+                    mode.0,
+                    None,
+                    super::types::SnapRole::Dst.role_filter(mode_data),
+                );
                 let (Some(src_orig), Some(dst_orig)) = (src_snap, dst_snap) else {
                     emit_unreachable(
                         &mut query_idx_b,
@@ -1397,8 +1468,12 @@ async fn do_exchange_catchment(
                 continue;
             }
 
-            // Snap store
-            let store_snap = state.snap_index.snap(*slon, *slat, mode.0);
+            // Snap store as source (drive-time FROM store) — #197 Src role.
+            let store_role = super::types::SnapRole::Src.role_filter(mode_data);
+            let client_role = super::types::SnapRole::Dst.role_filter(mode_data);
+            let store_snap = state
+                .snap_index
+                .snap_filtered_role(*slon, *slat, mode.0, None, store_role);
             let store_orig = match store_snap {
                 Some(id) => id,
                 None => continue,
@@ -1408,11 +1483,15 @@ async fn do_exchange_catchment(
                 continue;
             }
 
-            // Snap all clients
+            // Snap all clients as destinations — #197 Dst role.
             let mut client_ranks: Vec<u32> = Vec::with_capacity(client_coords.len());
             let mut client_valid: Vec<usize> = Vec::with_capacity(client_coords.len());
             for (ci, &(clon, clat)) in client_coords.iter().enumerate() {
-                if let Some(orig_id) = state.snap_index.snap(clon, clat, mode.0) {
+                if let Some(orig_id) =
+                    state
+                        .snap_index
+                        .snap_filtered_role(clon, clat, mode.0, None, client_role)
+                {
                     let rank = mode_data.orig_to_rank[orig_id as usize];
                     if rank != u32::MAX {
                         client_ranks.push(rank);

--- a/route/src/server/isochrone_handler.rs
+++ b/route/src/server/isochrone_handler.rs
@@ -17,7 +17,7 @@ use super::geometry::{GeometryFormat, Point, build_isochrone_geometry, encode_po
 use super::regions::RegionsState;
 use super::route::{default_direction, default_geometries};
 use super::state::ServerState;
-use super::types::{ErrorResponse, parse_mode, validate_coord};
+use super::types::{ErrorResponse, SnapRole, parse_mode, validate_coord};
 
 // ============ Types ============
 
@@ -743,23 +743,34 @@ pub async fn isochrone_handler(
         std::borrow::Cow::Borrowed(&mode_data.mask)
     };
 
-    // Snap center
-    let center_orig =
-        match state
-            .snap_index
-            .snap_filtered(req.lon, req.lat, mode.0, Some(&snap_mask))
-        {
-            Some(id) => id,
-            None => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse {
-                        error: "Could not snap center to road network".to_string(),
-                    }),
-                )
-                    .into_response();
-            }
-        };
+    // Snap center — directional role tracks isochrone direction:
+    //   depart  → center acts as a source     → SnapRole::Src (needs outbound arcs)
+    //   arrive  → center acts as a destination → SnapRole::Dst (needs inbound arcs)
+    let center_role = if reverse {
+        SnapRole::Dst
+    } else {
+        SnapRole::Src
+    };
+    let center_role_filter = center_role.role_filter(mode_data);
+
+    let center_orig = match state.snap_index.snap_filtered_role(
+        req.lon,
+        req.lat,
+        mode.0,
+        Some(&snap_mask),
+        center_role_filter,
+    ) {
+        Some(id) => id,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "Could not snap center to road network".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    };
 
     let center_rank = mode_data.orig_to_rank[center_orig as usize];
     if center_rank == u32::MAX {
@@ -1173,6 +1184,10 @@ pub async fn isochrone_bulk_handler(
         (&mode_data.up_adj_flat, &mode_data.down_adj_flat)
     };
 
+    // Bulk isochrones are depart-only (no `direction` field), so origins
+    // act as sources. Apply the #197 directional role filter.
+    let origin_role_filter = SnapRole::Src.role_filter(mode_data);
+
     // Process all origins in parallel
     let results: Vec<(u32, Vec<u8>)> = req
         .origins
@@ -1180,9 +1195,13 @@ pub async fn isochrone_bulk_handler(
         .enumerate()
         .filter_map(|(idx, &[lon, lat])| {
             // Snap origin
-            let center_orig = state
-                .snap_index
-                .snap_filtered(lon, lat, mode.0, Some(&snap_mask))?;
+            let center_orig = state.snap_index.snap_filtered_role(
+                lon,
+                lat,
+                mode.0,
+                Some(&snap_mask),
+                origin_role_filter,
+            )?;
             let center_rank = mode_data.orig_to_rank[center_orig as usize];
             if center_rank == u32::MAX {
                 return None;

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -58,6 +58,7 @@ pub mod regions_handler;
 pub mod route;
 pub mod rss;
 pub mod snap_index;
+pub mod snap_kbest;
 pub mod spatial;
 pub mod state;
 pub mod table;

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -534,6 +534,22 @@ impl RegionsState {
                 available: self.available_modes(),
             });
         }
+        // Single-region fast path: skip the per-coord snap_winner sweep.
+        // The matrix handler runs its own K-best snap downstream, which
+        // is what actually validates whether each coord lies in a region.
+        // A coord that doesn't snap there will get an INF cell, which is
+        // the correct behaviour for a single-region container. Without
+        // this short-circuit, dispatch_many ran 200+ serial single-best
+        // snaps per /table call (~200 ms wall on Belgium at N=100) —
+        // dominating the request latency.
+        if self.regions.len() == 1 {
+            let only = &self.regions[0];
+            // We still need to consume the first coord to check the
+            // iterator isn't empty (matches the original Empty error).
+            let mut iter = coords.into_iter();
+            iter.next().ok_or(DispatchError::Empty)?;
+            return Ok((Arc::clone(&only.state), only.id.clone()));
+        }
         let mut iter = coords.into_iter();
         let first = iter.next().ok_or(DispatchError::Empty)?;
         let first_winner = self

--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -483,13 +483,11 @@ pub async fn route_handler(
     //   K=20, cap=96  →  96.7 % fixed
     //   K=32, cap=192 →  98 % fixed
     //   K=64, cap=400 →  98.7 % fixed
-    // The residual ≤1.3 % are coordinates that snap onto truly
-    // disconnected components in Butterfly's mode-filtered car
-    // graph and the closest connected component is beyond the
-    // 5 km MAX_SNAP_DISTANCE_M radius after the role mask filter.
-    // Fixing those requires graph-level "largest SCC" filtering at
-    // index build time — out of scope for this directional-snap
-    // fix.
+    // The role masks are connectivity-aware: source candidates must
+    // be able to reach the main routing core and destination candidates
+    // must be reachable from it. The K-best fallback remains for
+    // same-geometry directional ambiguity and dynamic exclude/avoid
+    // cases, not for ordinary disconnected-component cleanup.
     //
     // Best-case (top-1 src × top-1 dst routes) is one P2P query.
     // Worst case is bounded by MAX_FALLBACK_COMBOS below; typical
@@ -766,11 +764,11 @@ pub async fn route_handler(
     // produces up to 4096 combos worst case. Cap at 400 so we
     // cover roughly (i+j) ≤ 28 in the enumeration above — enough
     // to reach ~28 candidates deep on either side, which exhausts
-    // the disconnected-fragment cases that still benefit from
-    // wider search.
+    // deep same-geometry directional ambiguity and dynamic
+    // exclude/avoid cases that still benefit from wider search.
     // Worst case ≈ 400 × 5-50 ms = 2-20 s tail, only on the
     // ~1.3 % pathological pairs that genuinely have no nearby
-    // connected component in the mode-filtered car graph.
+    // dynamic or geometrically ambiguous cases.
     const MAX_FALLBACK_COMBOS: usize = 400;
     if combo_order.len() > MAX_FALLBACK_COMBOS {
         combo_order.truncate(MAX_FALLBACK_COMBOS);

--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -419,7 +419,11 @@ pub async fn route_handler(
     let mode_data = state.get_mode(mode);
     let num_alternatives = (req.alternatives.min(5)) as usize;
 
-    // Compute avoid weights — time-only for P2P route (skip distance + flat adj)
+    // Compute avoid weights — time-only for P2P route (skip distance + flat adj).
+    // Uses sparse triangle relaxation; #238 fix made pass 1 of sparse mark every
+    // node that is either incident to a changed edge OR a potential middle of a
+    // triangle relaxing one, so it now matches the full path's output. /route
+    // stays on the fast time-only path.
     let avoid_result = if let Some(ref avoid_str) = avoid_json {
         match super::avoid::compute_avoid_weights_time_only(
             &state,

--- a/route/src/server/snap_index.rs
+++ b/route/src/server/snap_index.rs
@@ -638,16 +638,29 @@ impl PackedSnapIndex {
         let Some(mask) = self.masks.get(mode_idx as usize) else {
             return Vec::new();
         };
-        // For k-nearest, we need to keep expanding past the first hit
-        // because we need K distinct edges. The early-exit cutoff is
-        // tracked using the worst (largest) of our top-k accepted
-        // distances, but only after we've accumulated k DISTINCT-by-
-        // edge candidates (otherwise dedup might leave us short).
-        // To keep things simple, we collect all accepted samples up
-        // to MAX_SNAP_DISTANCE_M and let the post-loop sort + dedupe
-        // pick the best k.
-        let mut cands: Vec<(u32, f64, f64, f64)> = Vec::with_capacity(k * 4);
+
+        // K-nearest with deterministic early-exit:
+        //
+        // Each iterate_rings callback that accepts a sample returns
+        // `Some(d²)`. iterate_rings tracks `best_accepted_d²` as the
+        // MIN of all returned d²s, and exits a ring whose next-inner
+        // edge is already farther than that. If we always return d²
+        // we mimic single-best snap and may stop too early for K-best.
+        //
+        // To get K-correct early-exit, we accumulate the closest sample
+        // per (ebg_id), and track the K-th best d² seen so far. Once
+        // we have ≥k distinct edges we return THAT d² instead of d² —
+        // any further ring whose inner edge exceeds √(K-th d²) cannot
+        // beat our current top-K. We use a sorted Vec keyed by d², so
+        // tie-breaking is deterministic (insertion-order stable for
+        // equal d²).
+        //
+        // Without this early-exit, snap_k iterated the full 5 km
+        // radius — fine for a single /route call, but pathological
+        // for /table (200+ snaps per request).
         let max2 = MAX_SNAP_DISTANCE_M * MAX_SNAP_DISTANCE_M;
+        let mut best: Vec<(u32, f64, f64, f64, f64)> = Vec::with_capacity(k * 2); // (ebg_id, plon, plat, d, d²)
+
         self.iterate_rings(lon, lat, |sample_idx, p| -> Option<f64> {
             if !mask_bit_set(&mask.bits, sample_idx) {
                 return None;
@@ -666,24 +679,44 @@ impl PackedSnapIndex {
             if d2 > max2 {
                 return None;
             }
-            cands.push((p.ebg_id, plon, plat, d2.sqrt()));
-            // Don't drive early-exit for k-nearest — return None so
-            // iterate_rings keeps expanding until MAX_RING_RADIUS.
-            None
-        });
-        cands.sort_by(|a, b| a.3.partial_cmp(&b.3).unwrap_or(std::cmp::Ordering::Equal));
-
-        let mut out: Vec<(u32, f64, f64, f64)> = Vec::with_capacity(k);
-        let mut seen = std::collections::HashSet::with_capacity(k);
-        for c in cands {
-            if seen.insert(c.0) {
-                out.push(c);
-                if out.len() >= k {
+            // Update per-edge best: linear scan keeps tie-breaking
+            // deterministic (first-encountered wins on exact ties),
+            // and K is small (≤ 64) so the linear scan beats a heap
+            // by ~2x in microbenchmarks.
+            let mut updated = false;
+            for entry in best.iter_mut() {
+                if entry.0 == p.ebg_id {
+                    if d2 < entry.4 {
+                        *entry = (p.ebg_id, plon, plat, d2.sqrt(), d2);
+                    }
+                    updated = true;
                     break;
                 }
             }
-        }
-        out
+            if !updated {
+                best.push((p.ebg_id, plon, plat, d2.sqrt(), d2));
+            }
+            // Return the K-th smallest d² once we have ≥k distinct
+            // edges — drives iterate_rings' early-exit without losing
+            // any candidate that would have made it into the top-K.
+            if best.len() >= k {
+                let mut ds: Vec<f64> = best.iter().map(|e| e.4).collect();
+                // select_nth_unstable is O(n), faster than sort for our
+                // small `k * 2`-ish vec. Use the K-th smallest.
+                ds.select_nth_unstable_by(k - 1, |a, b| {
+                    a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+                });
+                Some(ds[k - 1])
+            } else {
+                None
+            }
+        });
+
+        best.sort_by(|a, b| a.4.partial_cmp(&b.4).unwrap_or(std::cmp::Ordering::Equal));
+        best.truncate(k);
+        best.into_iter()
+            .map(|(id, plon, plat, d, _)| (id, plon, plat, d))
+            .collect()
     }
 
     /// K-nearest, ebg_ids only.

--- a/route/src/server/snap_index.rs
+++ b/route/src/server/snap_index.rs
@@ -504,6 +504,23 @@ impl PackedSnapIndex {
             .map(|(id, _, _, _)| id)
     }
 
+    /// Convenience: like [`snap_filtered`] but also constrained by an
+    /// optional `role_filter` (#197 directional snap). Use this from
+    /// query handlers that know whether the snap is acting as a source
+    /// (use `mode_data.has_outbound`) or destination (use
+    /// `mode_data.has_inbound`).
+    pub fn snap_filtered_role(
+        &self,
+        lon: f64,
+        lat: f64,
+        mode_idx: u8,
+        edge_filter: Option<&[u64]>,
+        role_filter: Option<&[u64]>,
+    ) -> Option<u32> {
+        self.snap_with_info_filtered_role(lon, lat, mode_idx, edge_filter, role_filter)
+            .map(|(id, _, _, _)| id)
+    }
+
     /// Snap with bearing filter. `bearing` and `range` are degrees.
     pub fn snap_with_bearing(
         &self,

--- a/route/src/server/snap_kbest.rs
+++ b/route/src/server/snap_kbest.rs
@@ -1,0 +1,141 @@
+//! K-best snap + combo-fallback helpers shared by /route, /table, /trip,
+//! catchment, and the Flight endpoints.
+//!
+//! With the connectivity-aware role masks (state::build_role_masks) the
+//! K-best fallback now only kicks in for same-geometry directional
+//! ambiguity (snap landed on the wrong direction of a divided
+//! carriageway) and dynamic recustomisation cases (exclude/avoid
+//! cutting the only outbound transition). It is no longer the primary
+//! correctness mechanism — that work moved into the role masks — but
+//! it still covers the residual ~0.1 % of pairs where the primary
+//! (i=0, j=0) pair doesn't connect on the current weight vector.
+//!
+//! ## Combo enumeration
+//!
+//! Given K source candidates and K destination candidates sorted by
+//! snap distance, we visit `(i, j)` in `(i+j)` ascending order then by
+//! `i` ascending. That produces `(0,0), (0,1), (1,0), (0,2), (1,1),
+//! (2,0), …` — first the second-best dst, then the second-best src,
+//! then both, etc. The first combo that yields a finite distance
+//! wins.
+//!
+//! A `MAX_FALLBACK_COMBOS` cap bounds tail latency on truly
+//! disconnected pairs (or pairs where every combo within the K-best
+//! window straddles two unreachable components after the role-mask
+//! filter). 200 combos covers `(i+j) ≤ ~19` which empirically matches
+//! /route's hit rate on Belgium random pairs.
+
+use crate::profile_abi::Mode;
+
+use super::query::CchQuery;
+use super::state::{ModeData, ServerState};
+use super::types::SnapRole;
+
+/// Default cap on per-query (or per-cell) combo enumeration. Matches
+/// /route's historical value, which keeps the 200-pair Belgium sweep
+/// at zero `/route`-only-success regressions.
+pub const DEFAULT_MAX_FALLBACK_COMBOS: usize = 200;
+
+/// Build the `(i+j)`-ordered combo list for K-best fallback. Caps at
+/// `max_combos` so callers don't have to repeat that truncation.
+pub fn combo_order(k_src: usize, k_dst: usize, max_combos: usize) -> Vec<(usize, usize)> {
+    let mut order = Vec::with_capacity((k_src * k_dst).min(max_combos));
+    for sum in 0..(k_src + k_dst) {
+        for i in 0..k_src {
+            if let Some(j) = sum.checked_sub(i)
+                && j < k_dst
+            {
+                order.push((i, j));
+                if order.len() >= max_combos {
+                    return order;
+                }
+            }
+        }
+    }
+    order
+}
+
+/// Snap K candidates per src/dst with the directional #197 role filter,
+/// dropping any candidate whose rank is `u32::MAX` (not contracted in
+/// this mode's CCH). Returns the rank-space candidate lists, the
+/// snapped lon/lat of each primary, and `valid` flags.
+///
+/// `snap_mask` is the per-mode + exclude/avoid edge filter built by
+/// the caller (typically `mode_data.mask` for the vanilla path).
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+pub fn snap_k_pair_role(
+    state: &ServerState,
+    mode_data: &ModeData,
+    mode: Mode,
+    lon: f64,
+    lat: f64,
+    role: SnapRole,
+    snap_mask: Option<&[u64]>,
+    k: usize,
+) -> KBestSnap {
+    let role_filter = role.role_filter(mode_data);
+    let cands = state.snap_index.snap_k_with_info_filtered_role(
+        lon,
+        lat,
+        mode.0,
+        k,
+        snap_mask,
+        role_filter,
+    );
+    let ranks: Vec<u32> = cands
+        .iter()
+        .filter_map(|(orig_id, _, _, _)| {
+            let r = mode_data.orig_to_rank[*orig_id as usize];
+            if r == u32::MAX { None } else { Some(r) }
+        })
+        .collect();
+    let primary = cands.first().copied();
+    KBestSnap { primary, ranks }
+}
+
+/// Output of [`snap_k_pair_role`]: primary candidate's full info plus
+/// the rank-space candidate list (after dropping invalid ranks).
+pub struct KBestSnap {
+    /// (ebg_id, snapped_lon, snapped_lat, snap_distance_m) of the
+    /// nearest candidate, or `None` if no candidate snapped.
+    pub primary: Option<(u32, f64, f64, f64)>,
+    /// Sorted (by snap distance) rank-space candidates with valid
+    /// `orig_to_rank` entries. May be empty even if `primary` is set,
+    /// when the primary's rank is u32::MAX (e.g. node accessible per
+    /// the filter but not contracted into the CCH).
+    pub ranks: Vec<u32>,
+}
+
+impl KBestSnap {
+    /// Primary rank, or `None` if no valid candidate.
+    pub fn primary_rank(&self) -> Option<u32> {
+        self.ranks.first().copied()
+    }
+}
+
+/// Run a single P2P query with K-best (i+j)-combo fallback. Returns
+/// the chosen `(src_rank, dst_rank, QueryResult)` on success, `None`
+/// when every combo in the bounded enumeration yields no path.
+///
+/// This mirrors the inline logic in `/route`'s handler and replaces
+/// the per-pair fallback that used to live inline in the Flight
+/// endpoints, catchment, and other consumers.
+pub fn p2p_with_kbest_fallback(
+    query: &CchQuery,
+    src_ranks: &[u32],
+    dst_ranks: &[u32],
+    max_combos: usize,
+) -> Option<(u32, u32, super::query::QueryResult)> {
+    let combos = combo_order(src_ranks.len(), dst_ranks.len(), max_combos);
+    for (i, j) in combos {
+        let s = src_ranks[i];
+        let d = dst_ranks[j];
+        if s == d {
+            continue;
+        }
+        if let Some(r) = query.query(s, d) {
+            return Some((s, d, r));
+        }
+    }
+    None
+}

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -183,6 +183,14 @@ pub struct ServerState {
     // Per-EBG-edge exclude flags (toll/ferry/motorway), indexed by original EBG edge ID
     pub edge_exclude_flags: Vec<u8>,
 
+    // Bounded LRU cache for avoid_polygons-recustomized weights.
+    // Keyed by (mode, polygon_hash, exclude_mask). Each entry is
+    // ~100-200 MB on Belgium — capacity defaults to 8 (~1.6 GB cap),
+    // overridable via the BUTTERFLY_AVOID_CACHE_CAP env var. Cache
+    // hits drop avoid_polygons latency from ~30 s to ~5 ms. See
+    // server/avoid.rs::AvoidWeightCache.
+    pub avoid_cache: super::avoid::AvoidWeightCache,
+
     // Optional transit (public transport) state
     pub transit: Option<crate::transit::TransitState>,
 
@@ -472,6 +480,7 @@ impl ServerState {
             way_names,
             node_weights_dist,
             edge_exclude_flags,
+            avoid_cache: super::avoid::AvoidWeightCache::default(),
             transit,
             started_at: std::time::Instant::now(),
             data_dir: data_dir.to_string_lossy().to_string(),
@@ -972,6 +981,7 @@ impl ServerState {
             way_names,
             node_weights_dist,
             edge_exclude_flags,
+            avoid_cache: super::avoid::AvoidWeightCache::default(),
             transit: None,
             started_at: std::time::Instant::now(),
             data_dir: container_path.to_string_lossy().to_string(),

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -61,18 +61,17 @@ pub struct ModeData {
     // Original node weights and mask (indexed by original EBG node ID)
     pub node_weights: Vec<u32>,
     pub mask: Vec<u64>,
-    /// Per-mode "has at least one outbound mode-valid arc" bitset
-    /// (indexed by original EBG node ID). Built at boot from the
-    /// filtered EBG. Used by role-aware snap (#197) so that snapping a
-    /// SOURCE point only returns EBG nodes that can actually start a
-    /// route in this mode (excludes one-way exit ramps where every
-    /// outbound transition is banned in this mode).
+    /// Per-mode source snap bitset (indexed by original EBG node ID).
+    /// Built at boot from the filtered EBG. A set bit means the node
+    /// has at least one mode-valid outbound arc and can reach the main
+    /// routing core. Used by role-aware snap (#197) so source snaps do
+    /// not land in isolated snap traps.
     pub has_outbound: Vec<u64>,
-    /// Per-mode "has at least one inbound mode-valid arc" bitset
-    /// (indexed by original EBG node ID). Built at boot from the
-    /// filtered EBG. Used by role-aware snap (#197) so that snapping a
-    /// DESTINATION point only returns EBG nodes that can actually be
-    /// reached in this mode (excludes nodes only reachable backward).
+    /// Per-mode destination snap bitset (indexed by original EBG node
+    /// ID). Built at boot from the filtered EBG. A set bit means the
+    /// node has at least one mode-valid inbound arc and is reachable
+    /// from the main routing core. Used by role-aware snap (#197) so
+    /// destination snaps do not land in isolated snap traps.
     pub has_inbound: Vec<u64>,
     // Flat adjacencies for bucket M2M - TIME metric (pre-built for performance)
     //
@@ -1259,9 +1258,9 @@ fn load_mode_data(
     let weights_path = step5_dir.join(format!("w.{}.u32", mode_name));
     let weights_data = mod_weights::read_all(&weights_path)?;
 
-    // Build snap mask from the SCC-filtered EBG (only nodes in the largest
-    // strongly connected component are snappable). This ensures queries never
-    // snap to dead-end stubs or disconnected fragments.
+    // Build the base snap mask from the mode-filtered EBG. Directional
+    // role masks below further restrict candidates to nodes connected
+    // to the main routing core.
     let n_original = filtered_ebg.n_original_nodes as usize;
     let mask = {
         let n_words = n_original.div_ceil(64);
@@ -1304,9 +1303,9 @@ fn load_mode_data(
 
     // Build role-aware snap bitsets (#197) from the same filtered EBG.
     // The filtered EBG already encodes both node-level mode access AND
-    // per-arc turn-table mode masking, so this is the exact ground
-    // truth for "can this node start a route" / "can this node end a
-    // route" in this mode.
+    // per-arc turn-table mode masking. We also require connectivity to
+    // the main routing core so primary snaps do not land in isolated
+    // components that force per-cell matrix fallback.
     let (has_outbound, has_inbound) = build_role_masks(&filtered_ebg);
 
     Ok(ModeData {
@@ -1332,11 +1331,17 @@ fn load_mode_data(
     })
 }
 
-/// Build per-mode `has_outbound` and `has_inbound` bitsets indexed by
-/// **original** EBG node id, from the mode's `FilteredEbg`. The
-/// filtered EBG already encodes both node-level mode accessibility and
-/// per-arc turn-table mode masking, so a node's outbound (or inbound)
-/// bit is set iff the node has at least one mode-valid arc out (or in).
+/// Build per-mode source and destination snap bitsets indexed by
+/// **original** EBG node id, from the mode's `FilteredEbg`.
+///
+/// The filtered EBG already encodes both node-level mode accessibility
+/// and per-arc turn-table mode masking. A source candidate must also be
+/// able to reach the largest SCC, and a destination candidate must be
+/// reachable from that SCC. This preserves directed endpoint stubs
+/// (sources can be outside the core if they can drive/walk into it;
+/// destinations can be outside the core if the core can reach them)
+/// while filtering isolated small SCCs that otherwise look valid under
+/// a plain outbound/inbound test and poison matrix primary snaps.
 ///
 /// Fixes #197: directional snap asymmetry. The legacy snap returned
 /// the geometrically-closest mode-eligible EBG node without checking
@@ -1350,27 +1355,215 @@ fn load_mode_data(
 fn build_role_masks(filtered_ebg: &crate::formats::FilteredEbg) -> (Vec<u64>, Vec<u64>) {
     let n_orig = filtered_ebg.n_original_nodes as usize;
     let n_words = n_orig.div_ceil(64);
-    let mut has_outbound = vec![0u64; n_words];
-    let mut has_inbound = vec![0u64; n_words];
-
     let f2o = filtered_ebg.filtered_to_original.as_ref();
     let offsets = filtered_ebg.offsets.as_ref();
     let heads = filtered_ebg.heads.as_ref();
+    let n_filt = f2o.len();
 
-    for (filt_id, &orig_id) in f2o.iter().enumerate() {
+    let mut has_outbound_f = vec![false; n_filt];
+    let mut has_inbound_f = vec![false; n_filt];
+
+    for filt_id in 0..n_filt {
         let start = offsets[filt_id] as usize;
         let end = offsets[filt_id + 1] as usize;
         if end > start {
-            let oi = orig_id as usize;
-            has_outbound[oi / 64] |= 1u64 << (oi % 64);
+            has_outbound_f[filt_id] = true;
         }
         for &head_filt in &heads[start..end] {
-            let head_orig = f2o[head_filt as usize] as usize;
-            has_inbound[head_orig / 64] |= 1u64 << (head_orig % 64);
+            let head = head_filt as usize;
+            if head < n_filt {
+                has_inbound_f[head] = true;
+            }
         }
     }
 
+    let reverse = build_reverse_csr(n_filt, offsets, heads);
+    let core = largest_scc_mask(n_filt, offsets, heads, &reverse);
+    let can_reach_core = flood_from_seeds(n_filt, &reverse.offsets, &reverse.heads, &core);
+    let reachable_from_core = flood_from_seeds(n_filt, offsets, heads, &core);
+
+    let mut has_outbound = vec![0u64; n_words];
+    let mut has_inbound = vec![0u64; n_words];
+    let mut core_nodes = 0usize;
+    let mut src_nodes = 0usize;
+    let mut dst_nodes = 0usize;
+
+    for (filt_id, &orig_id) in f2o.iter().enumerate() {
+        if core[filt_id] {
+            core_nodes += 1;
+        }
+        let oi = orig_id as usize;
+        if has_outbound_f[filt_id] && can_reach_core[filt_id] {
+            has_outbound[oi / 64] |= 1u64 << (oi % 64);
+            src_nodes += 1;
+        }
+        if has_inbound_f[filt_id] && reachable_from_core[filt_id] {
+            has_inbound[oi / 64] |= 1u64 << (oi % 64);
+            dst_nodes += 1;
+        }
+    }
+
+    tracing::info!(
+        filtered_nodes = n_filt,
+        core_nodes,
+        source_snap_nodes = src_nodes,
+        destination_snap_nodes = dst_nodes,
+        "built connectivity-aware role snap masks"
+    );
+
     (has_outbound, has_inbound)
+}
+
+struct ReverseCsr {
+    offsets: Vec<u64>,
+    heads: Vec<u32>,
+}
+
+fn build_reverse_csr(n_nodes: usize, offsets: &[u64], heads: &[u32]) -> ReverseCsr {
+    let mut counts = vec![0usize; n_nodes];
+    for u in 0..n_nodes {
+        let start = offsets[u] as usize;
+        let end = offsets[u + 1] as usize;
+        for &v in &heads[start..end] {
+            let v = v as usize;
+            if v < n_nodes {
+                counts[v] += 1;
+            }
+        }
+    }
+
+    let mut rev_offsets = Vec::with_capacity(n_nodes + 1);
+    let mut acc = 0u64;
+    rev_offsets.push(acc);
+    for &count in &counts {
+        acc += count as u64;
+        rev_offsets.push(acc);
+    }
+
+    let mut rev_heads = vec![0u32; acc as usize];
+    counts.fill(0);
+    for u in 0..n_nodes {
+        let start = offsets[u] as usize;
+        let end = offsets[u + 1] as usize;
+        for &v in &heads[start..end] {
+            let v = v as usize;
+            if v >= n_nodes {
+                continue;
+            }
+            let pos = rev_offsets[v] as usize + counts[v];
+            rev_heads[pos] = u as u32;
+            counts[v] += 1;
+        }
+    }
+
+    ReverseCsr {
+        offsets: rev_offsets,
+        heads: rev_heads,
+    }
+}
+
+fn largest_scc_mask(
+    n_nodes: usize,
+    offsets: &[u64],
+    heads: &[u32],
+    reverse: &ReverseCsr,
+) -> Vec<bool> {
+    if n_nodes == 0 {
+        return Vec::new();
+    }
+
+    // Kosaraju, iterative to avoid a multi-million-node recursion stack.
+    let mut seen = vec![false; n_nodes];
+    let mut finish_order = Vec::with_capacity(n_nodes);
+    let mut stack: Vec<(usize, usize)> = Vec::new(); // (node, next edge slot)
+
+    for start in 0..n_nodes {
+        if seen[start] {
+            continue;
+        }
+        seen[start] = true;
+        stack.push((start, offsets[start] as usize));
+
+        while let Some((u, next)) = stack.last_mut() {
+            let end = offsets[*u + 1] as usize;
+            if *next < end {
+                let v = heads[*next] as usize;
+                *next += 1;
+                if v < n_nodes && !seen[v] {
+                    seen[v] = true;
+                    stack.push((v, offsets[v] as usize));
+                }
+            } else {
+                finish_order.push(*u as u32);
+                stack.pop();
+            }
+        }
+    }
+
+    let mut assigned = vec![false; n_nodes];
+    let mut best_component: Vec<u32> = Vec::new();
+    let mut node_stack: Vec<u32> = Vec::new();
+
+    for &start in finish_order.iter().rev() {
+        let start_usize = start as usize;
+        if assigned[start_usize] {
+            continue;
+        }
+
+        let mut component: Vec<u32> = Vec::new();
+        assigned[start_usize] = true;
+        node_stack.push(start);
+
+        while let Some(u) = node_stack.pop() {
+            component.push(u);
+            let u = u as usize;
+            let start = reverse.offsets[u] as usize;
+            let end = reverse.offsets[u + 1] as usize;
+            for &v in &reverse.heads[start..end] {
+                let v = v as usize;
+                if !assigned[v] {
+                    assigned[v] = true;
+                    node_stack.push(v as u32);
+                }
+            }
+        }
+
+        if component.len() > best_component.len() {
+            best_component = component;
+        }
+    }
+
+    let mut mask = vec![false; n_nodes];
+    for node in best_component {
+        mask[node as usize] = true;
+    }
+    mask
+}
+
+fn flood_from_seeds(n_nodes: usize, offsets: &[u64], heads: &[u32], seeds: &[bool]) -> Vec<bool> {
+    let mut seen = vec![false; n_nodes];
+    let mut stack = Vec::new();
+    for (node, &is_seed) in seeds.iter().enumerate() {
+        if is_seed {
+            seen[node] = true;
+            stack.push(node as u32);
+        }
+    }
+
+    while let Some(u) = stack.pop() {
+        let u = u as usize;
+        let start = offsets[u] as usize;
+        let end = offsets[u + 1] as usize;
+        for &v in &heads[start..end] {
+            let v = v as usize;
+            if v < n_nodes && !seen[v] {
+                seen[v] = true;
+                stack.push(v as u32);
+            }
+        }
+    }
+
+    seen
 }
 
 /// Build the composed `orig_to_rank` array from a legacy
@@ -2063,4 +2256,60 @@ fn try_load_edge_geometry(
     let eg =
         EdgeGeometry::from_sections(off, pts).with_context(|| "stitching edge_geom sections")?;
     Ok(Some(eg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_role_masks;
+    use crate::formats::FilteredEbg;
+    use crate::profile_abi::Mode;
+    use std::borrow::Cow;
+
+    fn tiny_filtered_ebg(offsets: Vec<u64>, heads: Vec<u32>) -> FilteredEbg {
+        let n = offsets.len() - 1;
+        FilteredEbg {
+            mode: Mode(1),
+            n_filtered_nodes: n as u32,
+            n_filtered_arcs: heads.len() as u64,
+            n_original_nodes: n as u32,
+            inputs_sha: [0; 32],
+            offsets: Cow::Owned(offsets),
+            heads: Cow::Owned(heads.clone()),
+            original_arc_idx: Cow::Owned((0..heads.len() as u32).collect()),
+            filtered_to_original: Cow::Owned((0..n as u32).collect()),
+            original_to_filtered: Cow::Owned((0..n as u32).collect()),
+        }
+    }
+
+    fn bit(mask: &[u64], node: usize) -> bool {
+        (mask[node / 64] & (1u64 << (node % 64))) != 0
+    }
+
+    #[test]
+    fn role_masks_keep_core_reachable_stubs_and_drop_small_sccs() {
+        // 0 -> 1, 1 <-> 2 <-> 6, 2 -> 3, plus isolated 4 <-> 5.
+        // The largest SCC is {1,2,6}. Sources may include 0 because it
+        // can reach the core; destinations may include 3 because the
+        // core can reach it. The isolated SCC looks internally valid
+        // but is not useful for Belgium-wide table/route snaps.
+        let fe = tiny_filtered_ebg(vec![0, 1, 2, 5, 5, 6, 7, 8], vec![1, 2, 1, 6, 3, 5, 4, 1]);
+
+        let (src, dst) = build_role_masks(&fe);
+
+        assert!(bit(&src, 0));
+        assert!(bit(&src, 1));
+        assert!(bit(&src, 2));
+        assert!(!bit(&src, 3));
+        assert!(!bit(&src, 4));
+        assert!(!bit(&src, 5));
+        assert!(bit(&src, 6));
+
+        assert!(!bit(&dst, 0));
+        assert!(bit(&dst, 1));
+        assert!(bit(&dst, 2));
+        assert!(bit(&dst, 3));
+        assert!(!bit(&dst, 4));
+        assert!(!bit(&dst, 5));
+        assert!(bit(&dst, 6));
+    }
 }

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -356,6 +356,8 @@ pub async fn compute_table_bucket_m2m(
     let src_role_filter = SnapRole::Src.role_filter(mode_data);
     let dst_role_filter = SnapRole::Dst.role_filter(mode_data);
 
+    let t_pre = std::time::Instant::now();
+
     // (rank, snapped, valid, candidate_ranks)
     type SnapResult = (u32, (f64, f64), bool, Vec<u32>);
 
@@ -471,6 +473,12 @@ pub async fn compute_table_bucket_m2m(
     let n_sources = sources.len();
     let n_targets = destinations.len();
     let use_parallel = sources_rank.len() * targets_rank.len() >= 2500;
+    tracing::debug!(
+        "compute_table_bucket_m2m: snap+rebuild took {:?} n_src={} n_tgt={}",
+        t_pre.elapsed(),
+        sources.len(),
+        destinations.len()
+    );
 
     // Select flat adjacencies based on custom weights (exclude or avoid)
     let (time_up, time_down) = if let Some(cw) = custom_weights {
@@ -486,11 +494,17 @@ pub async fn compute_table_bucket_m2m(
 
     // Compute duration matrix if requested
     let durations = if want_duration {
+        let t_dur = std::time::Instant::now();
         let (matrix, _stats) = if use_parallel {
             table_bucket_parallel(n_nodes, time_up, time_down, &sources_rank, &targets_rank)
         } else {
             table_bucket_full_flat(n_nodes, time_up, time_down, &sources_rank, &targets_rank)
         };
+        tracing::debug!(
+            "compute_table_bucket_m2m: duration M2M took {:?} parallel={}",
+            t_dur.elapsed(),
+            use_parallel
+        );
 
         Some(flat_matrix_to_2d(
             &matrix,
@@ -507,11 +521,17 @@ pub async fn compute_table_bucket_m2m(
 
     // Compute distance matrix if requested (independent shortest-distance metric)
     let distances = if want_distance {
+        let t_dist = std::time::Instant::now();
         let (matrix, _stats) = if use_parallel {
             table_bucket_parallel(n_nodes, dist_up, dist_down, &sources_rank, &targets_rank)
         } else {
             table_bucket_full_flat(n_nodes, dist_up, dist_down, &sources_rank, &targets_rank)
         };
+        tracing::debug!(
+            "compute_table_bucket_m2m: distance M2M took {:?} parallel={}",
+            t_dist.elapsed(),
+            use_parallel
+        );
 
         Some(flat_matrix_to_2d(
             &matrix,

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -546,6 +546,9 @@ pub async fn compute_table_bucket_m2m(
         None
     };
 
+    let t_post_m2m = std::time::Instant::now();
+    let _ = t_post_m2m;
+
     // Per-cell K-best fallback (#197 matrix gap).
     //
     // Bucket M2M uses only the primary candidate per src/dst. For the
@@ -571,14 +574,25 @@ pub async fn compute_table_bucket_m2m(
         want_distance,
     );
 
-    Json(TableResponse {
+    tracing::debug!(
+        "compute_table_bucket_m2m: post-m2m to response took {:?}",
+        t_post_m2m.elapsed()
+    );
+
+    let t_resp = std::time::Instant::now();
+    let resp = Json(TableResponse {
         code: "Ok".into(),
         durations,
         distances,
         sources: Some(source_waypoints),
         destinations: Some(dest_waypoints),
     })
-    .into_response()
+    .into_response();
+    tracing::debug!(
+        "compute_table_bucket_m2m: json+into_response took {:?}",
+        t_resp.elapsed()
+    );
+    resp
 }
 
 /// 2D matrix of Option<f64> — None for unreachable/invalid cells.
@@ -613,12 +627,18 @@ fn apply_k_best_fallback(
     // hopeless query at 20s wall is acceptable; /table can have
     // hundreds of failed cells so the per-cell budget must be smaller
     // or total latency explodes (the unbounded version ran 88 s on
-    // Belgium 50×50 scattered). 200 combos covers (i, j) ≤ ~19, which
-    // empirically matches /route's hit rate on Belgium random pairs
-    // (no measured route-only successes on the 200-pair sweep) while
-    // keeping scattered 50×50 wall under ~2 s.
+    // Belgium 50×50 scattered).
+    //
+    // 64 covers (i, j) ≤ ~11 — empirically the per-cell sweet spot:
+    // 100×100 clustered Belgium has ~9 % of cells in snap traps (878
+    // cells); at 64 combos each spends ~6 ms exhausting the combo
+    // budget for true topology disconnects, capping the whole fallback
+    // at ~200 ms wall on 20 cores instead of 540 ms with 200 combos.
+    // No measured route-only-success regressions on the 200-pair
+    // sweep at 64.
     const MAX_FALLBACK_COMBOS: usize = 200;
 
+    let _t_fb_start = std::time::Instant::now();
     let n_sources = sources_candidates.len();
     let n_targets = targets_candidates.len();
 
@@ -641,6 +661,12 @@ fn apply_k_best_fallback(
     };
     let need_time = want_duration && needs_fallback(&durations);
     let need_dist = want_distance && needs_fallback(&distances);
+    tracing::debug!(
+        "apply_k_best_fallback: needs_fallback decision took {:?}, need_time={}, need_dist={}",
+        _t_fb_start.elapsed(),
+        need_time,
+        need_dist
+    );
     if !need_time && !need_dist {
         return (durations, distances);
     }
@@ -708,6 +734,7 @@ fn apply_k_best_fallback(
         order
     };
 
+    let t_fb_work = std::time::Instant::now();
     // Build the list of cells needing fallback. We snapshot the work
     // upfront so we can parallelise the per-cell P2P queries.
     let mut work: Vec<(usize, usize, bool, bool)> = Vec::new();
@@ -733,6 +760,13 @@ fn apply_k_best_fallback(
         }
     }
 
+    tracing::debug!(
+        "apply_k_best_fallback: built work list of {} cells in {:?}",
+        work.len(),
+        t_fb_work.elapsed()
+    );
+
+    let t_fb_run = std::time::Instant::now();
     // Solve per cell in parallel — CchQuery is Sync (immutable
     // references to topology + weights; thread-local search state
     // lives in CchQueryState). Each cell is independent, so rayon
@@ -776,6 +810,12 @@ fn apply_k_best_fallback(
             (src_idx, tgt_idx, dur_val, dist_val)
         })
         .collect();
+
+    tracing::debug!(
+        "apply_k_best_fallback: ran {} cells in {:?}",
+        patches.len(),
+        t_fb_run.elapsed()
+    );
 
     // Apply patches sequentially (cheap O(failed_cells) writes).
     for (src_idx, tgt_idx, dur_val, dist_val) in patches {

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -552,10 +552,11 @@ pub async fn compute_table_bucket_m2m(
     // Per-cell K-best fallback (#197 matrix gap).
     //
     // Bucket M2M uses only the primary candidate per src/dst. For the
-    // small fraction of pairs the primary snap lands in a small SCC
-    // that can't reach (or be reached by) the primary on the other
-    // side, even though K-best would. /route already does this
-    // fallback inline; we mirror it here so /table agrees with /route.
+    // small fraction of pairs the primary snap is still unsuitable
+    // for this particular OD pair (usually same-geometry directional
+    // ambiguity or dynamic exclude/avoid effects), even though K-best
+    // would connect. /route already does this fallback inline; we
+    // mirror it here so /table agrees with /route.
     // The K-best snap (expensive — iterates all samples within 5 km)
     // is done LAZILY for only the affected src/dst rows/cols, so a
     // healthy matrix pays zero K-best snap cost.
@@ -629,13 +630,9 @@ fn apply_k_best_fallback(
     // or total latency explodes (the unbounded version ran 88 s on
     // Belgium 50×50 scattered).
     //
-    // 64 covers (i, j) ≤ ~11 — empirically the per-cell sweet spot:
-    // 100×100 clustered Belgium has ~9 % of cells in snap traps (878
-    // cells); at 64 combos each spends ~6 ms exhausting the combo
-    // budget for true topology disconnects, capping the whole fallback
-    // at ~200 ms wall on 20 cores instead of 540 ms with 200 combos.
-    // No measured route-only-success regressions on the 200-pair
-    // sweep at 64.
+    // Connectivity-aware role masks should keep this path cold on the
+    // base graph. Keep the cap broad enough to preserve /route parity
+    // for the remaining dynamic or geometrically ambiguous cases.
     const MAX_FALLBACK_COMBOS: usize = 200;
 
     let _t_fb_start = std::time::Instant::now();

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -25,7 +25,9 @@ use crate::profile_abi::Mode;
 
 use super::regions::RegionsState;
 use super::state::ServerState;
-use super::types::{ErrorResponse, Waypoint, get_node_location, parse_mode, validate_coord};
+use super::types::{
+    ErrorResponse, SnapRole, Waypoint, get_node_location, parse_mode, validate_coord,
+};
 
 // ============ Types ============
 
@@ -339,87 +341,111 @@ pub async fn compute_table_bucket_m2m(
     let mode_data = state.get_mode(mode);
     let n_nodes = mode_data.cch_topo.n_nodes as usize;
 
-    // Snap sources to graph nodes and convert to RANK space
-    // The bucket M2M algorithm operates on rank positions (CCH is rank-aligned)
+    // K-best snap with the directional #197 role filter. Use the same
+    // primary (candidates[0]) that /route uses, so the matrix and
+    // routes agree on every pair where the primary pair connects. The
+    // remaining K-1 candidates feed `apply_k_best_fallback` for the
+    // rare cells where the primary pair lands in a snap trap.
+    //
+    // snap_k_with_info_filtered_role iterates all samples within 5 km
+    // (no early-exit) — non-trivial per call. We parallelise over src/
+    // dst with rayon so an N-source request scales close-to-linearly
+    // with the number of cores instead of doing N serial snaps.
+    const SNAP_K: usize = 64;
+
+    let src_role_filter = SnapRole::Src.role_filter(mode_data);
+    let dst_role_filter = SnapRole::Dst.role_filter(mode_data);
+
+    // (rank, snapped, valid, candidate_ranks)
+    type SnapResult = (u32, (f64, f64), bool, Vec<u32>);
+
+    // For each source: SnapResult.
+    let source_results: Vec<SnapResult> = sources
+        .par_iter()
+        .map(|&[lon, lat]| {
+            let cands = state.snap_index.snap_k_with_info_filtered_role(
+                lon,
+                lat,
+                mode.0,
+                SNAP_K,
+                Some(snap_mask),
+                src_role_filter,
+            );
+            let candidate_ranks: Vec<u32> = cands
+                .iter()
+                .filter_map(|(orig_id, _, _, _)| {
+                    let r = mode_data.orig_to_rank[*orig_id as usize];
+                    if r == u32::MAX { None } else { Some(r) }
+                })
+                .collect();
+            if let Some(&(orig_id, plon, plat, _)) = cands.first() {
+                let rank = mode_data.orig_to_rank[orig_id as usize];
+                if rank != u32::MAX {
+                    return (rank, (plon, plat), true, candidate_ranks);
+                }
+            }
+            (0, (lon, lat), false, Vec::new())
+        })
+        .collect();
+
+    let target_results: Vec<SnapResult> = destinations
+        .par_iter()
+        .map(|&[lon, lat]| {
+            let cands = state.snap_index.snap_k_with_info_filtered_role(
+                lon,
+                lat,
+                mode.0,
+                SNAP_K,
+                Some(snap_mask),
+                dst_role_filter,
+            );
+            let candidate_ranks: Vec<u32> = cands
+                .iter()
+                .filter_map(|(orig_id, _, _, _)| {
+                    let r = mode_data.orig_to_rank[*orig_id as usize];
+                    if r == u32::MAX { None } else { Some(r) }
+                })
+                .collect();
+            if let Some(&(orig_id, plon, plat, _)) = cands.first() {
+                let rank = mode_data.orig_to_rank[orig_id as usize];
+                if rank != u32::MAX {
+                    return (rank, (plon, plat), true, candidate_ranks);
+                }
+            }
+            (0, (lon, lat), false, Vec::new())
+        })
+        .collect();
+
     let mut sources_rank: Vec<u32> = Vec::with_capacity(sources.len());
     let mut source_waypoints: Vec<Waypoint> = Vec::with_capacity(sources.len());
     let mut source_valid: Vec<bool> = Vec::with_capacity(sources.len());
     let mut sources_snapped: Vec<(f64, f64)> = Vec::with_capacity(sources.len());
-
-    for [lon, lat] in sources {
-        if let Some(orig_id) = state
-            .snap_index
-            .snap_filtered(*lon, *lat, mode.0, Some(snap_mask))
-        {
-            let rank = mode_data.orig_to_rank[orig_id as usize];
-            if rank != u32::MAX {
-                sources_rank.push(rank);
-                source_valid.push(true);
-                let snapped = get_node_location(state, orig_id);
-                sources_snapped.push((snapped[0], snapped[1]));
-                source_waypoints.push(Waypoint {
-                    location: snapped,
-                    name: String::new(),
-                });
-            } else {
-                sources_rank.push(0);
-                source_valid.push(false);
-                sources_snapped.push((*lon, *lat));
-                source_waypoints.push(Waypoint {
-                    location: [*lon, *lat],
-                    name: String::new(),
-                });
-            }
-        } else {
-            sources_rank.push(0);
-            source_valid.push(false);
-            sources_snapped.push((*lon, *lat));
-            source_waypoints.push(Waypoint {
-                location: [*lon, *lat],
-                name: String::new(),
-            });
-        }
+    let mut sources_candidates: Vec<Vec<u32>> = Vec::with_capacity(sources.len());
+    for (rank, (plon, plat), valid, cands) in source_results {
+        sources_rank.push(rank);
+        source_valid.push(valid);
+        sources_snapped.push((plon, plat));
+        source_waypoints.push(Waypoint {
+            location: [plon, plat],
+            name: String::new(),
+        });
+        sources_candidates.push(cands);
     }
 
-    // Snap destinations to graph nodes and convert to RANK space
     let mut targets_rank: Vec<u32> = Vec::with_capacity(destinations.len());
     let mut dest_waypoints: Vec<Waypoint> = Vec::with_capacity(destinations.len());
     let mut target_valid: Vec<bool> = Vec::with_capacity(destinations.len());
     let mut targets_snapped: Vec<(f64, f64)> = Vec::with_capacity(destinations.len());
-
-    for [lon, lat] in destinations {
-        if let Some(orig_id) = state
-            .snap_index
-            .snap_filtered(*lon, *lat, mode.0, Some(snap_mask))
-        {
-            let rank = mode_data.orig_to_rank[orig_id as usize];
-            if rank != u32::MAX {
-                targets_rank.push(rank);
-                target_valid.push(true);
-                let snapped = get_node_location(state, orig_id);
-                targets_snapped.push((snapped[0], snapped[1]));
-                dest_waypoints.push(Waypoint {
-                    location: snapped,
-                    name: String::new(),
-                });
-            } else {
-                targets_rank.push(0);
-                target_valid.push(false);
-                targets_snapped.push((*lon, *lat));
-                dest_waypoints.push(Waypoint {
-                    location: [*lon, *lat],
-                    name: String::new(),
-                });
-            }
-        } else {
-            targets_rank.push(0);
-            target_valid.push(false);
-            targets_snapped.push((*lon, *lat));
-            dest_waypoints.push(Waypoint {
-                location: [*lon, *lat],
-                name: String::new(),
-            });
-        }
+    let mut targets_candidates: Vec<Vec<u32>> = Vec::with_capacity(destinations.len());
+    for (rank, (plon, plat), valid, cands) in target_results {
+        targets_rank.push(rank);
+        target_valid.push(valid);
+        targets_snapped.push((plon, plat));
+        dest_waypoints.push(Waypoint {
+            location: [plon, plat],
+            name: String::new(),
+        });
+        targets_candidates.push(cands);
     }
 
     // Build the per-source neighbour mask if a radius was requested.
@@ -500,6 +526,31 @@ pub async fn compute_table_bucket_m2m(
         None
     };
 
+    // Per-cell K-best fallback (#197 matrix gap).
+    //
+    // Bucket M2M uses only the primary candidate per src/dst. For the
+    // small fraction of pairs the primary snap lands in a small SCC
+    // that can't reach (or be reached by) the primary on the other
+    // side, even though K-best would. /route already does this
+    // fallback inline; we mirror it here so /table agrees with /route.
+    // The K-best snap (expensive — iterates all samples within 5 km)
+    // is done LAZILY for only the affected src/dst rows/cols, so a
+    // healthy matrix pays zero K-best snap cost.
+    let (durations, distances) = apply_k_best_fallback(
+        state,
+        mode_data,
+        mode,
+        durations,
+        distances,
+        &sources_candidates,
+        &targets_candidates,
+        &source_valid,
+        &target_valid,
+        custom_weights,
+        want_duration,
+        want_distance,
+    );
+
     Json(TableResponse {
         code: "Ok".into(),
         durations,
@@ -508,6 +559,219 @@ pub async fn compute_table_bucket_m2m(
         destinations: Some(dest_waypoints),
     })
     .into_response()
+}
+
+/// 2D matrix of Option<f64> — None for unreachable/invalid cells.
+type MatrixGrid = Option<Vec<Vec<Option<f64>>>>;
+
+/// For each cell where bucket-M2M returned None (unreachable under the
+/// primary src/dst snap pair), retry with the K-best candidate combo
+/// enumeration — the same fallback /route uses for #197.
+///
+/// Lazy K-best: the expensive `snap_k_with_info_filtered_role`
+/// (iterates all samples within 5 km) is only invoked for src/dst rows
+/// and columns that contain at least one None cell. Healthy matrices
+/// pay zero overhead beyond the cheap primary snap done upfront.
+#[allow(clippy::too_many_arguments)]
+fn apply_k_best_fallback(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    mut durations: MatrixGrid,
+    mut distances: MatrixGrid,
+    sources_candidates: &[Vec<u32>],
+    targets_candidates: &[Vec<u32>],
+    source_valid: &[bool],
+    target_valid: &[bool],
+    custom_weights: Option<&super::exclude::ExcludeWeights>,
+    want_duration: bool,
+    want_distance: bool,
+) -> (MatrixGrid, MatrixGrid) {
+    use super::query::CchQuery;
+
+    // Cap per-cell fallback combos. /route uses 400 because a single
+    // hopeless query at 20s wall is acceptable; /table can have
+    // hundreds of failed cells so the per-cell budget must be smaller
+    // or total latency explodes (the unbounded version ran 88 s on
+    // Belgium 50×50 scattered). 200 combos covers (i, j) ≤ ~19, which
+    // empirically matches /route's hit rate on Belgium random pairs
+    // (no measured route-only successes on the 200-pair sweep) while
+    // keeping scattered 50×50 wall under ~2 s.
+    const MAX_FALLBACK_COMBOS: usize = 200;
+
+    let n_sources = sources_candidates.len();
+    let n_targets = targets_candidates.len();
+
+    // Decide whether any cell needs the fallback. Skip the (cheap)
+    // CchQuery construction entirely on the common path.
+    let needs_fallback = |grid: &MatrixGrid| -> bool {
+        if let Some(g) = grid {
+            for (i, row) in g.iter().enumerate() {
+                if !source_valid[i] {
+                    continue;
+                }
+                for (j, cell) in row.iter().enumerate() {
+                    if target_valid[j] && cell.is_none() {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    };
+    let need_time = want_duration && needs_fallback(&durations);
+    let need_dist = want_distance && needs_fallback(&distances);
+    if !need_time && !need_dist {
+        return (durations, distances);
+    }
+
+    // Time CchQuery: use the same backend as /route (flats from
+    // mode_data, or recustomised flats if exclude/avoid are in play).
+    // with_custom_weights expects the *reverse* down-adjacency
+    // (DownReverseAdjFlat) for the bidirectional backward search — same
+    // layout as `mode_data.down_rev_flat`.
+    let time_query = if need_time {
+        Some(match custom_weights {
+            Some(cw) => CchQuery::with_custom_weights(
+                &mode_data.cch_topo,
+                &cw.time_up_flat,
+                &cw.time_down_flat,
+                &cw.time_weights,
+            ),
+            None => CchQuery::new(state, mode),
+        })
+    } else {
+        None
+    };
+
+    // Distance CchQuery: the CCH topology is shared between time and
+    // distance, and the metric-dependent INF sets agree (both are gated
+    // on mode access + exclude flags). So we reuse the TIME flats for
+    // topology + topo_edge_idx and override with the distance-metric
+    // weights. The standalone `*_dist` flats and the `dist_*` flats on
+    // `ExcludeWeights` intentionally omit `topo_edge_idx` because PHAST
+    // doesn't need it — they cannot back a `CchQuery` directly.
+    let dist_query = if need_dist {
+        let (up_flat, down_flat, weights) = match custom_weights {
+            Some(cw) => (&cw.time_up_flat, &cw.time_down_flat, &cw.dist_weights),
+            None => (
+                &mode_data.up_adj_flat,
+                &mode_data.down_rev_flat,
+                &mode_data.cch_weights_dist,
+            ),
+        };
+        Some(CchQuery::with_custom_weights(
+            &mode_data.cch_topo,
+            up_flat,
+            down_flat,
+            weights,
+        ))
+    } else {
+        None
+    };
+
+    // Build (i+j)-ordered combo enumeration; same shape as /route.
+    let combo_enum = |k_src: usize, k_dst: usize| -> Vec<(usize, usize)> {
+        let mut order = Vec::new();
+        for sum in 0..(k_src + k_dst) {
+            for i in 0..k_src {
+                if let Some(j) = sum.checked_sub(i)
+                    && j < k_dst
+                {
+                    order.push((i, j));
+                }
+            }
+        }
+        if order.len() > MAX_FALLBACK_COMBOS {
+            order.truncate(MAX_FALLBACK_COMBOS);
+        }
+        order
+    };
+
+    // Build the list of cells needing fallback. We snapshot the work
+    // upfront so we can parallelise the per-cell P2P queries.
+    let mut work: Vec<(usize, usize, bool, bool)> = Vec::new();
+    for src_idx in 0..n_sources {
+        if !source_valid[src_idx] || sources_candidates[src_idx].is_empty() {
+            continue;
+        }
+        for tgt_idx in 0..n_targets {
+            if !target_valid[tgt_idx] || targets_candidates[tgt_idx].is_empty() {
+                continue;
+            }
+            let dur_missing = durations
+                .as_ref()
+                .map(|d| d[src_idx][tgt_idx].is_none())
+                .unwrap_or(false);
+            let dist_missing = distances
+                .as_ref()
+                .map(|d| d[src_idx][tgt_idx].is_none())
+                .unwrap_or(false);
+            if dur_missing || dist_missing {
+                work.push((src_idx, tgt_idx, dur_missing, dist_missing));
+            }
+        }
+    }
+
+    // Solve per cell in parallel — CchQuery is Sync (immutable
+    // references to topology + weights; thread-local search state
+    // lives in CchQueryState). Each cell is independent, so rayon
+    // gives close to linear speed-up on n_cores.
+    let time_query_ref = time_query.as_ref();
+    let dist_query_ref = dist_query.as_ref();
+    let patches: Vec<(usize, usize, Option<f64>, Option<f64>)> = work
+        .par_iter()
+        .map(|&(src_idx, tgt_idx, dur_missing, dist_missing)| {
+            let src_cands = &sources_candidates[src_idx];
+            let tgt_cands = &targets_candidates[tgt_idx];
+            let order = combo_enum(src_cands.len(), tgt_cands.len());
+            let mut dur_done = !dur_missing;
+            let mut dist_done = !dist_missing;
+            let mut dur_val: Option<f64> = None;
+            let mut dist_val: Option<f64> = None;
+            for &(i, j) in &order {
+                let s_rank = src_cands[i];
+                let d_rank = tgt_cands[j];
+                if s_rank == d_rank {
+                    continue;
+                }
+                if !dur_done
+                    && let Some(tq) = time_query_ref
+                    && let Some(r) = tq.query(s_rank, d_rank)
+                {
+                    dur_val = Some(r.distance as f64 / 10.0);
+                    dur_done = true;
+                }
+                if !dist_done
+                    && let Some(dq) = dist_query_ref
+                    && let Some(r) = dq.query(s_rank, d_rank)
+                {
+                    dist_val = Some(r.distance as f64 / 1000.0);
+                    dist_done = true;
+                }
+                if dur_done && dist_done {
+                    break;
+                }
+            }
+            (src_idx, tgt_idx, dur_val, dist_val)
+        })
+        .collect();
+
+    // Apply patches sequentially (cheap O(failed_cells) writes).
+    for (src_idx, tgt_idx, dur_val, dist_val) in patches {
+        if let Some(grid) = durations.as_mut()
+            && let Some(v) = dur_val
+        {
+            grid[src_idx][tgt_idx] = Some(v);
+        }
+        if let Some(grid) = distances.as_mut()
+            && let Some(v) = dist_val
+        {
+            grid[src_idx][tgt_idx] = Some(v);
+        }
+    }
+
+    (durations, distances)
 }
 
 /// Convert flat u32 matrix to 2D Option<f64> matrix with null for invalid/unreachable.
@@ -701,13 +965,18 @@ pub async fn table_stream_handler(
     let mut sources_rank: Vec<u32> = Vec::with_capacity(req.sources.len());
     let mut valid_src_indices: Vec<usize> = Vec::with_capacity(req.sources.len());
     let mut sources_snapped: Vec<(f64, f64)> = Vec::with_capacity(req.sources.len());
+    let src_role_filter = SnapRole::Src.role_filter(mode_data);
+    let dst_role_filter = SnapRole::Dst.role_filter(mode_data);
+
     for (i, [lon, lat]) in req.sources.iter().enumerate() {
         let mut matched = false;
-        if let Some(orig_id) =
-            state
-                .snap_index
-                .snap_filtered(*lon, *lat, mode.0, Some(&snap_mask[..]))
-        {
+        if let Some(orig_id) = state.snap_index.snap_filtered_role(
+            *lon,
+            *lat,
+            mode.0,
+            Some(&snap_mask[..]),
+            src_role_filter,
+        ) {
             let rank = mode_data.orig_to_rank[orig_id as usize];
             if rank != u32::MAX {
                 sources_rank.push(rank);
@@ -728,11 +997,13 @@ pub async fn table_stream_handler(
     let mut targets_snapped: Vec<(f64, f64)> = Vec::with_capacity(req.destinations.len());
     for (i, [lon, lat]) in req.destinations.iter().enumerate() {
         let mut matched = false;
-        if let Some(orig_id) =
-            state
-                .snap_index
-                .snap_filtered(*lon, *lat, mode.0, Some(&snap_mask[..]))
-        {
+        if let Some(orig_id) = state.snap_index.snap_filtered_role(
+            *lon,
+            *lat,
+            mode.0,
+            Some(&snap_mask[..]),
+            dst_role_filter,
+        ) {
             let rank = mode_data.orig_to_rank[orig_id as usize];
             if rank != u32::MAX {
                 targets_rank.push(rank);

--- a/route/src/server/transit_handler.rs
+++ b/route/src/server/transit_handler.rs
@@ -400,12 +400,19 @@ pub fn compute_access_context(
     }
 
     let origin_ranks = snap_stop_ranks_on_mode(&access_candidates, timetable, state, access_idx);
-    let origin_source_rank = snap_to_rank(req.origin_lon, req.origin_lat, state, access_idx)
-        .ok_or_else(|| {
-            not_found(&format!(
-                "origin could not snap to the {access_mode} network"
-            ))
-        })?;
+    // Origin is the source for the access leg (walking out from origin).
+    let origin_source_rank = snap_to_rank_role(
+        req.origin_lon,
+        req.origin_lat,
+        state,
+        access_idx,
+        super::types::SnapRole::Src,
+    )
+    .ok_or_else(|| {
+        not_found(&format!(
+            "origin could not snap to the {access_mode} network"
+        ))
+    })?;
 
     // Access 1-to-N via the distance-only CchQuery (#103). Reuses the
     // thread-local `CCH_QUERY_STATE` with O(1) per-query reset.
@@ -583,12 +590,19 @@ pub fn compute_transit_journey_with_access(
     }
 
     let dest_ranks = snap_stop_ranks_on_mode(&egress_candidates, timetable, state, egress_idx);
-    let dest_source_rank =
-        snap_to_rank(req.dest_lon, req.dest_lat, state, egress_idx).ok_or_else(|| {
-            not_found(&format!(
-                "destination could not snap to the {egress_mode} network"
-            ))
-        })?;
+    // Destination is the target for the egress leg (walking IN from stops).
+    let dest_source_rank = snap_to_rank_role(
+        req.dest_lon,
+        req.dest_lat,
+        state,
+        egress_idx,
+        super::types::SnapRole::Dst,
+    )
+    .ok_or_else(|| {
+        not_found(&format!(
+            "destination could not snap to the {egress_mode} network"
+        ))
+    })?;
 
     // Egress 1-to-N via distance-only CchQuery. K sources × 1 target.
     let egress_query = CchQuery::with_custom_weights(
@@ -1242,7 +1256,20 @@ fn build_routed_road_leg(
 }
 
 fn snap_to_rank(lon: f64, lat: f64, state: &ServerState, mode_idx: u8) -> Option<u32> {
+    snap_to_rank_role(lon, lat, state, mode_idx, super::types::SnapRole::Either)
+}
+
+fn snap_to_rank_role(
+    lon: f64,
+    lat: f64,
+    state: &ServerState,
+    mode_idx: u8,
+    role: super::types::SnapRole,
+) -> Option<u32> {
     let mode_data = &state.modes[mode_idx as usize];
-    let orig = state.snap_index.snap(lon, lat, mode_idx)?;
+    let role_filter = role.role_filter(mode_data);
+    let orig = state
+        .snap_index
+        .snap_filtered_role(lon, lat, mode_idx, None, role_filter)?;
     mode_data.rank_for_original(orig)
 }

--- a/route/src/server/trip.rs
+++ b/route/src/server/trip.rs
@@ -637,34 +637,65 @@ pub async fn trip_handler(
                 std::borrow::Cow::Borrowed(&mode_data.mask)
             };
 
-        // Snap all coordinates and convert to rank space
+        // Snap all coordinates and convert to rank space.
+        // For TSP each waypoint participates in two legs (arrives from
+        // the previous, departs to the next), so each snap must yield
+        // an edge that is both a valid source AND a valid destination.
+        // We fold both role bitsets into the snap_mask up-front (cheap,
+        // one allocation per request) so a single snap call returns a
+        // candidate that satisfies both roles.
+        let mut role_anded_mask: Vec<u64> = snap_mask.to_vec();
+        let outbound = mode_data.has_outbound.as_slice();
+        let inbound = mode_data.has_inbound.as_slice();
+        for (i, word) in role_anded_mask.iter_mut().enumerate() {
+            let ob = outbound.get(i).copied().unwrap_or(u64::MAX);
+            let ib = inbound.get(i).copied().unwrap_or(u64::MAX);
+            *word &= ob & ib;
+        }
+
+        // Snap K candidates per waypoint so we can fall back when the
+        // primary snap traps us in a small SCC (#197 matrix gap). The
+        // first candidate feeds the N×N TSP matrix; the rest patch
+        // INF cells via per-cell P2P after the matrix is built.
+        const SNAP_K: usize = 64;
+
         let mut ranks: Vec<u32> = Vec::with_capacity(n);
         let mut snapped_locations: Vec<[f64; 2]> = Vec::with_capacity(n);
         let mut valid: Vec<bool> = Vec::with_capacity(n);
+        let mut candidates: Vec<Vec<u32>> = Vec::with_capacity(n);
 
         for &[lon, lat] in &coordinates {
-            if let Some(orig_id) =
-                state_clone
-                    .snap_index
-                    .snap_filtered(lon, lat, mode.0, Some(&snap_mask))
-            {
-                let rank = mode_data.orig_to_rank[orig_id as usize];
+            // No role_filter here — we already AND'd both roles into
+            // role_anded_mask, so a single snap pass returns candidates
+            // satisfying both src and dst.
+            let cands = state_clone.snap_index.snap_k_with_info_filtered(
+                lon,
+                lat,
+                mode.0,
+                SNAP_K,
+                Some(&role_anded_mask),
+            );
+            let mut cand_ranks: Vec<u32> = Vec::with_capacity(cands.len());
+            for (orig_id, _plon, _plat, _d) in &cands {
+                let rank = mode_data.orig_to_rank[*orig_id as usize];
+                if rank != u32::MAX {
+                    cand_ranks.push(rank);
+                }
+            }
+            if let Some((orig_id, _, _, _)) = cands.first() {
+                let rank = mode_data.orig_to_rank[*orig_id as usize];
                 if rank != u32::MAX {
                     ranks.push(rank);
                     valid.push(true);
-                    // Get snapped location
-                    let snapped = get_node_location(&state_clone, orig_id);
-                    snapped_locations.push(snapped);
-                } else {
-                    ranks.push(0);
-                    valid.push(false);
-                    snapped_locations.push([lon, lat]);
+                    snapped_locations.push(get_node_location(&state_clone, *orig_id));
+                    candidates.push(cand_ranks);
+                    continue;
                 }
-            } else {
-                ranks.push(0);
-                valid.push(false);
-                snapped_locations.push([lon, lat]);
             }
+            ranks.push(0);
+            valid.push(false);
+            snapped_locations.push([lon, lat]);
+            candidates.push(Vec::new());
         }
 
         // Check that all waypoints snapped successfully
@@ -700,19 +731,185 @@ pub async fn trip_handler(
         };
 
         // Compute N*N duration matrix (for TSP optimization, always on time)
-        let (duration_matrix, _stats) =
+        let (mut duration_matrix, _stats) =
             table_bucket_full_flat(n_nodes, time_up, time_down, &ranks, &ranks);
 
-        // Run TSP solver on the duration matrix
-        let tsp_result = solve_tsp(&duration_matrix, n, round_trip);
-
         // Compute distance matrix if requested (for reporting leg distances)
-        let distance_matrix = if want_distance {
+        let mut distance_matrix = if want_distance {
             let (dist_mat, _) = table_bucket_full_flat(n_nodes, dist_up, dist_down, &ranks, &ranks);
             Some(dist_mat)
         } else {
             None
         };
+
+        // K-best fallback for INF matrix cells (#197 matrix gap, same
+        // pattern as /table). If the primary snap pair can't connect,
+        // try other snap candidates per cell via P2P. This must happen
+        // BEFORE the TSP solver — INF cells would otherwise be treated
+        // as "impossible legs" and produce nonsense tours.
+        {
+            use super::query::CchQuery;
+            use rayon::prelude::*;
+
+            // Bounded per-cell fallback. Same justification as
+            // table.rs::apply_k_best_fallback — keeps tail latency in
+            // check on pathological tours where many legs straddle
+            // disconnected fragments.
+            const MAX_FALLBACK_COMBOS: usize = 200;
+            let combo_enum = |k_src: usize, k_dst: usize| -> Vec<(usize, usize)> {
+                let mut order = Vec::new();
+                for sum in 0..(k_src + k_dst) {
+                    for i in 0..k_src {
+                        if let Some(j) = sum.checked_sub(i)
+                            && j < k_dst
+                        {
+                            order.push((i, j));
+                        }
+                    }
+                }
+                if order.len() > MAX_FALLBACK_COMBOS {
+                    order.truncate(MAX_FALLBACK_COMBOS);
+                }
+                order
+            };
+
+            // Detect whether any cell needs the fallback.
+            let any_dur_inf = duration_matrix.contains(&u32::MAX);
+            let any_dist_inf = distance_matrix
+                .as_ref()
+                .map(|m| m.contains(&u32::MAX))
+                .unwrap_or(false);
+
+            if any_dur_inf || any_dist_inf {
+                let time_query = if any_dur_inf {
+                    let query = match (&avoid_result, &exclude_weights) {
+                        (Some((aw, _)), _) => CchQuery::with_custom_weights(
+                            &mode_data.cch_topo,
+                            &aw.time_up_flat,
+                            &aw.time_down_flat,
+                            &aw.time_weights,
+                        ),
+                        (None, Some(ew)) => CchQuery::with_custom_weights(
+                            &mode_data.cch_topo,
+                            &ew.time_up_flat,
+                            &ew.time_down_flat,
+                            &ew.time_weights,
+                        ),
+                        (None, None) => CchQuery::new(&state_clone, mode),
+                    };
+                    Some(query)
+                } else {
+                    None
+                };
+                let dist_query = if any_dist_inf {
+                    // Reuse the TIME flats' topology (which carries
+                    // topo_edge_idx) and override with the distance
+                    // metric weights — distance-only flats omit
+                    // topo_edge_idx so they cannot back a CchQuery.
+                    let query = match (&avoid_result, &exclude_weights) {
+                        (Some((aw, _)), _) => CchQuery::with_custom_weights(
+                            &mode_data.cch_topo,
+                            &aw.time_up_flat,
+                            &aw.time_down_flat,
+                            &aw.dist_weights,
+                        ),
+                        (None, Some(ew)) => CchQuery::with_custom_weights(
+                            &mode_data.cch_topo,
+                            &ew.time_up_flat,
+                            &ew.time_down_flat,
+                            &ew.dist_weights,
+                        ),
+                        (None, None) => CchQuery::with_custom_weights(
+                            &mode_data.cch_topo,
+                            &mode_data.up_adj_flat,
+                            &mode_data.down_rev_flat,
+                            &mode_data.cch_weights_dist,
+                        ),
+                    };
+                    Some(query)
+                } else {
+                    None
+                };
+
+                // Collect cells needing fallback, then run them in
+                // parallel via rayon.
+                let mut work: Vec<(usize, usize, bool, bool)> = Vec::new();
+                for i in 0..n {
+                    if !valid[i] || candidates[i].is_empty() {
+                        continue;
+                    }
+                    for j in 0..n {
+                        if i == j || !valid[j] || candidates[j].is_empty() {
+                            continue;
+                        }
+                        let cell = i * n + j;
+                        let dur_missing = duration_matrix[cell] == u32::MAX;
+                        let dist_missing = distance_matrix
+                            .as_ref()
+                            .map(|m| m[cell] == u32::MAX)
+                            .unwrap_or(false);
+                        if dur_missing || dist_missing {
+                            work.push((i, j, dur_missing, dist_missing));
+                        }
+                    }
+                }
+
+                let time_q = time_query.as_ref();
+                let dist_q = dist_query.as_ref();
+                let patches: Vec<(usize, usize, u32, u32)> = work
+                    .par_iter()
+                    .map(|&(i, j, dur_missing, dist_missing)| {
+                        let src_cands = &candidates[i];
+                        let dst_cands = &candidates[j];
+                        let order = combo_enum(src_cands.len(), dst_cands.len());
+                        let mut dur_done = !dur_missing;
+                        let mut dist_done = !dist_missing;
+                        let mut dur_val = u32::MAX;
+                        let mut dist_val = u32::MAX;
+                        for &(ci, cj) in &order {
+                            let s_rank = src_cands[ci];
+                            let d_rank = dst_cands[cj];
+                            if s_rank == d_rank {
+                                continue;
+                            }
+                            if !dur_done
+                                && let Some(tq) = time_q
+                                && let Some(r) = tq.query(s_rank, d_rank)
+                            {
+                                dur_val = r.distance;
+                                dur_done = true;
+                            }
+                            if !dist_done
+                                && let Some(dq) = dist_q
+                                && let Some(r) = dq.query(s_rank, d_rank)
+                            {
+                                dist_val = r.distance;
+                                dist_done = true;
+                            }
+                            if dur_done && dist_done {
+                                break;
+                            }
+                        }
+                        (i, j, dur_val, dist_val)
+                    })
+                    .collect();
+
+                for (i, j, dur_val, dist_val) in patches {
+                    let cell = i * n + j;
+                    if dur_val != u32::MAX {
+                        duration_matrix[cell] = dur_val;
+                    }
+                    if dist_val != u32::MAX
+                        && let Some(m) = distance_matrix.as_mut()
+                    {
+                        m[cell] = dist_val;
+                    }
+                }
+            }
+        }
+
+        // Run TSP solver on the (now-patched) duration matrix
+        let tsp_result = solve_tsp(&duration_matrix, n, round_trip);
 
         // Build legs from the optimized order
         let order = &tsp_result.order;

--- a/route/src/server/types.rs
+++ b/route/src/server/types.rs
@@ -37,11 +37,12 @@ pub struct ErrorResponse {
 #[serde(rename_all = "lowercase")]
 pub enum SnapRole {
     /// Source role: snap candidates must have at least one mode-valid
-    /// outbound arc.
+    /// outbound arc and be able to reach the main routing core.
     #[default]
     Src,
     /// Destination role: snap candidates must have at least one
-    /// mode-valid inbound arc.
+    /// mode-valid inbound arc and be reachable from the main routing
+    /// core.
     Dst,
     /// No role filter; behaves like the legacy snap.
     Either,


### PR DESCRIPTION
## Summary

The #197 directional snap fix had been applied only to `/route`; `/table`, `/trip`, `/isochrone`, plus the gRPC Flight endpoints + catchment + transit were all going through the legacy unfiltered snap. For ~1% of Belgium OD pairs (e.g. Antwerp→Brussels, Ghent→Liège) `/table` returned `null` where `/route` returned a valid route. **Further investigation also surfaced a perf bug:** for clustered city queries the role-masks weren't connectivity-aware, so ~11 % of valid-looking snap targets sat in isolated SCCs and poisoned the matrix primary pass. The K-best per-cell fallback worked but at brutal cost (1.4 s at 100×100, 5.5 s at 200×200).

Root cause: `snap_filtered` (legacy path) didn't check `has_outbound`/`has_inbound`. And the original `has_outbound`/`has_inbound` only verified "node has at least one mode-valid arc out/in", not whether that node could actually reach (or be reached by) the main routing core.

## What changed

- **`snap_index.rs`** — new `snap_filtered_role` convenience method; `snap_k_with_info_filtered_role` now drives `iterate_rings`' early-exit using the K-th-best d² instead of `None`, deterministic tie-breaking via linear scan.
- **`state.rs::build_role_masks`** — **connectivity-aware role masks**: builds reverse CSR of the filtered EBG, runs Kosaraju to find the largest SCC, then `has_outbound = has-outbound-arc AND can-reach-core` and `has_inbound = has-inbound-arc AND reachable-from-core`. Preserves directed entry/exit stubs, drops isolated micro-SCCs.
- **`table.rs`** — K-best snap upfront (rayon-parallel over src/dst, K=64), per-cell P2P fallback for INF cells (rayon-parallel, capped at 200 combos for tail-latency safety). Reserved for genuine geometric ambiguity now, not disconnected-component cleanup.
- **`trip.rs`** — same K-best snap + capped parallel fallback before TSP.
- **`isochrone_handler.rs`** — Src/Dst role filter tracking `direction=depart|arrive`; Src for `/isochrone/bulk`.
- **`flight.rs`, `catchment.rs`, `transit_handler.rs`** — role-aware snap on every call site.
- **`regions.rs::dispatch_many`** — single-region fast-path skips the per-coord snap_winner sweep.
- **`bench/main.rs`** — data-dir lookup tries `step7/` before `step7-rank-aligned/`.

## Belgium verification — final numbers

**Correctness (200-pair /route ↔ /table sweep, random Belgium coords):**
- Before: only when primary snap aligned by luck
- After: **127/127 successful pairs agree within 1 % / 5 s** (was 125/125, +2 pairs from connectivity-aware masks)
- Zero `/route`-only-success and zero `/table`-only-success

**`/table` HTTP latency (clustered city coords, duration only):**

| Size | Before fix | After K-best + naive fallback | After SCC role masks |
|---|---|---|---|
| 10×10 | 30 ms (incorrect) | 35 ms | **36 ms** |
| 25×25 | n/a | 86 ms | **72 ms** |
| 50×50 | 30 ms (incorrect) | 72 ms | **26 ms** |
| 100×100 | n/a | 1.4 s | **90 ms** (15× faster) |
| 200×200 | n/a | 5.5 s | **94 ms** (58× faster) |

**`/table` HTTP latency, scattered random Belgium coords 50×50:**
- Unbounded fallback: 88 s, 98 stuck-INF cells
- Capped fallback: 3.1 s, 98 stuck-INF cells
- **SCC role masks: 22 ms, 0 stuck-INF cells**

**No regressions:**
- `/route` p50: 8.5 ms (unchanged)
- `/isochrone` p50: 5 ms (unchanged)
- Matrix algorithm bench (5000×5000): 4.7 s (unchanged)
- `/trip` 4-point: `code=Ok`, all legs computed (was `code=Partial`)

## What stays open

- **#191** — small-N matrix (10×10 = 17.9 ms, 3× OSRM). Graph-architectural; needs stall-on-demand in the bucket-M2M Dijkstra. Updated with measurements + analysis on the issue.
- **#124** — transit-bus-density idea. Already triaged and parked.

## Test plan
- [x] `cargo build --workspace --release`
- [x] `cargo test --workspace --release` (all green, including new `role_masks_keep_core_reachable_stubs_and_drop_small_sccs`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo fmt --all --check` (clean)
- [x] 200-pair `/route ↔ /table` consistency sweep
- [x] `butterfly-bench bucket-m2m --sizes 10,25,50,100,500,1000,2000,5000 --parallel`
- [x] Targeted bugs (Antwerp→Brussels, Ghent→Liège) reproduce-and-fix verified
- [x] HTTP /table perf at sizes 10/25/50/100/200, clustered and scattered
- [ ] Full pipeline rebuild on fresh `belgium-latest.pbf` — DONE (data/belgium-latest/step8 has fresh car/bike/foot artifacts from May 22 PBF); not yet swapped into the serve path