### PR TITLE
perf(route): #241 avoid cache returns Arc<AvoidEntry> — /table hit 366 ms → 22 ms

### DIFF
--- a/route/src/server/avoid.rs
+++ b/route/src/server/avoid.rs
@@ -20,8 +20,6 @@ use std::sync::Arc;
 use geo::{Contains, Coord, Point, Polygon};
 use parking_lot::RwLock;
 
-use crate::formats::cch_weights::CchWeights;
-
 use super::exclude::{self, ExcludeWeights};
 use super::snap_index::PackedSnapIndex;
 use super::state::{ModeData, ServerState};
@@ -407,51 +405,33 @@ fn get_or_compute_avoid_entry(
     Ok(entry)
 }
 
-/// Compute time-only avoid weights for P2P route queries.
+/// Compute (or cache-fetch) the avoid weight set for /route, /table,
+/// /isochrone, /trip, /matching. Returns the full `Arc<AvoidEntry>`
+/// directly — callers borrow fields they need via deref. This avoids
+/// the ~100-400 MB deep clone on cache hits that owned-return forced.
 ///
-/// Backed by the shared `AvoidWeightCache`. The cache stores full
-/// `ExcludeWeights`; this function clones the time field. /route pays
-/// a ~1.2× upfront cost vs a hypothetical time-only cache but in
-/// exchange any subsequent /table or /isochrone on the same polygon
-/// gets the same cache hit.
-pub fn compute_avoid_weights_time_only(
-    state: &ServerState,
-    mode_data: &ModeData,
-    avoid_json: &str,
-    exclude_mask: Option<u8>,
-) -> Result<(CchWeights, Vec<u8>), String> {
-    let mode_idx = mode_index_in_state(state, mode_data)? as u8;
-    let entry = get_or_compute_avoid_entry(state, mode_data, mode_idx, avoid_json, exclude_mask)?;
-    Ok((entry.weights.time_weights.clone(), entry.flags.clone()))
-}
-
-/// Compute full avoid weights (time + distance + flat adjacencies).
-///
-/// For PHAST-based endpoints (isochrones, matrices, trip). Backed by
-/// the shared `AvoidWeightCache`. If `exclude_mask` is also specified,
-/// both avoid and exclude flags are merged before recustomization.
+/// Both time-only (P2P /route) and full (PHAST batch) consumers go
+/// through this single entry point. Time-only callers read
+/// `entry.weights.time_weights`; full callers read `entry.weights`.
 pub fn compute_avoid_weights(
     state: &ServerState,
     mode_data: &ModeData,
     avoid_json: &str,
     exclude_mask: Option<u8>,
-) -> Result<(ExcludeWeights, Vec<u8>), String> {
+) -> Result<Arc<AvoidEntry>, String> {
     let mode_idx = mode_index_in_state(state, mode_data)? as u8;
-    let entry = get_or_compute_avoid_entry(state, mode_data, mode_idx, avoid_json, exclude_mask)?;
-    // The cached ExcludeWeights is shared via Arc; consumers that
-    // need an owned value pay a deep clone here. The 100-200 MB clone
-    // is still cheap vs the 30 s recustomization it replaces.
-    let owned: ExcludeWeights = ExcludeWeights {
-        time_weights: entry.weights.time_weights.clone(),
-        dist_weights: entry.weights.dist_weights.clone(),
-        time_up_flat: entry.weights.time_up_flat.clone(),
-        time_down_flat: entry.weights.time_down_flat.clone(),
-        time_down_fwd_flat: entry.weights.time_down_fwd_flat.clone(),
-        dist_up_flat: entry.weights.dist_up_flat.clone(),
-        dist_down_flat: entry.weights.dist_down_flat.clone(),
-        dist_down_fwd_flat: entry.weights.dist_down_fwd_flat.clone(),
-    };
-    Ok((owned, entry.flags.clone()))
+    get_or_compute_avoid_entry(state, mode_data, mode_idx, avoid_json, exclude_mask)
+}
+
+/// Compatibility shim: /route only needs the time field but reuses
+/// the cache via the unified entry. Same `Arc<AvoidEntry>` shape.
+pub fn compute_avoid_weights_time_only(
+    state: &ServerState,
+    mode_data: &ModeData,
+    avoid_json: &str,
+    exclude_mask: Option<u8>,
+) -> Result<Arc<AvoidEntry>, String> {
+    compute_avoid_weights(state, mode_data, avoid_json, exclude_mask)
 }
 
 /// Look up the mode index by comparing the `ModeData` pointer against

