### PR TITLE
chore(route): address PR review feedback from #232, #245, #246, #247

### DIFF
--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -1019,7 +1019,7 @@ fn load_phast(data_dir: &Path, mode: &str) -> anyhow::Result<PhastEngine> {
         &[
             format!("cch.{}.topo", mode),
             format!("step7/cch.{}.topo", mode),
-            format!("step7/cch.{}.topo", mode),
+            format!("step7-rank-aligned/cch.{}.topo", mode),
             format!("step7-belgium-fixed/cch.{}.topo", mode),
         ],
     )
@@ -1030,7 +1030,7 @@ fn load_phast(data_dir: &Path, mode: &str) -> anyhow::Result<PhastEngine> {
         &[
             format!("cch.w.{}.u32", mode),
             format!("step8/cch.w.{}.u32", mode),
-            format!("step8/cch.w.{}.u32", mode),
+            format!("step8-rank-aligned/cch.w.{}.u32", mode),
             format!("step8-belgium-fixed/cch.w.{}.u32", mode),
         ],
     )
@@ -1388,7 +1388,7 @@ fn load_batched_phast(data_dir: &Path, mode: &str) -> anyhow::Result<BatchedPhas
         &[
             format!("cch.{}.topo", mode),
             format!("step7/cch.{}.topo", mode),
-            format!("step7/cch.{}.topo", mode),
+            format!("step7-rank-aligned/cch.{}.topo", mode),
             format!("step7-belgium-fixed/cch.{}.topo", mode),
         ],
     )
@@ -1399,7 +1399,7 @@ fn load_batched_phast(data_dir: &Path, mode: &str) -> anyhow::Result<BatchedPhas
         &[
             format!("cch.w.{}.u32", mode),
             format!("step8/cch.w.{}.u32", mode),
-            format!("step8/cch.w.{}.u32", mode),
+            format!("step8-rank-aligned/cch.w.{}.u32", mode),
             format!("step8-belgium-fixed/cch.w.{}.u32", mode),
         ],
     )
@@ -1633,7 +1633,7 @@ fn run_batched_isochrone_bench(
         &[
             format!("cch.{}.topo", mode),
             format!("step7/cch.{}.topo", mode),
-            format!("step7/cch.{}.topo", mode),
+            format!("step7-rank-aligned/cch.{}.topo", mode),
             format!("step7-new/cch.{}.topo", mode),
         ],
     )
@@ -1644,7 +1644,7 @@ fn run_batched_isochrone_bench(
         &[
             format!("cch.w.{}.u32", mode),
             format!("step8/cch.w.{}.u32", mode),
-            format!("step8/cch.w.{}.u32", mode),
+            format!("step8-rank-aligned/cch.w.{}.u32", mode),
             format!("step8-new/cch.w.{}.u32", mode),
         ],
     )
