### PR TITLE
feat(route): #242 surface avoid_cache stats on /health + Prometheus metrics

### DIFF
--- a/route/src/server/health_handler.rs
+++ b/route/src/server/health_handler.rs
@@ -85,6 +85,37 @@ pub async fn health_handler(State(regions): State<Arc<RegionsState>>) -> impl In
 
     let n_failed = failed_sections.len();
 
+    // #242: aggregate avoid-cache stats across regions. /route, /table,
+    // /isochrone, /trip share one cache per region. We surface
+    // hits/misses/size/cap so operators can tune
+    // BUTTERFLY_AVOID_CACHE_CAP based on traffic.
+    let avoid_cache_stats: Vec<serde_json::Value> = regions
+        .regions
+        .iter()
+        .map(|region| {
+            let (hits, misses, size, capacity) = region.state.avoid_cache.stats();
+            // Mirror current stats into the Prometheus registry so the
+            // next /metrics scrape sees fresh values. /health is the
+            // natural "snapshot" hook — typical ops setups poll it
+            // alongside /metrics.
+            super::metrics::record_avoid_cache_stats(&region.id, hits, misses, size, capacity);
+            let total = hits + misses;
+            let hit_rate = if total > 0 {
+                hits as f64 / total as f64
+            } else {
+                0.0
+            };
+            serde_json::json!({
+                "region": region.id,
+                "hits": hits,
+                "misses": misses,
+                "hit_rate": hit_rate,
+                "size": size,
+                "capacity": capacity,
+            })
+        })
+        .collect();
+
     Json(serde_json::json!({
         "status": "ok",
         "version": env!("CARGO_PKG_VERSION"),
@@ -107,5 +138,6 @@ pub async fn health_handler(State(regions): State<Arc<RegionsState>>) -> impl In
             "n_failed": n_failed,
             "failed": failed_sections,
         },
+        "avoid_cache": avoid_cache_stats,
     }))
 }

--- a/route/src/server/metrics.rs
+++ b/route/src/server/metrics.rs
@@ -89,6 +89,46 @@ pub fn pending_count() -> i64 {
     PENDING.load(Ordering::Relaxed)
 }
 
+/// Record current avoid-cache stats as Prometheus gauges/counters (#242).
+/// Called from /metrics scrape via the health-style RegionsState snapshot.
+/// - `butterfly_route_avoid_cache_hits_total` (counter, label `region`)
+/// - `butterfly_route_avoid_cache_misses_total` (counter, label `region`)
+/// - `butterfly_route_avoid_cache_size` (gauge, label `region`)
+/// - `butterfly_route_avoid_cache_capacity` (gauge, label `region`)
+///
+/// Cumulative semantics: hits/misses are absolute counts since boot.
+/// The `metrics` counter API expects monotonic increments, so we mirror
+/// the absolute count via gauges rather than incrementing — Prometheus
+/// scrapes work fine with gauges-treated-as-counters.
+pub fn record_avoid_cache_stats(
+    region: &str,
+    hits: u64,
+    misses: u64,
+    size: usize,
+    capacity: usize,
+) {
+    metrics::gauge!(
+        "butterfly_route_avoid_cache_hits_total",
+        "region" => region.to_string()
+    )
+    .set(hits as f64);
+    metrics::gauge!(
+        "butterfly_route_avoid_cache_misses_total",
+        "region" => region.to_string()
+    )
+    .set(misses as f64);
+    metrics::gauge!(
+        "butterfly_route_avoid_cache_size",
+        "region" => region.to_string()
+    )
+    .set(size as f64);
+    metrics::gauge!(
+        "butterfly_route_avoid_cache_capacity",
+        "region" => region.to_string()
+    )
+    .set(capacity as f64);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Closes #242. /health JSON now includes per-region avoid_cache stats (hits/misses/hit_rate/size/capacity). Prometheus exposes butterfly_route_avoid_cache_{hits_total,misses_total,size,capacity} gauges labelled by region. Refreshed on every /health poll.