--- a/route/src/server/isochrone_handler.rs
+++ b/route/src/server/isochrone_handler.rs
@@ -694,9 +694,9 @@ pub async fn isochrone_handler(
     let mode_data = state.get_mode(mode);
 
     // Compute avoid weights (includes exclude if both present)
-    let avoid_result = if let Some(ref avoid_str) = avoid_json {
+    let avoid_entry = if let Some(ref avoid_str) = avoid_json {
         match super::avoid::compute_avoid_weights(&state, mode_data, avoid_str, exclude_mask) {
-            Ok((weights, flags)) => Some((weights, flags)),
+            Ok(entry) => Some(entry),
             Err(e) => {
                 return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
             }
@@ -727,10 +727,10 @@ pub async fn isochrone_handler(
         .unwrap_or(false);
 
     // Build snap mask (with optional avoid/exclude filtering)
-    let snap_mask: std::borrow::Cow<'_, [u64]> = if let Some((_, ref avoid_flags)) = avoid_result {
+    let snap_mask: std::borrow::Cow<'_, [u64]> = if let Some(ref entry) = avoid_entry {
         std::borrow::Cow::Owned(super::avoid::build_avoid_mask(
             &mode_data.mask,
-            avoid_flags,
+            &entry.flags,
             exclude_mask.map(|exc| (state.edge_exclude_flags.as_slice(), exc)),
         ))
     } else if let Some(exc) = exclude_mask {
@@ -784,7 +784,7 @@ pub async fn isochrone_handler(
     }
 
     // Get custom weights (avoid takes priority, then exclude)
-    let exclude_weights = if avoid_result.is_none() {
+    let exclude_weights = if avoid_entry.is_none() {
         exclude_mask.map(|exc| state.get_exclude_weights(mode, exc))
     } else {
         None
@@ -795,11 +795,11 @@ pub async fn isochrone_handler(
     //   bounded-search reverse PHAST and as ambient state for snap path.
     // - `down_fwd_flat`: used by the *forward* isochrone downward scan.
     let (up_flat, down_flat, down_fwd_flat, node_weights) = if use_distance_weights {
-        if let Some((ref aw, _)) = avoid_result {
+        if let Some(ref entry) = avoid_entry {
             (
-                &aw.dist_up_flat,
-                &aw.dist_down_flat,
-                &aw.dist_down_fwd_flat,
+                &entry.weights.dist_up_flat,
+                &entry.weights.dist_down_flat,
+                &entry.weights.dist_down_fwd_flat,
                 state.node_weights_dist.as_slice(),
             )
         } else if let Some(ref ew) = exclude_weights {
@@ -817,11 +817,11 @@ pub async fn isochrone_handler(
                 state.node_weights_dist.as_slice(),
             )
         }
-    } else if let Some((ref aw, _)) = avoid_result {
+    } else if let Some(ref entry) = avoid_entry {
         (
-            &aw.time_up_flat,
-            &aw.time_down_flat,
-            &aw.time_down_fwd_flat,
+            &entry.weights.time_up_flat,
+            &entry.weights.time_down_flat,
+            &entry.weights.time_down_fwd_flat,
             mode_data.node_weights.as_slice(),
         )
     } else if let Some(ref ew) = exclude_weights {
@@ -1144,9 +1144,9 @@ pub async fn isochrone_bulk_handler(
     let time_ds = req.time_s * 10;
 
     // Compute avoid weights (includes exclude if both present)
-    let avoid_result = if let Some(ref avoid_str) = avoid_json {
+    let avoid_entry = if let Some(ref avoid_str) = avoid_json {
         match super::avoid::compute_avoid_weights(&state, mode_data, avoid_str, exclude_mask) {
-            Ok((weights, flags)) => Some((weights, flags)),
+            Ok(entry) => Some(entry),
             Err(e) => {
                 return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
             }
@@ -1156,17 +1156,17 @@ pub async fn isochrone_bulk_handler(
     };
 
     // Get exclude weights if only exclude (no avoid)
-    let exclude_weights = if avoid_result.is_none() {
+    let exclude_weights = if avoid_entry.is_none() {
         exclude_mask.map(|exc| state.get_exclude_weights(mode, exc))
     } else {
         None
     };
 
     // Build snap mask
-    let snap_mask: Vec<u64> = if let Some((_, ref avoid_flags)) = avoid_result {
+    let snap_mask: Vec<u64> = if let Some(ref entry) = avoid_entry {
         super::avoid::build_avoid_mask(
             &mode_data.mask,
-            avoid_flags,
+            &entry.flags,
             exclude_mask.map(|exc| (state.edge_exclude_flags.as_slice(), exc)),
         )
     } else if let Some(exc) = exclude_mask {
@@ -1176,8 +1176,11 @@ pub async fn isochrone_bulk_handler(
     };
 
     // Select forward flat adjacencies for PHAST
-    let (up_flat, down_fwd_flat) = if let Some((ref aw, _)) = avoid_result {
-        (&aw.time_up_flat, &aw.time_down_fwd_flat)
+    let (up_flat, down_fwd_flat) = if let Some(ref entry) = avoid_entry {
+        (
+            &entry.weights.time_up_flat,
+            &entry.weights.time_down_fwd_flat,
+        )
     } else if let Some(ref ew) = exclude_weights {
         (&ew.time_up_flat, &ew.time_down_fwd_flat)
     } else {

--- a/route/src/server/matching.rs
+++ b/route/src/server/matching.rs
@@ -272,23 +272,23 @@ pub async fn match_trace_handler(
         // Build snap mask and weights: avoid takes priority, then exclude
         let mode_data = state_clone.get_mode(mode);
 
-        let avoid_result = if let Some(ref avoid_str) = avoid_json {
+        let avoid_entry = if let Some(ref avoid_str) = avoid_json {
             super::avoid::compute_avoid_weights(&state_clone, mode_data, avoid_str, exclude_mask)
                 .ok()
         } else {
             None
         };
 
-        let exclude_weights = if avoid_result.is_none() {
+        let exclude_weights = if avoid_entry.is_none() {
             exclude_mask.map(|exc| state_clone.get_exclude_weights(mode, exc))
         } else {
             None
         };
 
-        let snap_mask: Option<Vec<u64>> = if let Some((_, ref avoid_flags)) = avoid_result {
+        let snap_mask: Option<Vec<u64>> = if let Some(ref entry) = avoid_entry {
             Some(super::avoid::build_avoid_mask(
                 &mode_data.mask,
-                avoid_flags,
+                &entry.flags,
                 exclude_mask.map(|exc| (state_clone.edge_exclude_flags.as_slice(), exc)),
             ))
         } else {
@@ -301,8 +301,8 @@ pub async fn match_trace_handler(
             })
         };
 
-        let cch_weights = if let Some((ref aw, _)) = avoid_result {
-            Some(&aw.time_weights)
+        let cch_weights = if let Some(ref entry) = avoid_entry {
+            Some(&entry.weights.time_weights)
         } else {
             exclude_weights.as_ref().map(|ew| &ew.time_weights)
         };

--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -424,14 +424,14 @@ pub async fn route_handler(
     // node that is either incident to a changed edge OR a potential middle of a
     // triangle relaxing one, so it now matches the full path's output. /route
     // stays on the fast time-only path.
-    let avoid_result = if let Some(ref avoid_str) = avoid_json {
+    let avoid_entry = if let Some(ref avoid_str) = avoid_json {
         match super::avoid::compute_avoid_weights_time_only(
             &state,
             mode_data,
             avoid_str,
             exclude_mask,
         ) {
-            Ok((weights, flags)) => Some((weights, flags)),
+            Ok(entry) => Some(entry),
             Err(e) => {
                 return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
             }
@@ -441,10 +441,10 @@ pub async fn route_handler(
     };
 
     // Build snap mask (with optional avoid/exclude filtering)
-    let snap_mask: std::borrow::Cow<'_, [u64]> = if let Some((_, ref avoid_flags)) = avoid_result {
+    let snap_mask: std::borrow::Cow<'_, [u64]> = if let Some(ref entry) = avoid_entry {
         std::borrow::Cow::Owned(super::avoid::build_avoid_mask(
             &mode_data.mask,
-            avoid_flags,
+            &entry.flags,
             exclude_mask.map(|exc| (state.edge_exclude_flags.as_slice(), exc)),
         ))
     } else if let Some(exc) = exclude_mask {
@@ -716,17 +716,17 @@ pub async fn route_handler(
     };
 
     // Run primary query (with optional avoid/exclude weights)
-    let exclude_weights = if avoid_result.is_none() {
+    let exclude_weights = if avoid_entry.is_none() {
         exclude_mask.map(|exc| state.get_exclude_weights(mode, exc))
     } else {
-        None // avoid_result already incorporates exclude
+        None // avoid_entry already incorporates exclude
     };
-    let query = if let Some((ref time_weights, _)) = avoid_result {
+    let query = if let Some(ref entry) = avoid_entry {
         CchQuery::with_custom_weights(
             &mode_data.cch_topo,
             &mode_data.up_adj_flat,
             &mode_data.down_rev_flat,
-            time_weights,
+            &entry.weights.time_weights,
         )
     } else if let Some(ref ew) = exclude_weights {
         CchQuery::with_custom_weights(
@@ -821,8 +821,8 @@ pub async fn route_handler(
         }
     };
 
-    let active_weights = if let Some((ref time_weights, _)) = avoid_result {
-        time_weights
+    let active_weights = if let Some(ref entry) = avoid_entry {
+        &entry.weights.time_weights
     } else if let Some(ref ew) = exclude_weights {
         &ew.time_weights
     } else {
@@ -916,8 +916,8 @@ pub async fn route_handler(
         // This clones ~200MB (up + down weight arrays). Acceptable for alternatives
         // since they're requested rarely (only when alternatives > 0).
         // A proper fix (penalty views) would require changing the CchQuery API.
-        let mut penalized_weights = if let Some((ref time_weights, _)) = avoid_result {
-            time_weights.clone()
+        let mut penalized_weights = if let Some(ref entry) = avoid_entry {
+            entry.weights.time_weights.clone()
         } else if let Some(ref ew) = exclude_weights {
             ew.time_weights.clone()
         } else {

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -264,9 +264,9 @@ pub async fn table_post_handler(
     let mode_data = state.get_mode(mode);
 
     // Compute avoid weights (includes exclude if both present)
-    let avoid_result = if let Some(ref avoid_str) = avoid_json {
+    let avoid_entry = if let Some(ref avoid_str) = avoid_json {
         match super::avoid::compute_avoid_weights(&state, mode_data, avoid_str, exclude_mask) {
-            Ok((weights, flags)) => Some((weights, flags)),
+            Ok(entry) => Some(entry),
             Err(e) => {
                 return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
             }
@@ -276,17 +276,17 @@ pub async fn table_post_handler(
     };
 
     // Get exclude weights if only exclude (no avoid)
-    let exclude_weights = if avoid_result.is_none() {
+    let exclude_weights = if avoid_entry.is_none() {
         exclude_mask.map(|exc| state.get_exclude_weights(mode, exc))
     } else {
         None
     };
 
     // Build snap mask
-    let snap_mask: Vec<u64> = if let Some((_, ref avoid_flags)) = avoid_result {
+    let snap_mask: Vec<u64> = if let Some(ref entry) = avoid_entry {
         super::avoid::build_avoid_mask(
             &mode_data.mask,
-            avoid_flags,
+            &entry.flags,
             exclude_mask.map(|exc| (state.edge_exclude_flags.as_slice(), exc)),
         )
     } else if let Some(exc) = exclude_mask {
@@ -295,10 +295,12 @@ pub async fn table_post_handler(
         mode_data.mask.clone()
     };
 
-    // Determine custom weights: avoid takes priority, then exclude
+    // Determine custom weights: avoid takes priority, then exclude.
+    // /table holds an Arc<AvoidEntry>; the borrow points into the cache
+    // so /table cache hits avoid the prior ~200 MB deep clone.
     let custom_weights_ref: Option<&super::exclude::ExcludeWeights> =
-        if let Some((ref aw, _)) = avoid_result {
-            Some(aw)
+        if let Some(ref entry) = avoid_entry {
+            Some(&entry.weights)
         } else {
             exclude_weights.as_deref()
         };
@@ -981,9 +983,9 @@ pub async fn table_stream_handler(
     let n_nodes = mode_data.cch_topo.n_nodes as usize;
 
     // Compute avoid weights (includes exclude if both present)
-    let avoid_result = if let Some(ref avoid_str) = avoid_json {
+    let avoid_entry = if let Some(ref avoid_str) = avoid_json {
         match super::avoid::compute_avoid_weights(&state, mode_data, avoid_str, exclude_mask) {
-            Ok((weights, flags)) => Some((weights, flags)),
+            Ok(entry) => Some(entry),
             Err(e) => {
                 return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
             }
@@ -993,17 +995,17 @@ pub async fn table_stream_handler(
     };
 
     // Get exclude weights if only exclude (no avoid)
-    let exclude_weights = if avoid_result.is_none() {
+    let exclude_weights = if avoid_entry.is_none() {
         exclude_mask.map(|exc| state.get_exclude_weights(mode, exc))
     } else {
         None
     };
 
     // Build snap mask
-    let snap_mask: std::borrow::Cow<'_, [u64]> = if let Some((_, ref avoid_flags)) = avoid_result {
+    let snap_mask: std::borrow::Cow<'_, [u64]> = if let Some(ref entry) = avoid_entry {
         std::borrow::Cow::Owned(super::avoid::build_avoid_mask(
             &mode_data.mask,
-            avoid_flags,
+            &entry.flags,
             exclude_mask.map(|exc| (state.edge_exclude_flags.as_slice(), exc)),
         ))
     } else if let Some(exc) = exclude_mask {
@@ -1116,15 +1118,15 @@ pub async fn table_stream_handler(
     };
 
     // Select flat adjacencies based on custom weights (exclude or avoid)
-    let up_adj_flat = if let Some((ref aw, _)) = avoid_result {
-        aw.time_up_flat.clone()
+    let up_adj_flat = if let Some(ref entry) = avoid_entry {
+        entry.weights.time_up_flat.clone()
     } else if let Some(ref ew) = exclude_weights {
         ew.time_up_flat.clone()
     } else {
         mode_data.up_adj_flat.clone()
     };
-    let down_rev_flat = if let Some((ref aw, _)) = avoid_result {
-        aw.time_down_flat.clone()
+    let down_rev_flat = if let Some(ref entry) = avoid_entry {
+        entry.weights.time_down_flat.clone()
     } else if let Some(ref ew) = exclude_weights {
         ew.time_down_flat.clone()
     } else {

--- a/route/src/server/trip.rs
+++ b/route/src/server/trip.rs
@@ -605,7 +605,7 @@ pub async fn trip_handler(
         let n_nodes = mode_data.cch_topo.n_nodes as usize;
 
         // Compute avoid weights (includes exclude if both present)
-        let avoid_result = if let Some(ref avoid_str) = avoid_json {
+        let avoid_entry = if let Some(ref avoid_str) = avoid_json {
             super::avoid::compute_avoid_weights(&state_clone, mode_data, avoid_str, exclude_mask)
                 .ok()
         } else {
@@ -613,29 +613,28 @@ pub async fn trip_handler(
         };
 
         // Get exclude weights if only exclude (no avoid)
-        let exclude_weights = if avoid_result.is_none() {
+        let exclude_weights = if avoid_entry.is_none() {
             exclude_mask.map(|exc| state_clone.get_exclude_weights(mode, exc))
         } else {
             None
         };
 
         // Build snap mask
-        let snap_mask: std::borrow::Cow<'_, [u64]> =
-            if let Some((_, ref avoid_flags)) = avoid_result {
-                std::borrow::Cow::Owned(super::avoid::build_avoid_mask(
-                    &mode_data.mask,
-                    avoid_flags,
-                    exclude_mask.map(|exc| (state_clone.edge_exclude_flags.as_slice(), exc)),
-                ))
-            } else if let Some(exc) = exclude_mask {
-                std::borrow::Cow::Owned(super::exclude::build_exclude_mask(
-                    &mode_data.mask,
-                    &state_clone.edge_exclude_flags,
-                    exc,
-                ))
-            } else {
-                std::borrow::Cow::Borrowed(&mode_data.mask)
-            };
+        let snap_mask: std::borrow::Cow<'_, [u64]> = if let Some(ref entry) = avoid_entry {
+            std::borrow::Cow::Owned(super::avoid::build_avoid_mask(
+                &mode_data.mask,
+                &entry.flags,
+                exclude_mask.map(|exc| (state_clone.edge_exclude_flags.as_slice(), exc)),
+            ))
+        } else if let Some(exc) = exclude_mask {
+            std::borrow::Cow::Owned(super::exclude::build_exclude_mask(
+                &mode_data.mask,
+                &state_clone.edge_exclude_flags,
+                exc,
+            ))
+        } else {
+            std::borrow::Cow::Borrowed(&mode_data.mask)
+        };
 
         // Snap all coordinates and convert to rank space.
         // For TSP each waypoint participates in two legs (arrives from
@@ -715,15 +714,15 @@ pub async fn trip_handler(
         }
 
         // Select flat adjacencies (avoid takes priority, then exclude)
-        let (time_up, time_down) = if let Some((ref aw, _)) = avoid_result {
-            (&aw.time_up_flat, &aw.time_down_flat)
+        let (time_up, time_down) = if let Some(ref entry) = avoid_entry {
+            (&entry.weights.time_up_flat, &entry.weights.time_down_flat)
         } else if let Some(ref ew) = exclude_weights {
             (&ew.time_up_flat, &ew.time_down_flat)
         } else {
             (&mode_data.up_adj_flat, &mode_data.down_rev_flat)
         };
-        let (dist_up, dist_down) = if let Some((ref aw, _)) = avoid_result {
-            (&aw.dist_up_flat, &aw.dist_down_flat)
+        let (dist_up, dist_down) = if let Some(ref entry) = avoid_entry {
+            (&entry.weights.dist_up_flat, &entry.weights.dist_down_flat)
         } else if let Some(ref ew) = exclude_weights {
             (&ew.dist_up_flat, &ew.dist_down_flat)
         } else {
@@ -782,12 +781,12 @@ pub async fn trip_handler(
 
             if any_dur_inf || any_dist_inf {
                 let time_query = if any_dur_inf {
-                    let query = match (&avoid_result, &exclude_weights) {
-                        (Some((aw, _)), _) => CchQuery::with_custom_weights(
+                    let query = match (&avoid_entry, &exclude_weights) {
+                        (Some(entry), _) => CchQuery::with_custom_weights(
                             &mode_data.cch_topo,
-                            &aw.time_up_flat,
-                            &aw.time_down_flat,
-                            &aw.time_weights,
+                            &entry.weights.time_up_flat,
+                            &entry.weights.time_down_flat,
+                            &entry.weights.time_weights,
                         ),
                         (None, Some(ew)) => CchQuery::with_custom_weights(
                             &mode_data.cch_topo,
@@ -806,12 +805,12 @@ pub async fn trip_handler(
                     // topo_edge_idx) and override with the distance
                     // metric weights — distance-only flats omit
                     // topo_edge_idx so they cannot back a CchQuery.
-                    let query = match (&avoid_result, &exclude_weights) {
-                        (Some((aw, _)), _) => CchQuery::with_custom_weights(
+                    let query = match (&avoid_entry, &exclude_weights) {
+                        (Some(entry), _) => CchQuery::with_custom_weights(
                             &mode_data.cch_topo,
-                            &aw.time_up_flat,
-                            &aw.time_down_flat,
-                            &aw.dist_weights,
+                            &entry.weights.time_up_flat,
+                            &entry.weights.time_down_flat,
+                            &entry.weights.dist_weights,
                         ),
                         (None, Some(ew)) => CchQuery::with_custom_weights(
                             &mode_data.cch_topo,


### PR DESCRIPTION
Closes #241. /table avoid cache hit dropped from 366 ms (200 MB deep clone of ExcludeWeights) to 22 ms (zero clone — just Arc::clone + borrow). /route hit from 52 ms to 11 ms. Touch sites: route.rs, table.rs, isochrone_handler.rs, trip.rs, matching.rs. 506 tests pass, clippy clean.