@@ -2974,7 +2974,7 @@ fn run_bucket_m2m_bench(
         &[
             format!("cch.{}.topo", mode),
             format!("step7/cch.{}.topo", mode),
-            format!("step7/cch.{}.topo", mode),
+            format!("step7-rank-aligned/cch.{}.topo", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.{}.topo", mode))?;
@@ -2984,7 +2984,7 @@ fn run_bucket_m2m_bench(
         &[
             format!("cch.w.{}.u32", mode),
             format!("step8/cch.w.{}.u32", mode),
-            format!("step8/cch.w.{}.u32", mode),
+            format!("step8-rank-aligned/cch.w.{}.u32", mode),
         ],
     )
     .ok_or_else(|| anyhow::anyhow!("Cannot find cch.w.{}.u32", mode))?;

--- a/route/src/server/avoid.rs
+++ b/route/src/server/avoid.rs
@@ -137,18 +137,19 @@ impl Default for AvoidWeightCache {
 /// Hash an avoid_polygons JSON payload after canonicalising it (#243).
 ///
 /// Canonicalisation steps:
-///   1. Parse into a `Vec<Vec<(f64, f64)>>` of rings.
-///   2. Round each coordinate to 6 decimals (~10 cm precision). Belgium
-///      coords range up to 6 decimal digits naturally; tighter than this
-///      hits noise.
-///   3. Strip any duplicate trailing closing vertex (rings are then
+///   1. Parse the JSON into rings of `(i64, i64)` vertices, each
+///      coordinate quantised to 6 decimals (lon × 1e6, lat × 1e6, then
+///      `round() as i64`). 6 decimals ≈ 10 cm precision.
+///   2. Strip any duplicate trailing closing vertex (rings are then
 ///      stored open).
-///   4. Rotate each ring so its lexicographically smallest vertex is at
-///      position 0. The shortest cyclic shift uniquifies "same ring,
-///      different starting point".
-///   5. Sort polygons by their canonical first vertex so multi-polygon
-///      orderings collapse.
-///   6. Hash the resulting canonical byte stream.
+///   3. Rotate each ring to its lexicographically minimal cyclic
+///      rotation — picks the start that yields the smallest FULL
+///      sequence, not just the smallest first vertex (degenerate
+///      when multiple vertices share the min value).
+///   4. Sort polygons by the entire canonical ring sequence so
+///      multi-polygon orderings collapse and ties resolve
+///      deterministically.
+///   5. Hash the resulting canonical byte stream.
 ///
 /// Falls back to a raw-bytes hash if parsing fails — the cache will
 /// then miss as before, but the route handler's error path still
@@ -206,17 +207,39 @@ fn canonicalize_polygons(s: &str) -> Option<Vec<u8>> {
         if pts.first() == pts.last() {
             pts.pop();
         }
-        // Rotate ring so the lexicographically smallest vertex is at
-        // index 0. Makes "same ring, different start" hash to the
-        // same canonical key.
-        if let Some(min_idx) = (0..pts.len()).min_by_key(|&i| pts[i]) {
-            pts.rotate_left(min_idx);
+        // Rotate ring to its lexicographically minimal cyclic rotation.
+        // Naive `min_by_key` returns the FIRST index of the smallest
+        // vertex, which breaks rotation-independence when the same
+        // vertex value appears multiple times in the ring. Instead we
+        // pick the rotation start that yields the lexicographically
+        // smallest full sequence. For typical polygons (≤ ~100 verts)
+        // the O(n²) candidate enumeration is trivial; for pathological
+        // rings the upgrade to Booth's algorithm is mechanical.
+        if !pts.is_empty() {
+            let n = pts.len();
+            let mut best = 0usize;
+            for cand in 1..n {
+                for k in 0..n {
+                    let a = pts[(best + k) % n];
+                    let b = pts[(cand + k) % n];
+                    if b < a {
+                        best = cand;
+                        break;
+                    } else if b > a {
+                        break;
+                    }
+                }
+            }
+            pts.rotate_left(best);
         }
         rings.push(pts);
     }
 
-    // Multi-polygon order: sort rings by their canonical first vertex.
-    rings.sort_unstable_by_key(|r| r[0]);
+    // Multi-polygon order: sort by the FULL canonical ring sequence
+    // (not just first vertex). Two rings whose canonical first vertex
+    // collides need a stable tie-break to keep multi-polygon hashing
+    // deterministic.
+    rings.sort_unstable();
 
     // Serialise to a deterministic byte stream.
     let mut out = Vec::with_capacity(rings.iter().map(|r| r.len() * 16).sum::<usize>() + 8);
@@ -270,6 +293,22 @@ mod canon_tests {
         let a = "[[4.32,50.92],[4.50,50.92],[4.50,51.15],[4.32,51.15]]";
         let b = "[[4.32,50.92],[4.50,50.92],[4.50,51.20],[4.32,51.20]]";
         assert_ne!(canonicalize_polygons(a), canonicalize_polygons(b));
+    }
+
+    #[test]
+    fn multi_polygon_order_independent() {
+        let p1 = "[[4.32,50.92],[4.50,50.92],[4.50,51.15],[4.32,51.15]]";
+        let p2 = "[[5.10,50.50],[5.30,50.50],[5.30,50.70],[5.10,50.70]]";
+        let a = format!("[{},{}]", p1, p2);
+        let b = format!("[{},{}]", p2, p1);
+        assert_eq!(canonicalize_polygons(&a), canonicalize_polygons(&b));
+    }
+
+    #[test]
+    fn duplicate_min_vertex_rotation_independent() {
+        let a = "[[1.0,1.0],[2.0,3.0],[1.0,1.0],[4.0,5.0]]";
+        let b = "[[1.0,1.0],[4.0,5.0],[1.0,1.0],[2.0,3.0]]";
+        assert_eq!(canonicalize_polygons(a), canonicalize_polygons(b));
     }
 }
 

--- a/route/src/server/metrics.rs
+++ b/route/src/server/metrics.rs
@@ -89,17 +89,20 @@ pub fn pending_count() -> i64 {
     PENDING.load(Ordering::Relaxed)
 }
 
-/// Record current avoid-cache stats as Prometheus gauges/counters (#242).
-/// Called from /metrics scrape via the health-style RegionsState snapshot.
-/// - `butterfly_route_avoid_cache_hits_total` (counter, label `region`)
-/// - `butterfly_route_avoid_cache_misses_total` (counter, label `region`)
+/// Record current avoid-cache stats as Prometheus gauges (#242).
+///
+/// All four metrics are exported as GAUGES — Prometheus convention
+/// reserves the `_total` suffix for counters, so we dropped it. Names:
+/// - `butterfly_route_avoid_cache_hits` (gauge, label `region`)
+/// - `butterfly_route_avoid_cache_misses` (gauge, label `region`)
 /// - `butterfly_route_avoid_cache_size` (gauge, label `region`)
 /// - `butterfly_route_avoid_cache_capacity` (gauge, label `region`)
 ///
-/// Cumulative semantics: hits/misses are absolute counts since boot.
-/// The `metrics` counter API expects monotonic increments, so we mirror
-/// the absolute count via gauges rather than incrementing — Prometheus
-/// scrapes work fine with gauges-treated-as-counters.
+/// Cumulative hits/misses are tracked inside `AvoidWeightCache` as
+/// monotone counters; we publish the snapshot value as a gauge so the
+/// Prometheus type system stays consistent with the metric name. Rate
+/// queries (`rate(hits[5m])`) still work on a gauge that only
+/// increases.
 pub fn record_avoid_cache_stats(
     region: &str,
     hits: u64,
@@ -108,12 +111,12 @@ pub fn record_avoid_cache_stats(
     capacity: usize,
 ) {
     metrics::gauge!(
-        "butterfly_route_avoid_cache_hits_total",
+        "butterfly_route_avoid_cache_hits",
         "region" => region.to_string()
     )
     .set(hits as f64);
     metrics::gauge!(
-        "butterfly_route_avoid_cache_misses_total",
+        "butterfly_route_avoid_cache_misses",
         "region" => region.to_string()
     )
     .set(misses as f64);

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -1117,22 +1117,6 @@ pub async fn table_stream_handler(
             .into_response();
     };
 
-    // Select flat adjacencies based on custom weights (exclude or avoid)
-    let up_adj_flat = if let Some(ref entry) = avoid_entry {
-        entry.weights.time_up_flat.clone()
-    } else if let Some(ref ew) = exclude_weights {
-        ew.time_up_flat.clone()
-    } else {
-        mode_data.up_adj_flat.clone()
-    };
-    let down_rev_flat = if let Some(ref entry) = avoid_entry {
-        entry.weights.time_down_flat.clone()
-    } else if let Some(ref ew) = exclude_weights {
-        ew.time_down_flat.clone()
-    } else {
-        mode_data.down_rev_flat.clone()
-    };
-
     // ----------------------------------------------------------------
     // Smart algorithm selection:
     //   - Small matrices (N*M <= 50,000): Bucket M2M (fast, low overhead)
@@ -1143,10 +1127,26 @@ pub async fn table_stream_handler(
 
     if n_total_sources * n_total_targets <= BUCKET_M2M_THRESHOLD {
         // --- SMALL MATRIX PATH: Bucket M2M → single Arrow IPC tile ---
+        // Borrow the flats directly from the cached avoid entry /
+        // exclude weights / mode data — no deep clone on the hot path.
+        let up_adj_flat: &UpAdjFlat = if let Some(ref entry) = avoid_entry {
+            &entry.weights.time_up_flat
+        } else if let Some(ref ew) = exclude_weights {
+            &ew.time_up_flat
+        } else {
+            &mode_data.up_adj_flat
+        };
+        let down_rev_flat: &DownReverseAdjFlat = if let Some(ref entry) = avoid_entry {
+            &entry.weights.time_down_flat
+        } else if let Some(ref ew) = exclude_weights {
+            &ew.time_down_flat
+        } else {
+            &mode_data.down_rev_flat
+        };
         let resp = table_stream_bucket_path(
             n_nodes,
-            &up_adj_flat,
-            &down_rev_flat,
+            up_adj_flat,
+            down_rev_flat,
             n_total_sources,
             n_total_targets,
             n_total_cells,
@@ -1192,11 +1192,37 @@ pub async fn table_stream_handler(
     let cancelled_outer = cancelled.clone();
     let neighbor_mask_for_phast = neighbor_mask.clone();
 
+    // Move the Arc-wrapped state into the spawn_blocking closure so we
+    // can borrow flat adjacencies straight from the cached avoid entry
+    // / exclude weights / mode_data — no deep clone of the 100+ MB
+    // UpAdjFlat / DownReverseAdjFlat on the hot path.
+    let state_for_phast = Arc::clone(&state);
+    let avoid_entry_for_phast = avoid_entry.clone();
+    let exclude_weights_for_phast = exclude_weights.clone();
+
     // Spawn compute task - SOURCE-BLOCK OUTER LOOP to avoid repeated forward computation
     // For 10k x 10k with 1000 x 1000 tiles: forward computed 10x (once per src block) instead of 100x
     tokio::task::spawn_blocking(move || {
         let cancelled = cancelled_outer;
         let neighbor_mask = neighbor_mask_for_phast;
+        let state = state_for_phast;
+        let avoid_entry = avoid_entry_for_phast;
+        let exclude_weights = exclude_weights_for_phast;
+        let mode_data = state.get_mode(mode);
+        let up_adj_flat: &UpAdjFlat = if let Some(ref entry) = avoid_entry {
+            &entry.weights.time_up_flat
+        } else if let Some(ref ew) = exclude_weights {
+            &ew.time_up_flat
+        } else {
+            &mode_data.up_adj_flat
+        };
+        let down_rev_flat: &DownReverseAdjFlat = if let Some(ref entry) = avoid_entry {
+            &entry.weights.time_down_flat
+        } else if let Some(ref ew) = exclude_weights {
+            &ew.time_down_flat
+        } else {
+            &mode_data.down_rev_flat
+        };
         // Generate source and destination blocks
         let src_blocks: Vec<(usize, usize)> = (0..n_total_sources)
             .step_by(src_tile_size)
@@ -1280,7 +1306,7 @@ pub async fn table_stream_handler(
             // FORWARD PHASE: Compute forward searches ONCE for this source block
             let source_buckets = std::sync::Arc::new(forward_build_buckets(
                 n_nodes,
-                &up_adj_flat,
+                up_adj_flat,
                 &block_src_ranks,
             ));
 
@@ -1312,7 +1338,7 @@ pub async fn table_stream_handler(
                     // BACKWARD + JOIN using prebuilt source buckets
                     let tile_matrix = backward_join_with_buckets(
                         n_nodes,
-                        &down_rev_flat,
+                        down_rev_flat,
                         &source_buckets,
                         &block_dst_ranks,
                     );


### PR DESCRIPTION
5 cleanups from Copilot reviews on the recent merge train:
- #232: bench/main.rs duplicated step7/step8 fallbacks → step7-rank-aligned/ + step8-rank-aligned/
- #245: /table/stream still deep-cloned 100-200MB flats on avoid cache hit → borrow refs in both small-matrix and spawn_blocking paths
- #246: Prometheus metric names had _total suffix on gauges → renamed
- #247: ring rotation tie-break (duplicate min vertices) + multi-polygon sort tie-break + docstring fix + 2 new tests
513 tests pass, clippy clean.