### PR TITLE
docs: world-class documentation pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,128 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 For detailed tool-specific changes, see individual tool changelogs:
 - [butterfly-dl](./tools/butterfly-dl/CHANGELOG.md) - OSM data downloader
 
+## [Unreleased] — 2026-05-23
+
+### Added
+
+- **butterfly-route**: Incremental `avoid_polygons` customization
+  ([#240](https://github.com/butterfly-osm/butterfly-osm/issues/240),
+  [#249](https://github.com/butterfly-osm/butterfly-osm/pull/249)). The
+  recustomization pass now walks an explicit BFS frontier seeded from
+  the edges that intersect the avoid polygons, instead of re-running a
+  whole-graph triangle relaxation. A 1 km rural polygon on Belgium went
+  from 37 s to ~780 ms end-to-end (47× speedup); the larger E19
+  motorway-corridor polygon settles at 1.16 s. Cold `/route` requests
+  that previously dominated the response now spend the bulk of their
+  time in I/O and snap, not in customization.
+- **butterfly-route**: LRU avoid-polygon cache with operational
+  visibility ([#242](https://github.com/butterfly-osm/butterfly-osm/issues/242),
+  [#243](https://github.com/butterfly-osm/butterfly-osm/issues/243),
+  [#246](https://github.com/butterfly-osm/butterfly-osm/pull/246),
+  [#247](https://github.com/butterfly-osm/butterfly-osm/pull/247)).
+  Cache hit rate, entry count, and eviction counters are now surfaced
+  on `GET /health` and exported as four Prometheus gauges on
+  `GET /metrics`. Polygon inputs are canonicalized before hashing so
+  semantically equivalent JSON inputs (rotation, whitespace, ring
+  closure) collide on the same cache entry. Booth's algorithm
+  ([#250](https://github.com/butterfly-osm/butterfly-osm/pull/250))
+  replaces the quadratic rotation search used in the first cut of
+  canonicalization.
+- **belgium-latest container** ([#236](https://github.com/butterfly-osm/butterfly-osm/issues/236)):
+  refreshed Belgium build deployed with 5.13M EBG nodes, 14.98M edges,
+  769K named roads, and 4 modes (bike, car, foot, truck). Used as the
+  reference dataset for every benchmark in this release.
+
+### Changed
+
+- **butterfly-route**: Avoid cache now returns `Arc<AvoidEntry>` rather
+  than cloning the customized weight set per request
+  ([#241](https://github.com/butterfly-osm/butterfly-osm/issues/241),
+  [#245](https://github.com/butterfly-osm/butterfly-osm/pull/245)).
+  `/table` warm-hit latency dropped from 366 ms to 22 ms, matching the
+  baseline `/table` cost on un-avoided queries.
+- **butterfly-route**: `POST /table/stream` now borrows the flat
+  adjacency arrays from the cached `AvoidEntry` instead of cloning
+  them ([#248](https://github.com/butterfly-osm/butterfly-osm/pull/248)).
+  Eliminates a 100–200 MB per-request clone on Belgium-sized inputs;
+  visible as a flat memory profile under sustained streaming load.
+
+### Fixed
+
+- **butterfly-route**: Matrix gap closed
+  ([#197](https://github.com/butterfly-osm/butterfly-osm/issues/197),
+  [#232](https://github.com/butterfly-osm/butterfly-osm/pull/232)).
+  K-best snap and SCC-aware role masks are now applied at every snap
+  site — `/route`, `/nearest`, `/table`, `/matrix`, `/isochrone`,
+  `/trip`, and the Flight gRPC equivalents — instead of only `/route`.
+  A 200-pair Belgium `/route` ↔ `/table` correlation sweep now reports
+  100% agreement, up from a ~9% gap where `/table` would return
+  unreachable for pairs `/route` resolved successfully.
+- **butterfly-route**: Small-N matrix dispatch fast-path
+  ([#191](https://github.com/butterfly-osm/butterfly-osm/issues/191),
+  [#232](https://github.com/butterfly-osm/butterfly-osm/pull/232)).
+  10×10 and 25×25 matrices no longer fall through to the bulk
+  scheduler — rayon thread-dispatch overhead at those sizes outweighed
+  the parallelism win.
+- **butterfly-route**: Sparse triangle correctness for avoid polygons
+  ([#235](https://github.com/butterfly-osm/butterfly-osm/issues/235),
+  [#232](https://github.com/butterfly-osm/butterfly-osm/pull/232)).
+  `/route` and `/table` durations now match exactly on avoided
+  queries; the previous implementation had an 8% disagreement caused
+  by the sparse pass touching a different node set than the dense
+  baseline.
+- **butterfly-route**: Stale unpacked geometry in serve-time triangle
+  relaxation ([#239](https://github.com/butterfly-osm/butterfly-osm/issues/239),
+  [#244](https://github.com/butterfly-osm/butterfly-osm/pull/244)).
+  When the relax loop replaced a shortcut's middle node, the unpacking
+  arrays still pointed at the original topology middle, producing
+  polylines that crossed the avoid polygon even though the duration
+  number was correct. `up_middle` and `down_middle` are now updated in
+  lockstep with the weight.
+- **butterfly-route**: Additional correctness and review fixes for
+  the incremental avoid path
+  ([#233](https://github.com/butterfly-osm/butterfly-osm/issues/233),
+  [#234](https://github.com/butterfly-osm/butterfly-osm/issues/234),
+  [#248](https://github.com/butterfly-osm/butterfly-osm/pull/248),
+  [#251](https://github.com/butterfly-osm/butterfly-osm/pull/251),
+  [#252](https://github.com/butterfly-osm/butterfly-osm/pull/252)).
+
+### Removed
+
+- **butterfly-geocode**: Crate shelved
+  ([#253](https://github.com/butterfly-osm/butterfly-osm/issues/253),
+  [#254](https://github.com/butterfly-osm/butterfly-osm/pull/254)).
+  The full geocoder work tree is preserved under the git tag
+  `geocode-shelved-2026-05-23` and can be restored at any time; it is
+  removed from the workspace to keep CI and release artifacts focused
+  on the routing engine.
+
+### Documentation
+
+- New top-level `docs/` directory with a quickstart guide, REST + gRPC
+  API reference, deployment guide, architecture overview, and
+  troubleshooting notes.
+- README rewritten to reflect the current state of the workspace
+  (route engine production-ready, geocoder shelved, downloader stable).
+- Stale "sparse triangle" comments across `route/src/server/exclude.rs`
+  and adjacent modules updated to "incremental BFS"
+  ([#251](https://github.com/butterfly-osm/butterfly-osm/pull/251),
+  [#252](https://github.com/butterfly-osm/butterfly-osm/pull/252)) so
+  the code matches the algorithm that actually runs.
+
+### Performance reference (Belgium, 2026-05-23)
+
+- 10k×10k distance matrix: **18.3 s**, 1.8× faster than OSRM CH on the
+  same dataset.
+- 50k×50k Flight gRPC matrix: **9.61 min**, at parity with the
+  historical `/table/stream` baseline and well outside what OSRM can
+  serve at all (URL-length limits, no streaming).
+- `/route` with `avoid_polygons`, warm cache hit: **11 ms**.
+- `/route` with `avoid_polygons`, cold miss: **~780 ms** for a 1 km
+  rural polygon (was 37 s); **1.16 s** for the E19 motorway corridor.
+- `/table` with `avoid_polygons`, warm cache hit: **22 ms** (was
+  366 ms before the `Arc<AvoidEntry>` return).
+
 ## [Unreleased] — 2026-04-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,526 +2,198 @@
   <img src="images/butterfly_logo_900kb.jpg" width="280" alt="Butterfly-OSM logo" />
 </p>
 
-# Butterfly-OSM 🦋
+# Butterfly-OSM
 
-Hurricane-fast drivetime engine and OSM toolkit built for modern performance requirements.
+Production-grade routing engine and OSM toolkit, in Rust.
 
-## Vision
-
-**Goal**: 10x faster than state-of-the-art with minimal memory footprint and modern architecture.
-
-Butterfly-OSM reimagines OpenStreetMap data processing from the ground up, leveraging Rust's performance and safety to create a new generation of geographic tools that are both lightning-fast and resource-efficient.
-
-## What
-
-A comprehensive ecosystem of OSM tools designed around **separation of concerns** and **composability**:
-
-### Core Tools
-
-- **butterfly-dl**: Memory-efficient OSM data downloader (<1GB RAM for any file size) with verified content checks (magic-byte prefix, min-bytes floor, SHA-256 sidecar) and region-indexed parallel downloads
-- **butterfly-route**: High-performance road router **and** multimodal transit engine. Edge-based CCH for exact turn-aware driving/walking/cycling, PHAST isochrones, Arrow-streaming distance matrices, and a full RAPTOR-based public transport stack with multi-feed merging (SNCB, De Lijn, TEC, STIB via NeTEx-EPIP) and ULTRA transfer-graph preprocessing
-- **butterfly-common**: Shared utilities, error handling, and geographic algorithms
-
-## Why
-
-### The Performance Problem
-
-Current OSM tools suffer from fundamental limitations:
-- **Memory inefficiency**: Tools that require 10GB+ RAM for large datasets
-- **Single-threaded bottlenecks**: Missing modern parallelization opportunities  
-- **Monolithic architecture**: Difficult to compose and extend
-- **Legacy codebases**: Built before modern understanding of performance
-
-### Our Approach
-
-**Hurricane-fast through intelligent design:**
-- **🔥 Rust performance**: Zero-cost abstractions with memory safety
-- **🧠 Smart algorithms**: Geographic-aware data structures and caching
-- **🚀 Modern async**: Tokio-based concurrency for I/O-bound operations
-- **💎 Composable architecture**: Unix philosophy applied to OSM processing
-
-### Target Performance
-
-| Operation | Current Tools | Butterfly-OSM Target | Improvement |
-|-----------|---------------|---------------------|-------------|
-| Planet download | 2-4 hours | 20-40 minutes | **3-6x faster** |
-| Matrix 10k×10k | 32.9s (OSRM) | 18.2s | **1.8x faster** |
-| Memory usage | 4-16GB | <1GB | **4-16x less** |
-
-## How
-
-### Architecture Principles
-
-#### 1. Separation of Concerns
-Each tool has a single, well-defined responsibility:
-```
-butterfly-dl    → Data acquisition (download, streaming)
-butterfly-route → Routing engine (CCH, isochrones, matrices)
-butterfly-common → Shared utilities and algorithms
-```
-
-#### 2. Composable Design
-Common patterns abstracted into `butterfly-common`:
-- Geographic algorithms (bounding boxes, projections)
-- Error handling with fuzzy matching
-- Memory-efficient data structures
-- Async I/O primitives
-
-#### 3. Performance-First Design
-
-**Memory efficiency:**
-- Streaming architecture - process data without loading entirely into memory
-- Fixed-size buffers - predictable memory usage regardless of input size
-- Zero-copy operations where possible
-
-**Compute efficiency:**
-- Rust's zero-cost abstractions
-- SIMD operations for geometric calculations
-- Lock-free data structures for parallelism
-- Modern async/await for I/O concurrency
-
-**I/O efficiency:**  
-- HTTP/2 with connection pooling
-- Direct I/O for large sequential operations
-- Intelligent caching strategies
-- Range requests and resume capability
-
-### Modern Language Benefits
-
-**Rust advantages over C/C++:**
-- Memory safety without garbage collection overhead
-- Fearless concurrency with compile-time race condition prevention
-- Modern package management with Cargo
-- Excellent async ecosystem with Tokio
-
-**Rust advantages over Python/JavaScript:**
-- 10-100x performance improvement
-- Predictable memory usage
-- No GIL limitations for parallelism
-- Compiled binaries with no runtime dependencies
-
-## Ecosystem Status
-
-### ✅ Available Now
-
-- **butterfly-dl**: Production-ready OSM downloader
-  - Handles files from 1MB to 81GB (planet.osm.pbf)
-  - 79% faster than aria2, 3x faster than curl on medium files
-  - <1GB memory usage regardless of file size
-
-- **butterfly-route**: High-performance road router + multimodal transit engine
-  - Exact turn-aware routing (edge-based CCH)
-  - **1.8x FASTER than OSRM** at scale (10k×10k matrices)
-  - Full RAPTOR transit stack: multi-feed merging (GTFS + NeTEx-EPIP), ULTRA transfer preprocessing, `/transit` + `/transit/bulk` REST, `transit_bulk` + `edges_batch` Flight actions
-  - Production-hardened: structured logging, graceful shutdown, timeouts, compression, input validation, panic recovery, Prometheus metrics
-  - Open work tracked in GitHub issues (`gh issue list`); `competitive_landscape.md` captures where Butterfly wins vs OSRM / Valhalla / GraphHopper
-  - See [Routing Engine](#routing-engine-butterfly-route) below
-
-## Routing Engine (butterfly-route)
-
-High-performance routing engine with **exact turn-aware queries** using edge-based Customizable Contraction Hierarchies (CCH). Production-hardened with structured logging, graceful shutdown, request timeouts, response compression, input validation, panic recovery, and Prometheus metrics. Docker-ready.
-
-### Performance
-
-| Workload | Butterfly | OSRM | Result |
-|----------|-----------|------|--------|
-| Isochrones (bulk) | **1,526/sec** | - | Production-ready |
-| Matrix 100×100 | 164ms | 55ms | 3x slower (acceptable) |
-| Matrix 10k×10k | **18.2s** | 32.9s | **1.8x FASTER** |
-
-**Key insight**: Butterfly wins at scale. Use bulk APIs for production workloads.
-
-### Bulk APIs (Recommended for Production)
-
-#### Bulk Isochrones
-
-For computing many isochrones, use the bulk endpoint which processes origins in parallel:
-
-```bash
-# Compute 100 isochrones in one request
-curl -X POST http://localhost:3001/isochrone/bulk \
-  -H "Content-Type: application/json" \
-  -d '{
-    "origins": [[4.35, 50.85], [4.40, 50.86], ...],
-    "time_s": 1800,
-    "mode": "car"
-  }' \
-  --output isochrones.wkb
-
-# Response: Length-prefixed WKB stream
-# Format: [4B origin_idx][4B wkb_len][WKB polygon]...
-```
-
-**Throughput**: 1,526 isochrones/sec (vs 815/sec individual)
-
-#### Bulk Distance Matrices
-
-For large matrices (1000+ origins/destinations), use Arrow streaming:
-
-```bash
-# Compute 10,000 × 10,000 matrix via Arrow IPC
-curl -X POST http://localhost:3001/table/stream \
-  -H "Content-Type: application/json" \
-  -d '{
-    "sources": [[lon1,lat1], [lon2,lat2], ...],
-    "destinations": [[lon1,lat1], [lon2,lat2], ...],
-    "mode": "car"
-  }' \
-  --output matrix.arrow
-
-# Process with PyArrow, DuckDB, or any Arrow-compatible tool
-```
-
-**Performance**: 18.2s for 10k×10k (1.8x faster than OSRM)
-
-### Individual APIs
-
-For single queries or small workloads:
-
-```bash
-# Single route with turn-by-turn steps (includes road names)
-curl "http://localhost:3001/route?src_lon=4.35&src_lat=50.85&dst_lon=4.40&dst_lat=50.86&mode=car&steps=true"
-
-# Single isochrone (GeoJSON, CCW polygons, 5-decimal precision)
-curl "http://localhost:3001/isochrone?lon=4.35&lat=50.85&time_s=1800&mode=car"
-
-# Reverse isochrone (where can people reach me FROM within 30 min?)
-curl "http://localhost:3001/isochrone?lon=4.35&lat=50.85&time_s=1800&mode=car&direction=arrive"
-
-# TSP/trip optimization
-curl -X POST "http://localhost:3001/trip" -H "Content-Type: application/json" \
-  -d '{"coordinates": [[4.35,50.85],[4.40,50.86],[4.45,50.87]], "mode": "car"}'
-```
-
-### Multi-region Serving (#91 Phase 1)
-
-butterfly-route can serve multiple country-sized regions from a single
-process. Each region is its own `*.butterfly` container, loaded
-independently with its own CCH hierarchy, weights, snap index, and
-edge geometry. Query dispatch is automatic: each request snaps its
-coordinates and is routed to the matching region.
-
-```bash
-# Pack each region with its identifier
-butterfly-route pack --region BE -d data/belgium    -o data/belgium/baseline.butterfly
-butterfly-route pack --region LU -d data/luxembourg -o data/luxembourg/luxembourg.butterfly
-
-# Serve a directory of containers
-mkdir -p /srv/regions
-ln -s /path/to/data/belgium/baseline.butterfly       /srv/regions/be.butterfly
-ln -s /path/to/data/luxembourg/luxembourg.butterfly  /srv/regions/lu.butterfly
-butterfly-route serve --data-dir /srv/regions --port 3001
-
-# Optional --regions filter loads a subset
-butterfly-route serve --data-dir /srv/regions --regions BE,LU --port 3001
-
-# Inspect what's loaded
-curl -s http://localhost:3001/regions
-# {"loaded":[
-#   {"id":"BE","container":".../be.butterfly","nodes":5019052,"edges":14649023,
-#    "verify_status":"verified","named_roads":754380,"modes":[...]},
-#   {"id":"LU","container":".../lu.butterfly","nodes":478552,"edges":1365815,
-#    "verify_status":"verified","named_roads":46287,"modes":[...]}
-# ]}
-
-# Same-region queries route as expected
-curl "http://localhost:3001/route?src_lon=4.35&src_lat=50.85&dst_lon=3.22&dst_lat=51.21&mode=car"
-
-# Cross-region queries return HTTP 501 with a clear error unless an
-# overlay is loaded (#91 Phase 2):
-curl -w "\n%{http_code}\n" \
-  "http://localhost:3001/route?src_lon=4.35&src_lat=50.85&dst_lon=6.13&dst_lat=49.61&mode=car"
-# {"error":"route spans regions BE → LU; cross-region overlay not yet implemented (#91 Phase 2)"}
-# 501
-```
-
-#### Cross-region overlay (#91 Phase 2)
-
-The overlay extends multi-region serving with precomputed border-node
-tables and per-(src, dst, mode) distance matrices, so a single P2P
-request can stitch a route across two regions:
-
-```bash
-# 1. Extract cross-region border crossings from per-region containers
-butterfly-route extract-borders \
-  --regions data/belgium/baseline.butterfly data/luxembourg/luxembourg.butterfly \
-  --out data/be-lu-borders.json
-# Real BE+LU output: 8010 crossings in ~67 s, mean edge distance 3.4 m
-
-# 2. Build the overlay container (offline batch — see route/docs/91-overlay-design.md
-#    for the cost analysis; the live BE+LU build needs the optimisations
-#    tracked as follow-ups).
-butterfly-route build-overlay \
-  --regions data/belgium/baseline.butterfly data/luxembourg/luxembourg.butterfly \
-  --modes car --out data/be-lu-overlay.butterfly
-
-# 3. Boot serve with --overlay
-butterfly-route serve --data-dir /srv/regions --overlay data/be-lu-overlay.butterfly
-```
-
-When `--overlay` is supplied, `dispatch_p2p_with_overlay` returns a
-`P2pPlan::CrossRegion` for cross-region queries instead of 501. The
-default `route_handler` continues to use the 501 path so existing
-non-overlay deployments are unchanged.
-
-Algorithm + on-disk format details: `route/docs/91-overlay-design.md`.
-Synthetic 2-region oracle test (verifies the combinator against
-brute-force Dijkstra on the union graph for all 81 src×tgt pairs):
-`route/tests/cross_region_synthetic.rs`.
-
-**Per-region Prometheus metrics** at `/metrics`:
-
-- `butterfly_route_region_nodes_total{region}` — graph size
-- `butterfly_route_region_edges_total{region}` — graph size
-- `butterfly_route_query_total{region,endpoint}` — request counter
-- `butterfly_route_query_duration_seconds{region,endpoint}` — latency histogram
-- `butterfly_route_query_cross_region_total{src,dst}` — 501 counter
-
-Single-region deployments (`serve --data <file>` or a step-tree
-`serve --data-dir <tree>`) work unchanged — they're transparently
-wrapped as a one-region multi-region state, so handlers, JSON shapes,
-and the Flight gRPC surface are identical.
-
-## Multimodal Transit (RAPTOR + CCH)
-
-butterfly-route ships a production transit engine alongside the road router. Public transport queries thread a foot/bike/car **access leg** (CCH) + **RAPTOR rounds** over the merged timetable + foot **egress leg** (CCH), with ULTRA-preprocessed transfer graphs for sub-second stop-to-stop walking.
-
-### Feed coverage
-
-Out of the box on Belgium with **zero operator configuration**:
-
-- **SNCB** (national rail) — GTFS via iRail
-- **De Lijn** (Flanders bus + tram) — GTFS via iRail
-- **TEC** (Wallonia bus) — GTFS
-- **STIB** (Brussels metro/tram/bus) — **NeTEx-EPIP** via the Belgian National Access Point (no GTFS published — butterfly-route's streaming NeTEx parser handles the 720 MB EPIP file directly, reprojects Lambert-93 → WGS84, and merges with the GTFS feeds into one `Timetable`)
-
-Cross-feed equivalence bridges wire physically co-located stops (SNCB ↔ STIB at Brussels-Midi, SNCB ↔ De Lijn at suburban hubs), and same-station parent-child transfers (multiple platforms of the same station) are injected automatically into the foot-CCH transfer graph.
-
-### REST endpoints
-
-```bash
-# Single multimodal query (JSON)
-curl "http://localhost:3001/transit?origin_lon=4.3517&origin_lat=50.8466\
-&dest_lon=4.4025&dest_lat=51.2194&depart=08:00:00"
-
-# Batch routing: 100k queries in one call, rayon-amortised access CCH
-curl -X POST http://localhost:3001/transit/bulk \
-  -H 'content-type: application/json' \
-  -d '{"queries":[{"origin_lon":4.3517,"origin_lat":50.8466,"dest_lon":4.4025,"dest_lat":51.2194,"depart":"08:00:00"},...]}'
-
-# Opt-in routed polylines for access / egress / middle walking legs
-curl "http://localhost:3001/transit?...&geometry=full"
-```
-
-### Arrow Flight (gRPC, port 3002)
-
-For high-throughput analytics pipelines the **standalone gRPC Flight server** exposes Arrow IPC streaming on a separate port — no Arrow-over-HTTP hybrid, REST stays JSON and Flight stays Arrow:
-
-| Action | Ticket | Output shape |
-|---|---|---|
-| `matrix` | `matrix:<profile>:{"sources":[...],"destinations":[...]}` | One row per pair, duration + distance |
-| `route_batch` | `route_batch:<profile>:{"pairs":[[src,dst],...]}` | Pair-level duration + WKB polyline |
-| `isochrone` | `isochrone:<profile>:{"lon":...,"lat":...,"intervals":[...]}` | Polygons as WKB |
-| `catchment` | via DoExchange | Catchment hulls per store |
-| **`transit_bulk`** | `transit_bulk:<profile>:{"queries":[...]}` | Per-query row with metadata + JSON legs (up to 500 k queries/call) |
-| **`edges_batch`** | `edges_batch:<profile>:{"pairs":[...]}` | **Unnested per-edge path output** with OSM node ids — the flow-analytics primitive no other OSS router ships |
-
-The `edges_batch` action emits one Arrow row per traversed EBG edge with `(query_idx, target_idx, edge_seq, osm_node_from, osm_node_to, duration_ms, distance_m)` columns, unreachable pairs get a single row with null edge columns, and the continuity invariant `osm_node_to[i] == osm_node_from[i+1]` is enforced — ready to `GROUP BY osm_node_to` for traffic assignment, emissions inventory, or network vulnerability analysis.
-
-### Transit-specific perf (Belgium, 4 feeds merged)
-
-| Workload | Metric |
-|---|---|
-| Single `/transit` query, warm | **35 ms p50** |
-| Bulk 20 same-origin queries | **150 ms** (7× speedup vs serial) |
-| Bulk 1000 varied queries | **3.22 ms/query**, **311 queries/sec** |
-| Merged transfer graph | 66 512 stops, 668 k edges |
-| Cross-feed equivalence bridges | 986 post-ULTRA |
-| Same-station child-pair coverage | 94 % of multi-child parents |
-
-### Running the Routing Engine
-
-```bash
-# Build the Docker image
-docker build -t butterfly-route .
-
-# Run the server (Belgium data). Port 3001 = REST, 3002 = gRPC Flight.
-docker run -d --name butterfly \
-  -p 3001:8080 -p 3002:3002 \
-  -v "${PWD}/data/belgium:/data" \
-  butterfly-route
-
-# Health check (REST)
-curl http://localhost:3001/health
-
-# Swagger UI at http://localhost:3001/swagger-ui/
-
-# gRPC Flight server at 0.0.0.0:3002 — list available actions:
-grpcurl -plaintext localhost:3002 arrow.flight.protocol.FlightService/ListActions
-```
-
-See [CLAUDE.md](CLAUDE.md) for detailed build instructions, algorithm documentation, and local development setup.
-
-## Installation
-
-### Quick Start
-```bash
-# Install from crates.io
-cargo install butterfly-dl
-
-# Download Belgium OSM data
-butterfly-dl europe/belgium
-
-# Verify installation
-butterfly-dl --version
-```
-
-### Development Setup
-```bash
-# Clone the workspace
-git clone https://github.com/butterfly-osm/butterfly-osm
-cd butterfly-osm
-
-# Docker (recommended)
-docker build -t butterfly-route .
-
-# Local build
-cargo build --workspace --release
-
-# Run tests
-cargo test --workspace
-
-# Install specific tool
-cargo install --path dl
-```
-
-### Pre-built Binaries
-
-Download optimized binaries for your platform:
-- [Linux x86_64](https://github.com/butterfly-osm/butterfly-osm/releases/latest/download/butterfly-dl-latest-x86_64-unknown-linux-gnu.tar.gz)
-- [Linux ARM64](https://github.com/butterfly-osm/butterfly-osm/releases/latest/download/butterfly-dl-latest-aarch64-unknown-linux-gnu.tar.gz)  
-- [macOS Intel](https://github.com/butterfly-osm/butterfly-osm/releases/latest/download/butterfly-dl-latest-x86_64-apple-darwin.tar.gz)
-- [macOS Apple Silicon](https://github.com/butterfly-osm/butterfly-osm/releases/latest/download/butterfly-dl-latest-aarch64-apple-darwin.tar.gz)
-- [Windows x86_64](https://github.com/butterfly-osm/butterfly-osm/releases/latest/download/butterfly-dl-latest-x86_64-pc-windows-msvc.zip)
-
-## Workspace Structure
-
-```
-butterfly-osm/
-├── butterfly-common/     # Shared utilities and algorithms
-├── dl/                   # butterfly-dl: OSM data downloader (production-ready)
-├── route/                # butterfly-route: routing engine (production-ready)
-├── scripts/              # Benchmarking and validation scripts
-└── data/                 # Test data and examples
-```
-
-### Building Individual Tools
-
-```bash
-# Build specific tool
-cargo build --release -p butterfly-dl
-
-# Test specific tool  
-cargo test -p butterfly-dl
-
-# Install from workspace
-cargo install --path dl
-```
-
-## Performance Benchmarks
-
-### butterfly-route vs OSRM (Belgium)
-
-| Workload | Butterfly | OSRM | Ratio |
-|----------|-----------|------|-------|
-| Single route | 2ms | 1ms | 2x slower |
-| Isochrone (30min) | **5ms** | - | - |
-| Bulk isochrones | **1,526/sec** | - | - |
-| Matrix 100×100 | 164ms | 55ms | 3x slower |
-| Matrix 1k×1k | 1.55s | 0.68s | 2.3x slower |
-| Matrix 10k×10k | **18.2s** | 32.9s | **1.8x FASTER** |
-
-**Key insight**: Edge-based CH has ~2.5x more states than node-based (exact turn handling).
-The overhead is acceptable for small queries, and **Butterfly wins at scale**.
-
-### Production Features
-
-- **Structured logging**: `tracing` with text/JSON output (`--log-format json`)
-- **Graceful shutdown**: SIGINT + SIGTERM handling
-- **Request timeouts**: 120s for API routes, 600s for streaming
-- **Concurrency limiting**: Max 32 concurrent API requests, max 4 streaming requests
-- **Response compression**: gzip + brotli on API routes
-- **Input validation**: Coordinate bounds, time limits, size limits
-- **Panic recovery**: `CatchPanicLayer` returns 500 JSON instead of crashing
-- **Prometheus metrics**: Per-endpoint latency histograms at `/metrics`, plus per-section CRC verification counters (`butterfly_route_sections_verified_total`, `butterfly_route_sections_verify_pending`, `butterfly_route_section_verify_duration_seconds{section}`, `butterfly_route_section_verify_failed_total{section}`)
-- **Health check**: `/health` with uptime, node/edge counts, mode list, and per-section lazy-CRC verification status (`verify_status`, `verify.{n_sections,n_verified,n_unverified,n_verifying,n_failed,failed[]}`)
-- **Swagger UI**: OpenAPI docs at `/swagger-ui/`
-- **Lazy CRC verification (#160)**: When loaded from a `.butterfly` container (`--data <file>`), per-section CRC walks default to **on-first-access** rather than at boot — saves ~30 % wall-clock and ~30 % boot-transient peak RSS on Belgium. Use `--warmup-on-boot` for a background pass that walks every section in parallel after the listener binds (recommended for production). Use `--eager-verify` to restore the pre-#160 fail-fast-on-boot semantics.
-
-### butterfly-dl vs Industry Standard
-
-Real-world benchmarks on 43MB Luxembourg dataset:
-
-```
-Tool         Duration  Speed     Memory    Improvement
---------------------------------------------------------
-butterfly-dl 3.037s    14.07MB/s ~215MB   Baseline
-aria2c       5.447s    7.84MB/s  ~120MB   79% slower
-curl         9.349s    4.57MB/s  ~10MB    208% slower
-```
-
-**Key insights:**
-- **79% faster** than aria2 (industry standard)
-- **3x faster** than curl
-- Consistent ~215MB memory usage regardless of file size
-- Smart connection scaling based on file size
-
-### Memory Efficiency Verification
-
-```bash
-# Download 81GB planet file - uses <1GB RAM
-butterfly-dl planet
-
-# Memory usage remains constant
-ps aux | grep butterfly-dl
-# butterfly-dl   0.2  2.1  215MB  ...
-```
-
-## Contributing
-
-We welcome contributions to the butterfly-osm ecosystem! 
-
-### Development Philosophy
-- **Performance first**: Every change should maintain or improve performance
-- **Memory conscious**: Fixed memory usage patterns preferred
-- **Test driven**: Comprehensive benchmarks for all performance claims  
-- **Unix philosophy**: Small, composable tools that do one thing well
-
-### Getting Started
-1. Fork the repository
-2. Create a feature branch
-3. Add comprehensive tests and benchmarks
-4. Ensure all existing tests pass
-5. Submit a pull request
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
-
-## License
-
-AGPL-3.0-or-later — see [LICENSE](LICENSE) file for the canonical FSF text.
+Exact turn-aware edge-based CCH for driving, walking, cycling, and trucking;
+a full RAPTOR + ULTRA multimodal transit stack with merged GTFS and
+NeTEx-EPIP feeds; REST + Arrow Flight gRPC; Belgium-latest deployed today,
+faster than OSRM at scale.
 
 [![License: AGPL v3+](https://img.shields.io/badge/license-AGPL--3.0--or--later-blue.svg)](LICENSE)
 
-Network-deployed forks must publish their source code under AGPL §13. By
-submitting a pull request you agree your contribution is licensed under
-AGPL-3.0-or-later (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+## At a glance
 
-## Team
+- **Matrix 10k×10k**: 18.3 s in-process (1.8× faster than OSRM CH at 32.9 s).
+- **Flight gRPC matrix 50k×50k**: 9.61 min (parity with the historical `/table/stream` baseline; OSRM cannot run it).
+- **`/isochrone` 30-min**: 5 ms p50; bulk endpoint sustains **1 526 iso/sec**.
+- **`/route?avoid_polygons=...`**: ~780 ms cold MISS, ~22 ms warm HIT (incremental recustomization + LRU cache, #240).
+- **`/transit` single warm**: 35 ms p50; `/transit/bulk` sustains 311 q/s on varied queries.
+- **Coverage**: 4 modes (car, bike, foot, truck) × 4 merged transit feeds (SNCB, De Lijn, TEC, STIB).
+- Belgium artifact `data/belgium/baseline.butterfly` deployed to the production `belgium-latest` container.
 
-**Butterfly Project** - Built by Pierre <pierre@warnier.net> for the broader OpenStreetMap community.
+## Quickstart
 
----
+```bash
+docker build -t butterfly-route .
+docker run -d --name butterfly -p 3001:8080 -p 3002:3002 \
+  -v "${PWD}/data/belgium:/data" butterfly-route
+curl "http://localhost:3001/route?src_lon=4.3517&src_lat=50.8503&dst_lon=4.4025&dst_lat=51.2194&mode=car"
+```
 
-**Mission**: Democratizing high-performance geographic computing through modern tools and architecture.
+Boot is ~30-40 s for the road graph alone, ~3 min with transit feeds. See
+[Quickstart](docs/quickstart.md) for the full walk-through including the
+upstream `butterfly-dl` + step1–step8 pipeline.
 
-**butterfly-osm** - Hurricane-fast OSM processing for the modern era.
+## Workspace
+
+```
+butterfly-osm/
+├── butterfly-common/   # shared error types + utilities
+├── dl/                 # butterfly-dl — OSM downloader (<1GB RAM for any file size)
+└── route/              # butterfly-route — routing engine + transit
+```
+
+Support directories: `bench/` (regression and competitor benches),
+`scripts/` (OSRM/Valhalla harnesses), `data/` (Belgium artifacts), `traffic/`
+(per-density-class speed profiles for #84 recustomization), `models/`
+(declarative `*.model.json` cost models, Q-Sprint).
+
+## Features
+
+### Point-to-point routing
+- Exact turn restrictions (edge-based CCH state is a directed edge id).
+- Multiple alternatives (penalty-based).
+- `exclude=toll,ferry,motorway` via CCH recustomization with sparse triangle relaxation.
+- `avoid_polygons=...` — incremental recustomization seeded by polygon-flagged base edges (#240) plus a bounded LRU cache keyed by canonicalised polygon hash.
+- Traffic-aware variants (`?traffic=rush_hour`, #84): 5-bucket density classification, per-class speed factors, separate `cch.w.<mode>_<variant>.u32` weight set.
+- Turn-by-turn steps with road names from 754K named-roads index.
+- Bearing hints (`bearings=angle,range`).
+
+### Matrices
+- Bucket many-to-many CH for sparse `S × T` (small `/matrix`, low-latency).
+- K-lane batched PHAST + L3-aware source tiling (#190) for large matrices — 10k×10k in 18.3 s in-process.
+- Arrow Flight gRPC `matrix` action for 50k×50k+ over the wire, with parallel K-best snap (#232).
+- Per-row Arrow IPC streaming, cooperative cancellation on client disconnect.
+
+### Isochrones
+- Block-gated PHAST downward scan (18× faster than naive linear scan).
+- `direction=depart|arrive` (reverse isochrones).
+- `contours=300,600,1200` (multi-contour) and `distance_m=...` (isodistance).
+- GeoJSON or WKB output; CCW outer rings, 5-decimal precision.
+- `POST /isochrone/bulk` length-prefixed WKB stream.
+
+### Multimodal transit
+- RAPTOR rounds over a merged `Timetable` (GTFS + NeTEx-EPIP via streaming `quick-xml` parser, Lambert-93 → WGS84 reprojection).
+- ULTRA-preprocessed stop-to-stop transfer graph (66 512 stops, 668 K edges on Belgium).
+- Cross-feed equivalence bridges (SNCB ↔ STIB, SNCB ↔ De Lijn) and same-station parent-child transfers, injected before ULTRA dominance restriction.
+- `GET /transit` JSON, `POST /transit/bulk` (up to 100 K queries/call), Flight `transit_bulk` action (up to 500 K queries/call).
+- NeTEx calendar fallback: if the active day set is empty (stale publication), remap to the same weekday in the latest published period.
+
+### Other queries
+- `POST /trip` — TSP/trip optimization (nearest-neighbor + 2-opt + or-opt).
+- `GET /nearest` — K-best snap with connectivity-aware role masks (#197).
+- `GET /height` — SRTM DEM elevation.
+- Flight `edges_batch` — unnested per-edge path output with OSM node ids (flow analytics, emissions inventory, network vulnerability).
+- Flight `catchment` — per-store catchment hulls via DoExchange.
+
+### Operational
+- `/health` with uptime, per-region node/edge counts, lazy-CRC verification status, and `avoid_cache` stats (hits/misses/size/capacity per region, #242).
+- `/metrics` (Prometheus): latency histograms, per-section verification counters, `avoid_cache` gauges.
+- Graceful shutdown (SIGINT + SIGTERM), 120s request timeout, 600s streaming timeout, gzip+brotli compression, panic recovery (`CatchPanicLayer`), input validation, multi-region serving (#91).
+
+## Performance (Belgium, vs OSRM CH)
+
+In-process bucket M2M, parallel, 8 threads (`butterfly-bench bucket-m2m --parallel`):
+
+| Size       | OSRM CH | Butterfly | Ratio          |
+|------------|---------|-----------|----------------|
+| 50×50      | 17 ms   | 12 ms     | 1.4× FASTER    |
+| 100×100    | 35 ms   | 32 ms     | 1.1× FASTER    |
+| 1000×1000  | 684 ms  | 268 ms    | 2.56× FASTER   |
+| 5000×5000  | 8.0 s   | 5.5 s     | 1.45× FASTER   |
+| 10000×10000| 32.9 s  | **18.3 s**| **1.8× FASTER**|
+
+Edge-based CCH has ~2.5× more states than OSRM's node-based CH (~5M EBG
+nodes vs ~1.9M), and butterfly handles turn restrictions exactly where OSRM
+approximates them — we beat OSRM despite the extra work. Small `N` (<25)
+still loses to OSRM's sequential shape because rayon thread dispatch isn't
+amortised over so few cells; see closed issue #191 for the analysis.
+
+Flight gRPC end-to-end (includes Arrow IPC framing, full network roundtrip,
+parallel K-best snap):
+
+| Size      | Cells | Time      | Throughput |
+|-----------|-------|-----------|------------|
+| 1k × 1k   | 1 M   | 3.61 s    | 277 K c/s  |
+| 10k × 10k | 100 M | 35.5 s    | 2.8 M c/s  |
+| 50k × 50k | 2.5 B | **9.61 min** | 4.3 M c/s  |
+
+Bench source: `bench/route/results/2026-05-22-post-snap-kbest/REPORT.md`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph data[Data sources]
+        PBF[Belgium PBF]
+        GTFS[GTFS feeds<br/>SNCB · De Lijn · TEC]
+        NETEX[NeTEx-EPIP<br/>STIB]
+    end
+
+    subgraph pipeline[Build pipeline<br/>step1 → step8]
+        ING[step1-ingest<br/>step2-profile]
+        EBG[step3-nbg → step4-ebg<br/>edge-based graph]
+        CCH[step5-weights → step6-order<br/>step7-contract → step8-customize]
+    end
+
+    subgraph serve[Serve]
+        REST[REST :3001<br/>route · matrix · isochrone<br/>transit · trip · nearest · height]
+        FLIGHT[Flight gRPC :3002<br/>matrix · route_batch<br/>isochrone · catchment<br/>transit_bulk · edges_batch]
+    end
+
+    PBF --> ING --> EBG --> CCH --> REST
+    CCH --> FLIGHT
+    GTFS --> REST
+    NETEX --> REST
+    GTFS --> FLIGHT
+    NETEX --> FLIGHT
+```
+
+The edge-based CCH (EBG) is the **single source of truth**: routes,
+matrices, isochrones, transit access/egress legs, and avoid-polygon
+recustomization all run on the same hierarchy with the same weights. That
+invariant is what keeps them mutually consistent. See
+[Architecture](docs/architecture.md) for the full pipeline, PHAST and
+bucket M2M internals, the avoid_polygons fast path (#240), and the transit
+subsystem.
+
+## Documentation
+
+- [Quickstart](docs/quickstart.md) — Docker + first `/route` in 60 seconds.
+- [API reference](docs/api.md) — REST + Flight endpoint catalog, query parameters, response shapes.
+- [Deployment](docs/deployment.md) — env vars, `/health`, `/metrics`, Prometheus, multi-region.
+- [Architecture](docs/architecture.md) — edge-based CCH, pipeline steps, avoid_polygons internals, transit subsystem.
+- [Troubleshooting](docs/troubleshooting.md) — boot failures, snap errors, CRC mismatches, avoid-cache miss rate.
+
+Swagger UI is live at `http://<host>:3001/swagger-ui/` when the server is
+running. `CLAUDE.md` carries the in-tree engineering notes and benchmarking
+playbooks.
+
+## Contributing
+
+Performance claims must be benchmarked against OSRM (matrices) and Valhalla
+(isochrones) on Belgium. The harnesses live under `scripts/` and
+`bench/route/`. Workspace lints are enforced as errors (warnings included);
+run `cargo clippy --workspace --all-targets --all-features` and
+`cargo fmt --all` before opening a PR. Submission implies AGPL-3.0-or-later
+licensing per `CONTRIBUTING.md`.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.
+
+## License
+
+AGPL-3.0-or-later — applies to every crate in the workspace
+(`butterfly-common`, `butterfly-dl`, `butterfly-route`). Network-deployed
+forks must publish source per AGPL §13. See [LICENSE](LICENSE) for the
+canonical FSF text.
+
+## Status
+
+- **butterfly-route**: production-ready; `belgium-latest` container deployed.
+- **butterfly-dl**: production-ready; 79% faster than aria2 on Geofabrik downloads, <1 GB RAM for any file size up to the 81 GB planet.
+- **Geocoder**: shelved (see issue #254, tag `geocode-shelved-2026-05-23`).
+
+Built by Pierre &lt;pierre@warnier.net&gt; for the broader OpenStreetMap
+community.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,721 @@
+# Butterfly-route API reference
+
+Static endpoint reference, generated from source (`route/src/server/*.rs`). For live, interactive docs hit Swagger UI at `http://<host>:3001/swagger-ui` while the server is running.
+
+See also: [Quickstart](quickstart.md), [Deployment](deployment.md), [Architecture](architecture.md), [Troubleshooting](troubleshooting.md).
+
+## Transport overview
+
+| Transport | Port | Wire format | Use for |
+|-----------|------|-------------|---------|
+| REST (Axum) | 3001 | JSON request / JSON response (content-negotiated on `/route`, `/isochrone`) | Human-facing clients, dashboards, single queries |
+| gRPC Flight (tonic) | 3002 | Arrow IPC (`DoGet` ticket + record-batch stream) | Machine-facing bulk pipelines, polars/duckdb consumers |
+
+Architectural rule: **REST stays JSON, Flight stays Arrow.** New bulk Arrow endpoints land on Flight, not on Axum. `/isochrone/bulk` is a pre-Flight exception (length-prefixed WKB stream over HTTP).
+
+Coordinates are always `[longitude, latitude]` (GeoJSON order). Transport modes depend on what models were built at pipeline time — typically `car`, `bike`, `foot` on the Belgium dataset.
+
+Server-wide layers (defined in `route/src/server/api.rs`):
+
+- `ConcurrencyLimitLayer(32)` on every non-streaming route
+- `TimeoutLayer(120s)` on every non-streaming route, `TimeoutLayer(600s)` on `/isochrone/bulk`
+- `DefaultBodyLimit(256 MiB)` on `/isochrone/bulk`
+- `CompressionLayer` (gzip + brotli) on non-streaming routes
+- Permissive CORS
+- `CatchPanicLayer` (panics turn into 500 instead of dropping the connection)
+- Prometheus metrics exposed at `GET /metrics`
+
+---
+
+## REST endpoints
+
+### `GET /route`
+
+Point-to-point routing with geometry, optional turn-by-turn steps with road names, and optional alternatives. Source file: `route/src/server/route.rs`.
+
+**Request**
+
+| Param | Type | Default | Notes |
+|-------|------|---------|-------|
+| `src_lon`, `src_lat` | f64 | required | Source coordinate |
+| `dst_lon`, `dst_lat` | f64 | required | Destination coordinate |
+| `mode` | string | required | `car` / `bike` / `foot` (or any loaded mode) |
+| `traffic` | string | none | Maps to synthetic mode `<mode>_<traffic>` (e.g. `rush_hour`). Variant must exist from `step8-customize --traffic`. |
+| `geometries` | string | `polyline6` | `polyline6` / `geojson` / `points` |
+| `alternatives` | u32 | `0` | Up to 5 alternative routes (penalty-based) |
+| `steps` | bool | `false` | Include turn-by-turn instructions with road names |
+| `annotations` | string | none | Comma list of `duration`, `distance`, `speed`, `nodes` |
+| `bearings` | string | none | `angle,range;angle,range` (source;destination), angle 0-360, range 0-180 |
+| `exclude` | string | none | Comma list of `toll`, `ferry`, `motorway` |
+| `avoid_polygons` | string | none | JSON `[[lon,lat],...]` or `[[[lon,lat],...],...]` |
+| `debug` | bool | `false` | Include snap diagnostics in response |
+
+Content negotiation:
+- `Accept: application/json` (default) → JSON `RouteResponse`
+- `Accept: application/gpx+xml` → GPX 1.1 XML track
+
+**Response (JSON)**
+
+| Field | Type |
+|-------|------|
+| `duration_s` | f64 |
+| `distance_m` | f64 |
+| `geometry` | RouteGeometry (polyline6 string, or GeoJSON LineString, or array of `{lon, lat}`) |
+| `steps` | array of `RouteStep` (if `steps=true`) |
+| `annotations` | object with optional `duration` / `distance` / `speed` / `nodes` arrays |
+| `alternatives` | array of `RouteAlternative` (if `alternatives>0`) |
+| `debug` | `{ src_snapped, dst_snapped }` (if `debug=true`) |
+
+**Errors**
+
+| Status | Cause |
+|--------|-------|
+| 400 | Invalid coord, unknown mode, bad bearing/exclude/annotation token, bad traffic variant, unsnappable point |
+| 404 | No route found after K-best snap fallback (up to 400 combos) |
+
+**Notes**
+
+- K-best snap with `SNAP_K=64` per role + bounded combo fallback (max 400) — see `route.rs:476-498`.
+- Avoid-polygon recustomisation result cached per-region; cache capacity from `BUTTERFLY_AVOID_CACHE_CAP` (default 8), see `route/src/server/avoid.rs`. Hits cost ~22 ms vs minutes for a cold recustomise; surfaced in `/health.avoid_cache`.
+- Same-edge src/dst short-circuits to zero-distance result.
+- Cross-region routing is handled via the overlay cluster (#91 Phase 2) when multiple regions are loaded; same-region queries take the fast intra-region path.
+- See [Architecture: routing pipeline](architecture.md) for the CCH P2P + path-unpack flow.
+
+---
+
+### `GET /nearest`
+
+Snap a coordinate to the nearest road segments accessible by a given transport mode. Source: `route/src/server/nearest.rs`.
+
+**Request**
+
+| Param | Type | Default | Notes |
+|-------|------|---------|-------|
+| `lon`, `lat` | f64 | required | Query coordinate |
+| `mode` | string | required | Transport mode |
+| `number` | u32 | `1` | 1-100 results (returns 400 on `0` or `>100`) |
+| `role` | string | `src` | Directional filter: `src` / `dst` / `either` (#197) |
+
+**Response**
+
+```
+{ "code": "Ok", "waypoints": [{ "location": [lon,lat], "distance": meters, "edge_length_m": ... }, ...] }
+```
+
+**Errors**
+
+- 400 — invalid coord, `number=0`, `number>100`, no road within snap radius
+
+**Notes**
+
+- `Src` filters to candidates with outbound capability for this mode; `Dst` filters to inbound; `Either` is the unfiltered legacy snap.
+- Bike/foot are effectively undirected so all three roles converge.
+
+---
+
+### `POST /table`
+
+Many-to-many distance/duration matrix using Bucket M2M CH. Source: `route/src/server/table.rs`.
+
+**Request body (JSON)**
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `sources` | `[[lon,lat], ...]` | required | One or more |
+| `destinations` | `[[lon,lat], ...]` | required | One or more |
+| `mode` | string | required | Transport mode |
+| `annotations` | string | `"duration"` | `duration`, `distance`, or `duration,distance` |
+| `exclude` | string | none | Same tokens as `/route` |
+| `avoid_polygons` | string | none | Same shape as `/route` |
+| `radius_km` | number / `"auto"` / null | none | Euclidean pre-filter; pairs beyond are emitted as `null` |
+
+Hard cap: `sources × destinations ≤ 10_000_000` cells. Larger workloads must use the Flight `matrix` action (port 3002).
+
+**Response (OSRM-compatible)**
+
+```
+{
+  "code": "Ok",
+  "durations": [[seconds | null, ...], ...],     // present if duration requested
+  "distances": [[meters | null, ...], ...],      // present if distance requested
+  "sources":      [{ "location": [lon,lat], "name": "" }, ...],
+  "destinations": [{ "location": [lon,lat], "name": "" }, ...]
+}
+```
+
+Unreachable cells are `null`. `distances` are shortest-distance routes (separate metric from time-optimal `durations`).
+
+**Errors**
+
+- 400 — empty sources/destinations, invalid coord, matrix too large, bad annotation/exclude token, mixed-region inputs
+
+**Notes**
+
+- `use_parallel` threshold: `≥ 2500` cells uses `table_bucket_parallel` (rayon over sources), smaller uses sequential `table_bucket_full_flat`.
+- K-best snap (`SNAP_K=64`) parallelised over src/dst with rayon. Per-cell K-best fallback (max 200 combos per cell) patches cells the primary snap couldn't connect.
+- Avoid-cache shared with `/route` and `/trip` (`BUTTERFLY_AVOID_CACHE_CAP`).
+- Performance (Belgium, 8 threads, from CLAUDE.md): 50×50 = 12 ms, 100×100 = 32 ms, 500×500 = 116 ms, 1000×1000 = 268 ms, 5000×5000 = 5.5 s, 10000×10000 = 18.3 s — **1.4×–2.56× faster than OSRM CH** across the 50–10000 range.
+
+---
+
+### `POST /table/stream` *(not mounted in current build)*
+
+The HTTP Arrow streaming endpoint exists in source (`table.rs::table_stream_handler`) but is not wired into the router (`api.rs:104`). Its replacement is the Flight `matrix` action on port 3002, which has the same semantics with proper Arrow Flight framing.
+
+Historical performance (when mounted): 10k×10k in 24 s, 50k×50k (2.5 B distances) in 9.5 min with 2.4 GB RAM overhead via tile-by-tile streaming.
+
+---
+
+### `POST /trip`
+
+TSP/trip optimisation: multi-start nearest-neighbor + 2-opt + or-opt over an N×N duration matrix. Source: `route/src/server/trip.rs`.
+
+**Request body (JSON)**
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `coordinates` | `[[lon,lat], ...]` | required | 2-100 waypoints |
+| `mode` | string | `"car"` | Transport mode |
+| `round_trip` | bool | `true` | If false: open path, fixed start at waypoint 0 |
+| `annotations` | string | `"duration"` | `duration`, `distance`, or `duration,distance` |
+| `exclude` | string | none | Same tokens as `/route` |
+| `avoid_polygons` | string | none | Same shape as `/route` |
+
+**Response**
+
+```
+{
+  "code": "Ok" | "Partial",
+  "waypoints": [{ "location": [lon,lat], "waypoint_index": ..., "trips_index": 0, "name": "" }, ...],
+  "trips": [{
+    "legs": [{ "duration": s | null, "distance": m | null, "summary": "" }, ...],
+    "duration": s, "distance": m, "weight": s,
+    "weight_name": "duration",
+    "improvement_pct": <2-opt vs greedy>
+  }]
+}
+```
+
+Unreachable legs emit `null` durations / distances (not `0.0`).
+
+**Errors**
+
+- 400 — `< 2` or `> 100` waypoints, invalid coord, unknown mode/annotation token, mixed-region inputs
+
+---
+
+### `GET /isochrone`
+
+Reachability polygon using PHAST. Source: `route/src/server/isochrone_handler.rs`.
+
+**Request**
+
+| Param | Type | Default | Notes |
+|-------|------|---------|-------|
+| `lon`, `lat` | f64 | required | Origin |
+| `time_s` | u32 | none | 1-7200 seconds. Exactly one of `time_s` / `distance_m` / `contours` must be set. |
+| `distance_m` | u32 | none | 1-100000 meters |
+| `contours` | string | none | Comma list of seconds, 1-10 values, each 1-7200 |
+| `mode` | string | required | Transport mode |
+| `direction` | string | `depart` | `depart` (forward) or `arrive` (reverse PHAST) — case-insensitive |
+| `geometries` | string | `polyline6` | `polyline6` / `geojson` / `points` |
+| `include` | string | none | `network` adds reachable road segments |
+| `exclude` | string | none | Same tokens as `/route` |
+| `avoid_polygons` | string | none | Same shape as `/route` |
+
+Content negotiation:
+- `Accept: application/json` (default) → `IsochroneResponse`
+- `Accept: application/octet-stream` → raw WKB polygon (single contour only)
+
+**Response (JSON)**
+
+```
+{
+  "contours": [{
+    "time_s": ..., "distance_m": ...,           // one of these is set
+    "polygon" | "polygon_geojson" | "polygon_points": ...,
+    "reachable_edges": ...
+  }, ...],
+  "network": [[[lon,lat], ...], ...]   // only if include=network
+}
+```
+
+Polygon ring orientation is enforced CCW for outer rings (GeoJSON spec). JSON coordinate precision is 5 decimals (~1 m) since contours come from a 30 m raster grid.
+
+**Errors**
+
+- 400 — invalid coord/mode, missing or multiple metric (must provide exactly one), out-of-range threshold, invalid direction, bad geometry format
+
+**Notes**
+
+- Block-gated downward PHAST + thread-local state — 5 ms p50 on the 30-min car case (CLAUDE.md). 815/sec for JSON, 814/sec for WKB.
+- Reverse isochrone (`direction=arrive`) uses plain linear-scan downward (PUSH+block-gating is broken for reverse PHAST — see MEMORY.md).
+
+---
+
+### `POST /isochrone/bulk`
+
+Parallel batch isochrones (rayon-fanned PHAST), returns a length-prefixed WKB stream. Source: `route/src/server/isochrone_handler.rs:1062`.
+
+**Request body**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `origins` | `[[lon,lat], ...]` | Max 10000 |
+| `time_s` | u32 | 1-7200 |
+| `mode` | string | Transport mode |
+| `exclude` | string | optional |
+| `avoid_polygons` | string | optional |
+
+**Response (binary, `application/octet-stream`)**
+
+Per origin: `[u32 LE origin_idx][u32 LE wkb_len][N bytes WKB polygon]`.
+
+**Errors**
+
+- 400 — empty origins, too many (>10000), invalid coord, out-of-range `time_s`, mixed-region origins
+
+**Notes**
+
+- 256 MB request body limit, 600 s request timeout, concurrency limit 4 (memory-intensive).
+- Cooperative cancellation on client disconnect via atomic flag checked inside the rayon worker.
+- 1526 iso/sec on Belgium (CLAUDE.md).
+
+---
+
+### `POST /catchment`
+
+Per-store catchment polygons: for each store, run 1-to-N matrix against clients, then build a percentile hull. Source: `route/src/server/catchment.rs`.
+
+**Request body**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `mode` | string | required |
+| `hull_mode` | enum | `convex` / `concave` / `isochrone` |
+| `percentiles` | `[f32]` | required, each 0-100 |
+| `remove_outliers` | bool | default `true` |
+| `stores` | `[{ id, lon, lat }]` | required |
+| `clients` | `[{ lon, lat }]` | required |
+| `radius_km` | number / `"auto"` / null | optional Euclidean pre-filter, per-store |
+
+**Response**
+
+```
+{ "results": [{
+    "store_id": "...",
+    "percentile": 80.0,
+    "threshold_seconds": ...,
+    "clients_covered": u32,
+    "clients_total": u32,
+    "polygon_wkb_base64": "..."
+}, ...] }
+```
+
+**Errors**
+
+- 400 — empty stores or percentiles, invalid coord, percentile out of `[0, 100]`, mixed-region inputs
+
+---
+
+### `POST /match`
+
+Map-match a GPS trace to the road network using HMM + Viterbi (Newson & Krumm 2009). Source: `route/src/server/matching.rs`.
+
+**Request body**
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `coordinates` | `[[lon,lat], ...]` | required | At least 2, max 500 |
+| `mode` | string | `"car"` | Transport mode |
+| `gps_accuracy` | f64 | `10` | Meters |
+| `geometry` | string | `"polyline6"` | Same set as `/route` |
+| `steps` | bool | `false` | Turn-by-turn |
+| `exclude` | string | none | |
+| `avoid_polygons` | string | none | |
+
+**Response**
+
+```
+{
+  "code": "Ok",
+  "matchings": [{
+    "geometry": ...,
+    "duration": s, "distance": m,
+    "confidence": 0..1,
+    "steps": [...]  // if requested
+  }, ...],
+  "tracepoints": [ { location, name, matchings_index, waypoint_index } | null, ... ]
+}
+```
+
+**Errors**
+
+- 400 — `< 2` coordinates, invalid coord, unknown mode
+- 404 — no match
+
+**Notes**
+
+- Candidate selection uses spatial-index midpoints (topologically reliable); perpendicular projection is used only for emission probability and snap position. ~5 s for a 10-point trace; ~500 ms per transition step (CLAUDE.md / MEMORY.md).
+- Cross-region matching (#194) supported when an overlay cluster is loaded.
+
+---
+
+### `GET /height`
+
+Elevation lookup from SRTM `.hgt` tiles. Source: `route/src/server/height_handler.rs`.
+
+**Request**
+
+| Param | Type | Notes |
+|-------|------|-------|
+| `coordinates` | string | Pipe-separated `lon,lat` pairs, e.g. `4.35,50.85\|4.40,50.86` (URL-encode the pipe). Max 10000. |
+
+**Response**
+
+```
+{ "elevations": [{ "lon": ..., "lat": ..., "elevation": meters | null }, ...] }
+```
+
+`null` for coordinates outside SRTM coverage.
+
+**Errors**
+
+- 400 — empty / malformed coordinate string, too many coordinates
+- 503 — elevation data not loaded (no SRTM tiles in `data/srtm/`)
+
+---
+
+### `GET /transit`
+
+Single multimodal transit journey: access leg (any road mode) → RAPTOR rounds (any merged GTFS/NeTEx feed) → egress leg. Source: `route/src/server/transit_handler.rs`.
+
+**Request**
+
+| Param | Type | Default | Notes |
+|-------|------|---------|-------|
+| `origin_lon`, `origin_lat` | f64 | required | |
+| `dest_lon`, `dest_lat` | f64 | required | |
+| `depart` | string | `08:00:00` | `HH:MM` or `HH:MM:SS`, service-local time |
+| `access_mode` | string | `foot` | Any loaded road mode |
+| `egress_mode` | string | same as `access_mode` | |
+| `max_access_m` | u32 | per-mode: foot 2000, bike 8000, car 30000 | |
+| `max_egress_m` | u32 | per-mode | |
+| `max_walk_m` | u32 | none | Deprecated alias when both modes are `foot` |
+| `max_access_stops` | usize | foot 20, bike 60, car 500, other 100 | |
+| `walk_speed_mps` | f64 | `1.3` | Only used when access mode is foot |
+| `geometry` | string | `straight` | `straight` (endpoints only) or `full` (routed polyline via CCH unpack) |
+
+**Response**
+
+```
+{
+  "origin": [lon,lat], "destination": [lon,lat],
+  "depart_time": "HH:MM:SS", "arrival_time": "HH:MM:SS",
+  "total_duration_s": u32,
+  "access_mode": "foot", "egress_mode": "foot",
+  "legs": [
+    { "type": "walk" | "drive" | "road", "from": [lon,lat], "to": [lon,lat],
+      "duration_s": ..., "distance_m": ..., "geometry": [...]? },
+    { "type": "transit", "from_stop_id": "sncb:8814001", "from_stop_name": "...",
+      "from": [...], "to_stop_id": "...", "to_stop_name": "...", "to": [...],
+      "board_time": "HH:MM:SS", "alight_time": "HH:MM:SS", "duration_s": ...,
+      "route_short_name": "...", "route_long_name": "...", "headsign": "..." }
+  ]
+}
+```
+
+**Errors**
+
+- 400 — bad params / mode
+- 503 — transit subsystem not loaded (no feeds configured at boot)
+
+**Notes**
+
+- Single-region only (#91 Phase 1). Transit always uses the primary region's foot CCH + merged timetable.
+- 35 ms p50 warm (CLAUDE.md, 4 feeds merged on Belgium).
+
+---
+
+### `POST /transit/bulk`
+
+Batch multimodal routing. Source: `route/src/server/transit_handler.rs:966`.
+
+**Request body**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `queries` | array of `TransitRequest` | Max 100000 |
+| `max_walk_m` | u32 | Per-batch default for any query that omits the field |
+| `access_mode` | string | Per-batch default |
+| `egress_mode` | string | Per-batch default |
+
+**Response**
+
+```
+{ "count": N, "results": [
+    { "kind": "ok", "journey": { ... TransitResponse ... } }
+  | { "kind": "err", "status": 400, "error": "..." }
+] }
+```
+
+**Errors**
+
+- 413 — batch larger than 100000
+- 503 — transit subsystem not loaded
+
+**Notes**
+
+- Origin grouping (#120): queries with the same quantised origin + access params share the access fan-out (snap + R-tree + CCH 1-to-N).
+- Sustained 311 q/s on 1000 varied queries; 7× speed-up on 20 same-origin queries vs serial (CLAUDE.md).
+- For larger / Arrow-shaped workloads use the Flight `transit_bulk` action (port 3002, up to 500000 queries per call).
+
+---
+
+### `GET /health`
+
+Health snapshot. Source: `route/src/server/health_handler.rs`.
+
+**Response**
+
+```
+{
+  "status": "ok",
+  "version": "...",
+  "uptime_s": u64,
+  "modes": ["bike", "car", "foot"],
+  "data_dir": "...",
+  "nodes_count": ..., "edges_count": ..., "named_roads_count": ...,
+  "regions_count": ..., "regions": ["belgium"],
+  "total_nodes_count": ..., "total_edges_count": ...,
+  "verify_status": "ok" | "verified" | "pending" | "degraded",
+  "verify": { "n_sections": ..., "n_verified": ..., "n_unverified": ...,
+              "n_verifying": ..., "n_failed": ..., "failed": [...] },
+  "avoid_cache": [{ "region": ..., "hits": u64, "misses": u64,
+                    "hit_rate": 0..1, "size": ..., "capacity": ... }, ...]
+}
+```
+
+Status field is always `"ok"` while the server can answer requests. `verify_status` and `avoid_cache` are the operational signals; tune `BUTTERFLY_AVOID_CACHE_CAP` based on the hit rate.
+
+---
+
+### `GET /metrics`
+
+Prometheus exposition (text format). Plain `axum_prometheus::PrometheusMetricLayer` register, plus avoid-cache stats mirrored at every `/health` scrape (`record_avoid_cache_stats`).
+
+No request params.
+
+---
+
+### `GET /regions`
+
+Per-region listing (multi-region deploys). One row per loaded region with `id`, snap-bounding box, node/edge counts. Source: `route/src/server/regions_handler.rs`.
+
+---
+
+## gRPC Flight actions (port 3002)
+
+Ticket format (verified from `route/src/server/flight.rs:81-98`):
+
+```
+<action>:<profile>:<json_params>
+```
+
+- `<action>` — `matrix` / `route_batch` / `isochrone` / `transit_bulk` / `edges_batch`
+- `<profile>` — any loaded mode (looked up case-insensitively)
+- `<json_params>` — UTF-8 JSON, action-specific shape
+
+`catchment` is exposed via `DoExchange` rather than `DoGet`: send batches with `flight_descriptor.cmd = "catchment:<profile>:<json>"` (input columns: `store_id:utf8, store_lon:f64, store_lat:f64, client_lon:f64, client_lat:f64`).
+
+Common output: a stream of Arrow `RecordBatch`es. Bound-checking errors surface as `tonic::Status::invalid_argument`. Service unavailable (transit not loaded) → `failed_precondition`.
+
+### Action: `matrix`
+
+Params:
+
+```json
+{ "sources": [[lon,lat], ...],
+  "destinations": [[lon,lat], ...],
+  "radius_km": <number | "auto" | null> }
+```
+
+Output schema:
+
+| Column | Arrow type | Notes |
+|--------|------------|-------|
+| `source_idx` | u32 | Original input position |
+| `target_idx` | u32 | |
+| `duration_ms` | u32 | `u32::MAX` for unreachable |
+| `distance_m` | u32 | `u32::MAX` (distance not computed under the time metric in this action) |
+
+### Action: `route_batch`
+
+Params:
+
+```json
+{ "pairs": [[src_lon, src_lat, dst_lon, dst_lat], ...] }
+```
+
+Max 100000 pairs. Chunked into 1000-pair RecordBatches.
+
+| Column | Arrow type | Notes |
+|--------|------------|-------|
+| `src_lon`, `src_lat`, `dst_lon`, `dst_lat` | f64 | Echo of input |
+| `duration_s` | f32 | `NaN` on no-route |
+| `distance_m` | f32 | `NaN` on no-route |
+| `geometry_wkb` | binary | Little-endian LineString WKB, empty bytes when no route |
+
+Each pair gets K-best snap (`SNAP_K=64`) + bounded combo fallback (mirror of `/route`).
+
+### Action: `isochrone`
+
+Params:
+
+```json
+{ "lon": f64, "lat": f64,
+  "intervals": [u32, ...],    // seconds, 1-10 values each 1-7200
+  "direction": "depart" | "arrive" }
+```
+
+| Column | Arrow type | Notes |
+|--------|------------|-------|
+| `interval_s` | u32 | |
+| `polygon_wkb` | binary | WKB Polygon, CCW outer ring |
+
+### Action: `catchment` *(DoExchange)*
+
+Descriptor cmd: `catchment:<profile>:<params>` with params
+
+```json
+{ "percentiles": [50, 80], "hull_mode": "isochrone" | "convex" | "concave",
+  "remove_outliers": true }
+```
+
+Input schema:
+
+| Column | Arrow type |
+|--------|------------|
+| `store_id` | utf8 |
+| `store_lon`, `store_lat` | f64 |
+| `client_lon`, `client_lat` | f64 |
+
+Output: per-store × per-percentile rows (`catchment_arrow_schema`):
+
+| Column | Arrow type |
+|--------|------------|
+| `store_idx` | u32 |
+| `store_id` | utf8 |
+| `percentile` | f32 |
+| `threshold_seconds` | f32 |
+| `clients_covered`, `clients_total` | u32 |
+| `polygon_wkb` | binary |
+
+### Action: `transit_bulk`
+
+Params (`route/src/server/flight.rs:1166`):
+
+```json
+{ "queries": [ { ...TransitRequest... }, ... ],
+  "max_walk_m": u32?, "access_mode": string?, "egress_mode": string? }
+```
+
+Max 500000 queries. The `profile` portion of the ticket is ignored — every query carries its own `access_mode`/`egress_mode`. Chunked into 1024-row RecordBatches.
+
+| Column | Arrow type | Nullable |
+|--------|------------|----------|
+| `query_idx` | u32 | no |
+| `status` | utf8 (`"ok"` / `"err"`) | no |
+| `http_status` | u16 (200, 4xx, 5xx) | no |
+| `error` | utf8 | yes |
+| `origin_lon`, `origin_lat`, `dest_lon`, `dest_lat` | f64 | no |
+| `depart_time`, `arrival_time` | utf8 | yes |
+| `total_duration_s` | u32 | yes |
+| `access_mode`, `egress_mode` | utf8 | yes |
+| `legs_json` | utf8 | yes — JSON-encoded leg array |
+
+`legs_json` is JSON rather than native `List<Struct>` because the transit-leg enum has four tagged variants with up to 12 nullable fields including `Arc<str>` route metadata.
+
+### Action: `edges_batch`
+
+Params (`route/src/server/flight.rs:914`):
+
+```json
+{ "pairs": [[src_lon, src_lat, dst_lon, dst_lat], ...] }
+```
+
+Max 500000 pairs. Chunked at 256 pairs per RecordBatch (≈5000 rows after ~20-edge average path).
+
+| Column | Arrow type | Nullable |
+|--------|------------|----------|
+| `query_idx` | u32 | no |
+| `target_idx` | u32 | no (placeholder 0 in the flat MVP shape) |
+| `edge_seq` | u32 | yes — null marks unreachable pair |
+| `osm_node_from`, `osm_node_to` | i64 | yes |
+| `duration_ms`, `distance_m` | u32 | yes |
+
+**Continuity invariant:** within a `(query_idx, target_idx)` group, consecutive rows satisfy `osm_node_to[i] == osm_node_from[i+1]`. Unreachable pairs emit exactly one row with all edge columns null.
+
+Designed for flow analytics / traffic-assignment / emissions inventory — the unnested shape is deliberate (per the #125 ticket: nested `list<struct>` fights every downstream tool).
+
+---
+
+## End-to-end flow: `/route` with `avoid_polygons`
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant H as route_handler
+    participant Cache as AvoidWeightCache<br/>(per region)
+    participant Recust as compute_avoid_weights_time_only
+    participant Q as CchQuery
+    participant U as unpack_path
+
+    C->>H: GET /route?...&avoid_polygons=...
+    H->>H: validate coords, parse mode, exclude,<br/>annotations, bearings, avoid JSON
+    H->>H: canonicalise polygon JSON, hash key
+    H->>Cache: lookup(hash)
+    alt cache HIT (~22 ms)
+        Cache-->>H: Arc<AvoidEntry> (shared weights + flags)
+    else cache MISS
+        H->>Recust: R-tree edge lookup + sparse triangle relaxation
+        Recust-->>H: AvoidEntry { time_weights, flags, ... }
+        H->>Cache: insert(hash, Arc::clone)
+    end
+    H->>H: build snap_mask = mode mask AND avoid flags AND exclude flags
+    H->>H: K-best snap src + dst (SNAP_K=64) under role + mask
+    H->>Q: CchQuery::with_custom_weights(topo, up_flat, down_flat, time_weights)
+    H->>Q: query(src_rank, dst_rank) [+ combo fallback up to 400]
+    Q-->>H: QueryResult { forward_parent, backward_parent, meeting_node, distance }
+    H->>U: unpack_path → EBG edge sequence
+    U-->>H: ebg_path
+    H->>H: build_geometry / build_steps with way_names lookup
+    H-->>C: JSON RouteResponse (or GPX on Accept: application/gpx+xml)
+```
+
+Cache key is a quantised, deduped hash of the polygon JSON (`avoid.rs:hash_avoid_payload` — 6-decimal quantisation, ring rotation-normalised). Cache capacity is set by `BUTTERFLY_AVOID_CACHE_CAP` (default 8); current hit / miss / size / capacity is surfaced via `/health.avoid_cache` and Prometheus.
+
+---
+
+## Status codes
+
+| Status | When |
+|--------|------|
+| 200 | Success — including "no route" when the response body itself carries the failure (e.g. `TripLeg.duration = null`) |
+| 400 | Validation: bad coord, bad mode, bad token (annotation/exclude/bearing/direction), empty required field, matrix too large, batch too large for the JSON endpoint, mixed-region inputs to a same-region endpoint |
+| 404 | `/route` only: no path between src and dst after the K-best fallback |
+| 408 | Request timeout — 120 s on most endpoints, 600 s on `/isochrone/bulk`; emitted by `TimeoutLayer` |
+| 413 | `/transit/bulk` batch larger than 100000 |
+| 500 | Internal bug. Panics are caught by `CatchPanicLayer` and turned into 500 instead of dropping the connection |
+| 503 | Subsystem unavailable: `/height` with no SRTM tiles loaded, `/transit*` with no feeds loaded |
+
+REST error body shape (`route/src/server/types.rs::ErrorResponse`):
+
+```json
+{ "error": "human-readable message" }
+```
+
+`/trip` uses a slightly different shape (`{ "code": "InvalidValue", "message": "..." }`) for OSRM compatibility on validation paths.
+
+Flight errors surface as `tonic::Status` with codes `InvalidArgument` (validation / unknown action / bad ticket), `FailedPrecondition` (transit not loaded), and `Internal` (Arrow encoding errors).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,501 @@
+# Butterfly-route architecture
+
+This document explains how `butterfly-route` works under the hood: which graph
+the engine routes on, why, how queries are dispatched, and where the marquee
+performance/feature mechanisms live in the source tree.
+
+For the user-facing endpoint surface (REST + Flight), see
+[API reference](api.md).
+
+---
+
+## 1. Why edge-based CCH
+
+`butterfly-route` is built on a **Customizable Contraction Hierarchy** whose
+state is a **directed edge id**, not a node id. That choice is the single most
+load-bearing decision in the codebase, so it gets paid back in every other
+section.
+
+In a classic node-based CH (what OSRM uses):
+
+- The Dijkstra label is a node.
+- A turn restriction (`no_u_turn`, `no_right_on_red`, banned right-on-red from
+  way A onto way B) cannot be encoded as a node property — it is a property
+  of the *transition* between two incident ways.
+- The CH preprocessing therefore either ignores turn restrictions (OSRM's
+  matrix path) or approximates them by collapsing forbidden transitions into
+  larger penalties that fight with shortest-path semantics.
+
+Butterfly's edge-based graph (EBG) replaces every original road edge with a
+*directed edge node*. A turn from edge `e_in` to edge `e_out` is a literal
+arc `e_in → e_out`, and its cost is `cost(e_in) + turn_penalty(e_in, e_out)`.
+That makes turn restrictions **structural**: a forbidden turn is just an
+absent arc.
+
+The trade-off is real:
+
+| Aspect             | OSRM (node-based)  | Butterfly (edge-based) |
+|--------------------|--------------------|------------------------|
+| Routing state      | Node id            | Directed edge id       |
+| Belgium graph size | ~1.9M nodes        | ~5M edge-states (~2.5x)|
+| Turn restrictions  | Approximated/ignored | Exact                |
+| CH preprocessing   | Simpler            | More shortcuts, more work |
+
+The "one graph, one hierarchy, one query engine" invariant in
+`CLAUDE.md` follows directly: routes, matrices, isochrones, transit access
+legs and avoid-polygon recustomization all run on the **same** EBG-based CCH.
+That means a turn restriction that affects routing also affects matrix
+distances and isochrone reach — they cannot drift.
+
+---
+
+## 2. The pipeline
+
+`butterfly-route` builds its routing artifacts in 8 explicit, lockable steps.
+Each step writes a deterministic, CRC-checked binary file and a
+`stepN.lock.json` manifest. The serve binary mmaps the step-8 outputs at boot.
+
+```mermaid
+flowchart LR
+    pbf[(belgium.pbf)]
+    s1[step1-ingest]
+    s2[step2-profile]
+    s3[step3-nbg]
+    s4[step4-ebg]
+    s5[step5-weights]
+    s6[step6-order]
+    s7[step7-contract]
+    s8[step8-customize]
+    serve[serve]
+
+    pbf --> s1
+    s1 --> |nodes.sa<br/>nodes.si<br/>ways.raw<br/>relations.raw| s2
+    s2 --> |way_attrs.MODE.bin<br/>turn_rules.MODE.bin| s3
+    s3 --> |nbg.nodes<br/>nbg.csr<br/>nbg.geo| s4
+    s4 --> |ebg.nodes<br/>ebg.csr<br/>ebg.turn_table| s5
+    s5 --> |w.MODE.u32<br/>t.MODE.u32<br/>mask.MODE.bitset| s6
+    s6 --> |order.MODE| s7
+    s7 --> |cch.topo.MODE| s8
+    s8 --> |cch.w.MODE.u32<br/>cch.w.MODE_VARIANT.u32| serve
+```
+
+- **step1-ingest** — Parse PBF into raw sorted arrays. No semantics, just OSM
+  bytes laid out for streaming.
+- **step2-profile** — Apply the declarative JSON profile (`*.model.json`) to
+  every way and turn restriction. Produces per-mode attribute arrays. This is
+  where density classes (urban_high…rural) get baked in for traffic
+  recustomization (#84).
+- **step3-nbg** — Build a Node-Based Graph. **Build-time intermediate only**:
+  the NBG geometry is preserved (for polyline reconstruction) but the NBG
+  topology is discarded after step 4.
+- **step4-ebg** — Convert NBG → EBG. Every directed road edge becomes an EBG
+  node; every legal turn becomes an EBG arc. Turn restrictions live in
+  `ebg.turn_table`.
+- **step5-weights** — Per-mode weights (time and distance) and the snap mask
+  bitsets. The mask says "this EBG node is accessible to mode M with at least
+  one outbound *and* one inbound arc connected to the routing core".
+- **step6-order** — Nested-dissection ordering on the **filtered EBG**
+  (per-mode). The lifted-from-NBG shortcut (mode-agnostic ordering reused
+  across modes) produced catastrophic contraction in tests (truck on Belgium:
+  1053M shortcuts vs 27.6M, 38× worse). Step 7 warns if the resulting ratio
+  exceeds 50× — see `MEMORY.md → Ordering Quality`.
+- **step7-contract** — CCH contraction. Emits UP/DOWN edge CSRs plus the
+  shortcut → triangle witness table.
+- **step8-customize** — Apply the step-5 weights to the contracted hierarchy
+  (bottom-up + triangle relaxation). The triangle relaxation phase is
+  ~98% of step-8 wall time on Belgium (43 s freeflow car) and is
+  **correctness-critical**: skipping it produces wildly wrong paths
+  (Brussels–Antwerp went 77 km / 5583 s without relaxation vs the correct
+  45 km / 1947 s).
+
+Step 8 optionally writes traffic-variant weight files
+(`cch.w.car_rush_hour.u32`, …) by applying per-density-class speed factors.
+At boot, the server auto-discovers these and exposes them as synthetic modes
+(`?traffic=rush_hour` query parameter).
+
+---
+
+## 3. Query model
+
+Three query shapes, three algorithms, one CCH:
+
+```mermaid
+flowchart TD
+    q{Query type}
+    q -->|P2P route| p2p[Bidirectional CCH search<br/>upward fwd + upward bwd<br/>meeting node minimises sum]
+    q -->|Isochrone<br/>1-to-all| phast[PHAST<br/>upward Dijkstra<br/>+ linear DOWN scan]
+    q -->|Matrix N×M| mselect{N×M ≤ 10000?}
+    mselect -->|yes| bucket[Bucket many-to-many CCH<br/>fwd buckets per source<br/>bwd join per target]
+    mselect -->|no| kphast[K-lane batched PHAST<br/>8 sources per DOWN scan<br/>L3-aware source tiling]
+
+    p2p --> geom[Path unpack via<br/>middle-witness recursion]
+    phast --> contour[Frontier extract → tile stamp<br/>→ Moore trace → simplify]
+    bucket --> arrow[Arrow IPC<br/>tile-streamed]
+    kphast --> arrow
+```
+
+The selection logic lives in `route/src/matrix/` and
+`route/src/server/table.rs`. Justifications:
+
+- **P2P uses bidirectional CCH search** because it has the lowest constant
+  factor for single-pair queries (~25 ms on Belgium for a Brussels→Antwerp
+  car query) and integrates with the version-stamped `CchQueryState`
+  thread-local so per-query init is O(1).
+- **Isochrones use PHAST** because they need *all* reachable nodes; PHAST's
+  linear DOWN scan in rank order is bandwidth-optimal for the full distance
+  field and beats a Dijkstra-with-threshold by ~18×
+  (90 ms → 5 ms p50 after block-gating).
+- **Small matrices use Bucket M2M** because it only explores paths to the
+  *requested* targets. For 50×50 the bucket variant touches ~5% of the
+  graph; PHAST would touch 100%.
+- **Large matrices use K-lane PHAST** because at ≥1000 sources the
+  per-source forward search becomes the bottleneck and batching 8 sources
+  through one DOWN scan amortises the memory-access cost (cache miss rate
+  is 80–87% — bandwidth is the limit, not CPU).
+
+The bucket M2M's directed-graph correctness invariant deserves an explicit
+call-out:
+
+```
+d(s → t) = min over middle m of d(s → m) + d(m → t)
+
+source phase   : forward UP search   → d(s → m)
+target phase   : REVERSE search on   → d(m → t)
+                 DownReverseAdjFlat    (NOT d(t → m)!)
+```
+
+In a directed graph `d(t → m) ≠ d(m → t)`. The reverse adjacency
+(`route/src/matrix/bucket_ch.rs::DownReverseAdjFlat`) is what makes the
+target phase actually search backward, not just "in the other direction".
+
+---
+
+## 4. The avoid_polygons fast path (#240)
+
+`avoid_polygons=[[lon,lat],…]` lets the client penalise edges inside a user
+polygon. Naively this requires a fresh CCH customization (~30 s on Belgium
+for any polygon, because the bottom-up rebuilds every shortcut weight). The
+#240 silver bullet does two things to make repeat queries cheap:
+
+1. **Incremental recustomization** — seed only the base edges actually in the
+   polygon, BFS-propagate via triangle dependencies, stop when the queue
+   empties. Work is bounded by polygon size, not graph size.
+2. **Bounded LRU cache** keyed by `(mode, polygon_hash, exclude_mask)`. The
+   polygon hash is canonicalised (6-decimal quantisation, Booth's
+   lex-minimal-rotation, ring sort) so byte-different but
+   geometrically-identical polygons collide. Default capacity 8 entries
+   (~1.6 GB ceiling); override via `BUTTERFLY_AVOID_CACHE_CAP`.
+
+Measured wall time on Belgium:
+
+| Polygon size  | Cold MISS (incremental) | Warm HIT (`Arc::clone`) |
+|---------------|-------------------------|-------------------------|
+| 1 km rural    | ~780 ms                 | ~22 ms                  |
+| Old code      | ~37 s                   | n/a                     |
+
+Sequence for a single `/route?avoid_polygons=…` request:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant R as REST handler
+    participant H as polygon hash<br/>(canon + Booth)
+    participant K as AvoidWeightCache
+    participant I as incremental<br/>recustomize
+    participant Q as CCH P2P search
+
+    C->>R: GET /route?avoid_polygons=...
+    R->>H: canonicalise + hash JSON
+    H-->>R: 64-bit key (mode, exc, polyhash)
+    R->>K: get(key)
+    alt cache HIT
+        K-->>R: Arc<AvoidEntry>
+        Note over R,K: no clone of weights<br/>only Arc bump
+        R->>Q: search(time_weights from entry)
+        Q-->>R: path + metrics
+    else cache MISS
+        K-->>R: None
+        R->>I: seed flagged base edges<br/>+ BFS triangle deps
+        I-->>R: ExcludeWeights (time + dist + flats)
+        R->>K: insert(key, Arc<AvoidEntry>)
+        R->>Q: search(time_weights)
+        Q-->>R: path + metrics
+    end
+    R-->>C: JSON route
+```
+
+The BFS itself is the heart of `exclude.rs::recustomize_weights_incremental`:
+
+```mermaid
+flowchart TD
+    seed[Seed queue<br/>every CCH base edge<br/>whose OSM edge is in polygon]
+    seed --> pop{queue empty?}
+    pop -->|no| edge[pop edge x→y]
+    edge --> recompute[recompute_edge_weight<br/>scan all triangles x→m→y<br/>pick lex-smallest pack_wm]
+    recompute --> changed{weight or<br/>middle changed?}
+    changed -->|no| pop
+    changed -->|yes| writeback[write new weight + middle]
+    writeback --> deps{UP or DOWN?}
+    deps -->|UP edge m→y| upward[walk reverse-DOWN m<br/>enqueue x→y for every<br/>x with DOWN edge x→m]
+    deps -->|DOWN edge x→m| downward[walk UP m<br/>enqueue x→y for every<br/>y with UP edge m→y]
+    upward --> pop
+    downward --> pop
+    pop -->|yes| done[done — bounded by<br/>polygon size, not graph]
+```
+
+The triangle witness is encoded as `pack_wm(weight, middle)` — a single u64
+with weight in the high 32 bits, middle rank in the low 32, so a min over the
+packed value gives a deterministic `(weight, middle)` tuple even on ties.
+The lex-min property is what makes the BFS converge: weights only decrease
+or hold steady, so the recomputed graph is monotone in iteration count.
+
+The cache stores `Arc<AvoidEntry>` containing time weights, distance
+weights, *and* the three flat adjacencies (`UpAdjFlat`, `DownReverseAdjFlat`,
+`DownAdjFlat`). One MISS pays for every subsequent /route, /table,
+/isochrone, /trip on the same polygon — the entry is shared across endpoints.
+
+---
+
+## 5. The transit subsystem
+
+Multimodal transit is a **first-class peer** of road routing, not an add-on.
+It reuses the same `ServerState`, the same foot CCH, and the same packed
+snap index.
+
+```mermaid
+flowchart LR
+    O[origin lat,lon]
+    A[access CCH<br/>1-to-N<br/>foot/bike/car]
+    R[RAPTOR rounds<br/>round-based<br/>earliest arrival]
+    E[egress CCH<br/>1-to-N<br/>foot only]
+    D[destination]
+
+    O --> A
+    A -->|max_access_m<br/>max_access_stops| R
+    R -->|round k: relax stops<br/>round k+1: ULTRA transfers| R
+    R --> E
+    E -->|max_egress_m| D
+```
+
+The pieces:
+
+- **Access leg** — `CchQuery::distances_one_to_many` on the foot/bike/car
+  CCH. Bounded by `max_access_m` (radius) and `max_access_stops` (count) to
+  cap fan-out.
+- **RAPTOR** — round-based earliest-arrival over the merged `Timetable`.
+  Thread-local `RaptorState` with generation-stamped scratch arrays gives
+  O(1) per-query init.
+- **Transfer graph** — ULTRA-preprocessed stop-to-stop, pure foot, built once
+  at startup by bounded multi-source Dijkstra over the foot CCH. Cached at
+  `transit/transfers.bin` with provenance (CCH fingerprint + feed hash +
+  algo version). On Belgium: **66 512 stops, 668 k edges**.
+- **Egress leg** — same shape as access, foot mode only.
+
+The Timetable is **merged** across feeds:
+
+```mermaid
+flowchart TD
+    cfg[transit.toml feeds]
+    cfg --> dispatch{format?}
+    dispatch -->|Gtfs| gtfs[gtfs::load_into_builder<br/>SNCB, De Lijn, TEC]
+    dispatch -->|NetexEpip| epip[netex_epip::load_into_builder<br/>STIB, streaming quick-xml<br/>Lambert-93 → WGS84]
+    gtfs --> tb[(shared TimetableBuilder)]
+    epip --> tb
+    tb --> tt[merged Timetable<br/>namespaced stop ids<br/>sncb:8814001<br/>stib:FR:ScheduledStopPoint:...]
+    tt --> ultra[ULTRA transfer build]
+    ultra --> bridges[inject cross-feed bridges<br/>30s equivalent stops<br/>60s same-station child pairs]
+    bridges --> restrict[ULTRA dominance restriction]
+    restrict --> tg[(TransferGraph)]
+```
+
+Cross-feed bridges are injected **before** the ULTRA dominance restriction
+so the restriction drops a synthetic bridge cleanly whenever a shorter real
+walking transfer dominates it — no special-casing in the RAPTOR loop.
+
+Calendar handling is asymmetric:
+
+- **GTFS** — `ServiceFilter` applied at load time against today's date.
+- **NeTEx-EPIP** — STIB publications are often weeks stale, so
+  `compute_active_day_types` tries today's date first; if every period is in
+  the past, it remaps today to **the same weekday in the latest published
+  period**. Tuesday-today → Tuesday-in-window. Preserves weekday/weekend
+  semantics, costs nothing at query time.
+
+Performance on Belgium (4 feeds merged):
+
+| Query                        | Metric                  |
+|------------------------------|-------------------------|
+| Single `/transit` warm       | 35 ms p50               |
+| `/transit/bulk` 20 same-origin | 150 ms (7× vs serial) |
+| `/transit/bulk` 1000 varied  | 311 q/s sustained       |
+
+---
+
+## 6. Multi-region dispatch
+
+A single `butterfly-route serve` process can host multiple `*.butterfly`
+region containers (e.g. one per country). Each request runs against
+**exactly one** region — cross-region overlay is filed as #91 Phase 2,
+deferred.
+
+```mermaid
+flowchart TD
+    req[HTTP request<br/>coords + mode]
+    req --> count{n_regions == 1?}
+    count -->|yes| fast[single-region fast path<br/>regions[0] wins<br/>downstream K-best snap<br/>validates membership]
+    count -->|no| sweep[snap_winner per coord<br/>all regions]
+    sweep --> agree{all coords<br/>same region?}
+    agree -->|yes| pick[use that region's<br/>ServerState]
+    agree -->|no| reject[DispatchError::CrossRegion<br/>HTTP 501 with hint<br/>bump cross-region metric]
+    fast --> exec[execute query]
+    pick --> exec
+    reject --> err[JSON error]
+```
+
+The single-region fast path is the production case today and matters: the
+previous behaviour (per-coord serial single-best snap across all loaded
+regions) cost ~200 ms wall on Belgium at N=100 for `/table` — pure
+coordination overhead. The short-circuit hands the request straight to
+`regions[0]` and lets the downstream K-best snap inside the matrix handler
+do the actual membership check. Coords that don't lie on the road network
+get a `Inf` cell, which is the right answer.
+
+`overlay: Option<Arc<OverlayCluster>>` is wired in `RegionsState` and the
+`dispatch_p2p_with_overlay` entry point exists, but `OverlayCluster` is
+`None` in production until #91 Phase 2 (border nodes + border matrix +
+cross-region coordinator) lands.
+
+---
+
+## 7. Performance optimizations summary
+
+The numbers below are the cumulative effect; absolute throughputs at the
+top of `CLAUDE.md` already include all of them.
+
+| Optimization                                  | Mechanism                                                | Speedup / effect          |
+|-----------------------------------------------|----------------------------------------------------------|---------------------------|
+| Edge-based CCH (foundational)                 | Single graph for routes/matrices/isochrones              | exact turns, internal consistency |
+| Flat reverse adjacency (embedded weights)     | One contiguous array per `(node, weight)` pair           | eliminates indirection    |
+| 4-ary heap + version-stamped distances        | `wrapping_add(1)` per query; no per-call array zeroing   | 0% stale pops, O(1) init  |
+| O(1) prefix-sum bucket lookup                 | Per-node bucket offset table                             | -7% matrix time           |
+| Bound-aware join pruning                      | Skip joins whose lower bound exceeds best                | -41% joins, -10% time     |
+| SoA bucket layout                             | Separate arrays for `(target, dist)` vs interleaved      | -24% matrix time          |
+| Thread-local PHAST state                      | `RefCell<Option<PhastState>>`; reinit only on n_nodes change | O(1) per-query init   |
+| Thread-local bucket M2M state (parallel fwd+bwd) | Per-thread search arenas                              | 6× at 100×100, 5.5× at 1000×1000 |
+| Block-gated downward scan (C1)                | Skip DOWN blocks whose min rank ≥ best frontier dist     | 90 ms → 5 ms iso p50 (18×)|
+| L3-aware source tiling (#190)                 | Split source dimension to keep working set L3-resident   | 10k×10k 25.6 s → 18.3 s (28%) |
+| Software prefetch on matrix writes (#190)     | `_mm_prefetch` on next-row pointer, gated ≥ 8 MiB        | small gain at large N, no small-N regression |
+| Incremental avoid recustomization (#240)      | BFS seeded by polygon-flagged base edges                 | 37 s → 0.78 s MISS, 22 ms HIT |
+| Connectivity-aware role snap masks (#197)     | Separate `has_outbound`/`has_inbound` bitsets per mode   | eliminates matrix snap traps |
+| Parallel K-best snap (#232)                   | `rayon::par_iter` per-coord snap inside Flight matrix    | 50k×50k 10.94 → 9.61 min (1.14×) |
+| mmap-backed container loads (#155)            | Zero-copy weights/topology/geometry                      | RSS down, boot time down  |
+
+Snapshot of the current matrix curve on Belgium (in-process
+`butterfly-bench bucket-m2m --parallel`, 2026-05-22):
+
+| Size        | Time     | Throughput  | Notes                          |
+|-------------|----------|-------------|--------------------------------|
+| 10×10       | 18.6 ms  | 5 365 c/s   | rayon dispatch dominates       |
+| 50×50       | 11.5 ms  | 216 K c/s   | faster than OSRM (17 ms)       |
+| 1000×1000   | 270.8 ms | 3.7 M c/s   | 2.56× faster than OSRM         |
+| 5000×5000   | 4 815 ms | 5.2 M c/s   | 1.45× faster than OSRM         |
+| 10000×10000 | 18.1 s   | 5.5 M c/s   | 1.8× faster than OSRM (32.9 s) |
+
+Flight `matrix` end-to-end (clustered city coords, parallel snap):
+
+| Size        | Wall time | Throughput |
+|-------------|-----------|------------|
+| 1k × 1k     | 3.61 s    | 277 K c/s  |
+| 10k × 10k   | 35.5 s    | 2.8 M c/s  |
+| 25k × 25k   | 2.88 min  | 3.6 M c/s  |
+| 50k × 50k   | 9.61 min  | 4.3 M c/s  |
+
+The gap between in-process (18 s @ 10k²) and Flight (35.5 s) is Arrow IPC
+framing + handshake + per-coord parallel K-best snap — not the algorithm.
+
+---
+
+## 8. Memory layout
+
+The server's steady-state RSS on Belgium is ~24 GB per region, dominated by
+mmap-backed (page-cache-eligible) regions, not heap. The split:
+
+```mermaid
+flowchart TD
+    proc[butterfly-route serve<br/>process]
+
+    proc --> mmap[mmap regions<br/>zero-copy, page-cache eligible]
+    proc --> heap[heap-resident<br/>anon RSS]
+    proc --> tls[thread-local arenas]
+
+    mmap --> mw[CCH weights per mode<br/>cch.w.MODE.u32]
+    mmap --> mt[CCH topology per mode<br/>up/down CSRs + middles]
+    mmap --> mg[edge geometry #155<br/>flat polyline arena]
+    mmap --> mf[flat adjacencies<br/>up_adj_flat, down_rev_flat]
+    mmap --> ms[snap index #154<br/>shared points + per-mode masks]
+    mmap --> mn[nbg_node_to_osm ~11 MB]
+
+    heap --> hw[way_names HashMap<br/>~30-50 MB, 754K named roads]
+    heap --> ha[AvoidWeightCache LRU<br/>up to 8 × 100-200 MB]
+    heap --> hex[exclude_cache per mode<br/>RwLock HashMap]
+    heap --> ht[transit Timetable + TransferGraph<br/>~66K stops + 668K edges]
+    heap --> hi[transit stop_index<br/>R-tree]
+
+    tls --> tp[PHAST state<br/>generation-stamped dist/parent]
+    tls --> tb[bucket M2M state<br/>per-thread search arenas]
+    tls --> tc[CchQueryState<br/>versioned dist + parent]
+    tls --> tr[RaptorState<br/>generation-stamped scratch]
+```
+
+Why the split matters:
+
+- **mmap** for everything that's pure read-only at serve time. The OS page
+  cache handles cold-start warmup, and identical containers shared across
+  processes (e.g. dev + prod on the same host) share physical pages.
+  `#155` was a hard push to move polyline geometry off the heap so boot-time
+  anon RSS dropped.
+- **Heap** is reserved for things that *must* be mutable (the
+  `AvoidWeightCache` LRU, the per-mode `exclude_cache` `RwLock<HashMap>`)
+  or that have an irregular shape the binary formats don't support yet
+  (`way_names: HashMap<i64, String>` — 754K entries, ~30–50 MB).
+- **Thread-local** for query scratch space. Generation-stamped scratch
+  arrays (PHAST, RaptorState, CchQueryState) avoid both per-query allocation
+  *and* a per-query O(n_nodes) memset. Resetting state is a single
+  `wrapping_add(1)` on the generation counter; stale reads are detected by
+  comparing the stamp.
+
+The avoid cache is the only heap component that can grow unboundedly under
+adversarial input — it's capped at 8 entries by default
+(`BUTTERFLY_AVOID_CACHE_CAP`) so the worst case is ~1.6 GB resident.
+Eviction is LRU by a wrapping `u64` generation counter incremented on every
+access; the eviction scan is O(capacity) under a single write lock.
+
+---
+
+## Source-file landmarks
+
+| Topic                          | Path                                              |
+|--------------------------------|---------------------------------------------------|
+| Edge-based graph construction  | `route/src/ebg/`                                  |
+| CCH ordering (nested dissection) | `route/src/ordering.rs`                         |
+| CCH contraction                | `route/src/contraction.rs`                        |
+| CCH customization              | `route/src/customization.rs`                      |
+| P2P query                      | `route/src/server/query.rs`                       |
+| Bucket many-to-many            | `route/src/matrix/bucket_ch.rs`                   |
+| PHAST single-source            | `route/src/range/phast.rs`                        |
+| K-lane batched PHAST           | `route/src/range/batched_isochrone.rs`            |
+|                                | `route/src/matrix/batched_phast.rs`               |
+| Exclude / incremental recustomize | `route/src/server/exclude.rs`                  |
+| Avoid polygons + LRU cache     | `route/src/server/avoid.rs`                       |
+| Server state                   | `route/src/server/state.rs`                       |
+| Multi-region dispatch          | `route/src/server/regions.rs`                     |
+| RAPTOR engine                  | `route/src/transit/raptor.rs`                     |
+| ULTRA transfer build           | `route/src/transit/transfers.rs`                  |
+| GTFS loader                    | `route/src/transit/gtfs.rs`                       |
+| NeTEx-EPIP loader (STIB)       | `route/src/transit/netex_epip.rs`                 |
+| Flight gRPC server             | `route/src/server/flight.rs`                      |
+
+For benchmark methodology and historical numbers, see
+`bench/route/results/2026-05-22-post-snap-kbest/REPORT.md` and the
+"Benchmark Reference" section of `CLAUDE.md`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,337 @@
+# Deployment guide
+
+Production deployment of `butterfly-route` against a baked container or a step-tree directory. The runtime is a single Rust binary; everything ships in one Docker image. Multi-region serve is one process per region pack (see [Architecture](architecture.md)).
+
+If you have never run the server, start with the [Quickstart](quickstart.md). For request shapes see the [API reference](api.md). For boot or query failures see [Troubleshooting](troubleshooting.md).
+
+## Build the container
+
+The Dockerfile is multi-stage. Stage 1 is `rust:1.95-trixie` and builds the release binary (Cargo workspace, `protobuf-compiler` is needed for the `gtfs-rt` codegen). Stage 2 is `debian:trixie-slim` with `curl` and `ca-certificates` only; the binary copies in and the image runs as a non-root `butterfly` user.
+
+```dockerfile
+FROM rust:1.95-trixie AS builder
+# ... cargo build --release -p butterfly-route
+FROM debian:trixie-slim
+COPY --from=builder /build/target/release/butterfly-route /usr/local/bin/butterfly-route
+USER butterfly
+VOLUME /data
+EXPOSE 8080 8081
+ENV RUST_LOG=info,tower_http=debug
+HEALTHCHECK --interval=30s --timeout=5s --start-period=25s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+ENTRYPOINT ["butterfly-route"]
+CMD ["serve", "--data-dir", "/data", "--port", "8080", "--log-format", "json"]
+```
+
+Build it:
+
+```bash
+docker build -t butterfly-route .
+```
+
+The image is roughly 26 GB once a baked Belgium container is mounted at runtime; the image itself is small (the binary is ~80 MB) and the size lives in the data volume.
+
+## Run conventions
+
+The container reads everything from `/data`. Mount your baked region(s) there:
+
+```bash
+docker run -d --name butterfly \
+  -p 3001:8080 \
+  -p 3002:8081 \
+  -v "${PWD}/data/belgium:/data" \
+  --memory=32g \
+  butterfly-route
+```
+
+- **`-p 3001:8080`** — REST/JSON (Axum). Default container port is 8080.
+- **`-p 3002:8081`** — Arrow Flight gRPC (tonic). Default is 8081 (REST port + 1).
+- **`-v ./data:/data`** — required. The container path is fixed by the Dockerfile `CMD`; if you override `--data-dir`, mount accordingly.
+
+**Recommended resources:**
+
+- **32 GB RAM.** Belgium steady-state RSS is ~24 GB with 4 modes (~5.13M EBG nodes per mode) plus the 754K-entry road-name index, the merged transit timetable, the ULTRA transfer graph, and the per-region `AvoidWeightCache` (default 8 entries × ~100-200 MB = up to 1.6 GB ceiling). Headroom matters: avoid-polygon and exclude recustomizations briefly allocate a second weight set. Below 28 GB you will OOM on first avoid query.
+- **8+ vCPUs.** Matrix and isochrone parallelism saturate near 8 cores (memory-bandwidth limited beyond that). REST concurrency is capped at 32 in-flight requests and 4 for `/isochrone/bulk`; gRPC Flight is unbounded but bound by the same backends.
+- **Fast local disk for first-load mmap.** All step artefacts are mmap'd; pages fault in during boot. On NVMe the difference between cold and warm boot is ~10 s.
+
+**Boot time expectations:**
+
+| Configuration | Time to first `/health` 200 |
+|---|---|
+| Belgium baked container, road-only (`--modes car`) | ~10 s |
+| Belgium baked container, all 4 modes, no transit | ~30 s |
+| Belgium baked container, all 4 modes + transit (4 feeds, ULTRA rebuild) | ~3 min |
+| Belgium baked container + transit + `transfers.bin` cache hit | ~45 s |
+
+The transit transfer graph (~66 k stops, ~668 k edges) is rebuilt at boot if the cache provenance hash mismatches the foot CCH or feed checksums. Bake the cache once and the rebuild only re-fires when feeds or the CCH change.
+
+## Configuration
+
+### Environment variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `BUTTERFLY_AVOID_CACHE_CAP` | `8` | LRU capacity for the per-region recustomized-weight cache. Each entry holds time + distance weights + flat adjacencies, ~100-200 MB on Belgium. The default caps memory at ~1.6 GB per region. Drop to `2` or `4` on RAM-constrained hosts; raise on hosts serving heavy `avoid_polygons` traffic with a small working set of polygon shapes. |
+| `BUTTERFLY_RSS_CHECKPOINTS` | unset | When set to `1`, the server emits `RSS_CHECKPOINT phase=... total_kb=N anon_kb=M file_kb=K` lines at every boot phase, parsed from `/proc/self/smaps_rollup`. Equivalent to passing `--rss-checkpoints`. Use for capacity-planning diagnostics. |
+| `RUST_LOG` | `info,tower_http=debug` (in the Dockerfile) | Standard `tracing-subscriber` filter. To debug avoid/exclude customization passes: `RUST_LOG=info,butterfly_route::server::exclude=debug`. To trace HTTP request lifecycle: `RUST_LOG=info,tower_http=trace`. |
+
+### CLI flags (passed through `docker run` after the image name, or via `CMD` override)
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--data-dir <path>` | none, mutually exclusive with `--data` | Directory with either a `step{1..8}/` tree (legacy) or one-or-more `*.butterfly` containers (multi-region). Multi-region is auto-detected from the presence of any `*.butterfly` file. |
+| `--data <path>` | none, mutually exclusive with `--data-dir` | Single `*.butterfly` container. Loaded via mmap. |
+| `--port <N>` | 8080 (or next free) | REST listener. |
+| `--grpc-port <N>` | `--port + 1` | gRPC Flight listener. |
+| `--transport rest\|grpc\|both` | `both` | Disable one transport entirely; useful when running REST and gRPC on separate replica pools. |
+| `--modes car,bike,foot,...` | all discovered | Limits which per-mode bundles are loaded. Each mode skipped saves ~5-6 GB RSS on Belgium. |
+| `--regions BE,LU,...` | all discovered | Multi-region container directory only. Ignored with `--data`. |
+| `--log-format text\|json` | `text`; the Dockerfile `CMD` sets `json` | Structured-log toggle. JSON in production, text for local debugging. |
+| `--rss-checkpoints` | off | Same as `BUTTERFLY_RSS_CHECKPOINTS=1`. |
+| `--eager-verify` | off | #160 lazy-CRC opt-out: walk every section's CRC at boot. Adds ~10-30 s to first-byte. Mutually exclusive with `--warmup-on-boot`. |
+| `--warmup-on-boot` | off | Background-verify every section after `/health` first reports ready. Same total coverage as `--eager-verify`, faster to first byte. |
+| `--overlay <path>` | none | #91 Phase 2: cross-region overlay container for cross-region P2P. |
+
+### Data layout
+
+Two supported layouts under the mounted `/data` volume:
+
+**Single baked container (preferred for production):**
+
+```
+/data/
+└── belgium.butterfly        # one-file mmap, embedded section manifest
+```
+
+Run with `--data /data/belgium.butterfly`. Fastest boot, single-file deploy artefact, CRC-verified per section (lazy by default, see #160 flags above).
+
+**Step tree (legacy, useful for development):**
+
+```
+/data/
+├── step1/   nodes.sa, nodes.si, ways.raw, relations.raw, node_signals.bin
+├── step2/   way_attrs.<mode>.bin, turn_rules.<mode>.bin
+├── step3/   nbg.csr, nbg.geo, nbg.node_map
+├── step4/   ebg.nodes, ebg.csr, ebg.turn_table
+├── step5/   w.<mode>.u32, t.<mode>.u32, mask.<mode>.bitset, filtered.<mode>.ebg
+├── step6/   order.<mode>.ebg
+├── step7/   cch.<mode>.topo
+└── step8/   cch.w.<mode>.u32, cch.d.<mode>.u32, cch.w.<mode>_<variant>.u32
+```
+
+Run with `--data-dir /data`.
+
+**Multi-region:**
+
+```
+/data/
+├── belgium.butterfly
+├── luxembourg.butterfly
+└── france.butterfly
+```
+
+Run with `--data-dir /data`. Auto-detected from the `*.butterfly` extension. Use `--regions BE,LU` to load a subset.
+
+A `transit/` subdirectory (next to the step tree or container files) triggers transit bootstrap on the primary region. See the transit section in [CLAUDE.md](../CLAUDE.md).
+
+## Health and metrics
+
+### `/health`
+
+JSON, no auth, served by the same Axum router as the API. Shape:
+
+```json
+{
+  "status": "ok",
+  "version": "0.x.y",
+  "uptime_s": 1234,
+  "modes": ["bike", "car", "foot", "truck"],
+  "data_dir": "/data",
+  "nodes_count": 5132876,
+  "edges_count": 12876543,
+  "named_roads_count": 754321,
+  "regions_count": 1,
+  "regions": ["BE"],
+  "total_nodes_count": 5132876,
+  "total_edges_count": 12876543,
+  "verify_status": "verified",
+  "verify": {
+    "n_sections": 87,
+    "n_verified": 87,
+    "n_unverified": 0,
+    "n_verifying": 0,
+    "n_failed": 0,
+    "failed": []
+  },
+  "avoid_cache": [
+    {"region": "BE", "hits": 142, "misses": 18, "hit_rate": 0.8875, "size": 8, "capacity": 8}
+  ]
+}
+```
+
+`verify_status` transitions through `ok` (no manifest, legacy step tree), `pending` (sections still verifying in the background), `verified` (all sections clean), `degraded` (one or more sections failed CRC — server keeps running but the failed sections will panic on access).
+
+**Kubernetes probes:**
+
+```yaml
+livenessProbe:
+  httpGet: { path: /health, port: 8080 }
+  initialDelaySeconds: 30        # bump to 200 if transit is loaded
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  httpGet: { path: /health, port: 8080 }
+  initialDelaySeconds: 30        # bump to 200 if transit is loaded
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 2
+```
+
+The readiness probe should only mark ready once the listener is up; `--warmup-on-boot` lets you serve traffic while CRC verification runs in the background. Drive `verify_status=degraded` to an alert (see below) rather than failing readiness on it.
+
+### `/metrics`
+
+Prometheus exposition format, served by `axum_prometheus::PrometheusMetricLayer`. The router-level HTTP metrics (`axum_http_requests_*`) are provided by that crate. butterfly-route specifically adds:
+
+| Metric | Type | Labels | Source |
+|---|---|---|---|
+| `butterfly_route_avoid_cache_hits` | gauge | `region` | `server::metrics::record_avoid_cache_stats` |
+| `butterfly_route_avoid_cache_misses` | gauge | `region` | same |
+| `butterfly_route_avoid_cache_size` | gauge | `region` | same |
+| `butterfly_route_avoid_cache_capacity` | gauge | `region` | same |
+| `butterfly_route_sections_verified_total` | counter | none | `record_section_verified` |
+| `butterfly_route_sections_verify_pending` | gauge | none | `register_pending` / saturating decrement |
+| `butterfly_route_section_verify_duration_seconds` | histogram | `section` | `record_section_verified` |
+| `butterfly_route_section_verify_failed_total` | counter | `section` | `record_section_failed` |
+| `butterfly_route_region_nodes_total` | gauge | `region` | `region_metrics::register_region_size` at boot |
+| `butterfly_route_region_edges_total` | gauge | `region` | same |
+| `butterfly_route_query_total` | counter | `region`, `endpoint` | `region_metrics` (per-request) |
+| `butterfly_route_query_duration_seconds` | histogram | `region`, `endpoint` | same |
+| `butterfly_route_query_cross_region_total` | counter | `src`, `dst` | cross-region P2P dispatch |
+
+`avoid_cache_*` gauges are refreshed on every `/health` scrape (the handler mirrors the live atomic counters into the Prometheus registry). Scrape `/metrics` and `/health` together to keep them coherent.
+
+### Prometheus scrape
+
+```yaml
+scrape_configs:
+  - job_name: butterfly-route
+    scrape_interval: 15s
+    scrape_timeout: 5s
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - butterfly-route-0.internal:3001
+          - butterfly-route-1.internal:3001
+```
+
+15 s is the sweet spot: `axum_prometheus` histograms are cheap, and the avoid-cache snapshot only refreshes when `/health` is hit, so don't scrape faster than `/health` is polled by your load balancer or readiness probe.
+
+### Alerting rules
+
+```yaml
+groups:
+  - name: butterfly-route
+    rules:
+      - alert: ButterflyAvoidCacheThrashing
+        # Hit rate < 20% sustained 10m with >100 queries.
+        expr: |
+          (
+            sum by (region) (rate(butterfly_route_avoid_cache_hits[5m]))
+            /
+            clamp_min(sum by (region) (
+              rate(butterfly_route_avoid_cache_hits[5m])
+              + rate(butterfly_route_avoid_cache_misses[5m])
+            ), 1)
+          ) < 0.2
+          and on (region) sum by (region) (
+            rate(butterfly_route_avoid_cache_hits[5m])
+            + rate(butterfly_route_avoid_cache_misses[5m])
+          ) > 100 / 60
+        for: 10m
+        annotations:
+          summary: "Avoid-cache thrashing on {{ $labels.region }} — bump BUTTERFLY_AVOID_CACHE_CAP."
+
+      - alert: ButterflyRouteSlow
+        expr: |
+          histogram_quantile(0.99,
+            sum by (le, endpoint) (
+              rate(butterfly_route_query_duration_seconds_bucket{endpoint="/route"}[5m])
+            )
+          ) > 0.5
+        for: 5m
+        annotations:
+          summary: "/route p99 > 500 ms."
+
+      - alert: ButterflyVerifyDegraded
+        # Probe-driven: scrape /health, expose verify_status via blackbox or a sidecar.
+        # Direct signal: any section_verify_failed_total increases.
+        expr: increase(butterfly_route_section_verify_failed_total[15m]) > 0
+        for: 0m
+        annotations:
+          summary: "Section CRC verification failed — container is corrupt or truncated."
+```
+
+## Graceful shutdown
+
+The server installs SIGINT and SIGTERM handlers (see `server::shutdown_signal`). On signal:
+
+1. Both REST (Axum `with_graceful_shutdown`) and gRPC (tonic `serve_with_shutdown`) stop accepting new connections.
+2. In-flight requests run to completion, bounded by the per-route timeout (120 s for normal endpoints, 600 s for `/isochrone/bulk`).
+3. `tracing::info!("server shut down gracefully")` is emitted and the process exits 0.
+
+There is no explicit drain timeout in code beyond the route timeouts. For Kubernetes:
+
+```yaml
+terminationGracePeriodSeconds: 660   # 600s stream timeout + 60s slack
+```
+
+If you don't run `/isochrone/bulk`, drop to 180 s. Docker's default `docker stop --time` is 10 s — set it explicitly: `docker stop --time 180 butterfly`.
+
+## Deployment topology
+
+```mermaid
+flowchart LR
+    subgraph LB[Load balancer]
+        IN[Ingress / L7]
+    end
+    subgraph BE[Region BE replicas]
+        BE1[butterfly-route #1<br/>--data /data/belgium.butterfly]
+        BE2[butterfly-route #2<br/>--data /data/belgium.butterfly]
+        BE3[butterfly-route #3<br/>--data /data/belgium.butterfly]
+    end
+    subgraph LU[Region LU replicas]
+        LU1[butterfly-route #1<br/>--data /data/luxembourg.butterfly]
+        LU2[butterfly-route #2<br/>--data /data/luxembourg.butterfly]
+    end
+    subgraph DATA[Shared read-only volume]
+        VOL[belgium.butterfly<br/>luxembourg.butterfly<br/>transit/]
+    end
+    subgraph OBS[Observability]
+        PROM[Prometheus]
+        ALERT[Alertmanager]
+        GRAF[Grafana]
+    end
+
+    IN -->|/route, /table, /isochrone| BE1 & BE2 & BE3
+    IN -->|host header or path| LU1 & LU2
+    VOL -.mmap.-> BE1 & BE2 & BE3 & LU1 & LU2
+    BE1 -- /metrics --> PROM
+    BE2 -- /metrics --> PROM
+    BE3 -- /metrics --> PROM
+    LU1 -- /metrics --> PROM
+    LU2 -- /metrics --> PROM
+    PROM --> ALERT
+    PROM --> GRAF
+```
+
+The load balancer routes by region (host header, path prefix, or client logic). The data volume is read-only and shared between replicas of the same region; each replica mmaps the same file independently.
+
+## Scaling notes
+
+- **One process per region pack.** A single binary can load multiple regions in one process (`--data-dir` over a directory of `*.butterfly` files), and that is the current scale-out shape for cross-region serve. Going further than #91 multi-region containers — sharding a region across processes for horizontal scale-out — is not yet implemented. If you need it, read `route/src/server/regions.rs` and `route/src/server/cross_region.rs` first.
+- **Cache locality is per-process.** Every replica has its own `AvoidWeightCache`. Multi-replica deployments amortize recustomization cost independently per replica — a polygon that hits the cache on replica A still costs ~30 s on replica B the first time. For predictable latency, pin clients (consistent hash on polygon hash) or accept the cold-cache outliers.
+- **gRPC Flight is single-region in #91 Phase 1.** With multiple regions loaded, the Flight server only serves the primary region (the lexicographically first one or whichever was discovered first). REST handles all regions. Cross-region Flight is tracked for a future PR.
+- **Memory scales with modes, not query volume.** Doubling QPS does not double RSS; adding a mode does (~5-6 GB per mode on Belgium). Trim with `--modes`.
+- **HTTP concurrency is bounded.** 32 in-flight `/route`/`/table`/etc., 4 in-flight `/isochrone/bulk`. Past those limits clients see a queue, not a 503; size your timeouts accordingly.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart
+
+Get a Belgium routing server answering `/route` requests in 60 seconds. Docker, one country, one curl.
+
+## 1. Download Belgium data
+
+```bash
+mkdir -p data/belgium && cd data/belgium
+cargo install butterfly-dl   # or grab a release binary from GitHub
+butterfly-dl europe/belgium belgium.osm.pbf
+```
+
+This pulls ~654 MB from Geofabrik. A `.sha256` sidecar is written next to the PBF; subsequent runs short-circuit if the hash already matches.
+
+## 2. Build the Docker image
+
+```bash
+cd /path/to/butterfly-osm
+docker build -t butterfly-route .
+```
+
+No pre-built images are published yet — build locally. The multi-stage build produces a ~26 GB image (the build stage is fat; only the slim runtime layer is what ships if you squash). Build takes 5-10 min cold, seconds warm.
+
+## 3. Run the server
+
+You still need to run steps 1-8 of the pipeline against `belgium.osm.pbf` to produce the routing artifacts under `data/belgium/`. See `architecture.md` for the pipeline. Once `data/belgium/` contains the step outputs:
+
+```bash
+docker run -d --name butterfly \
+  -p 3001:8080 \
+  -v "${PWD}/data/belgium:/data" \
+  butterfly-route
+```
+
+Boot takes 30-40 s for the road graph alone (~5M EBG nodes + 754k named roads + spatial index). With the transit subsystem enabled (4 Belgian feeds + ULTRA transfer graph), expect ~3 min. Watch `docker logs -f butterfly` until you see `listening on 0.0.0.0:8080`.
+
+## 4. First /route call
+
+Brussels (Grand-Place) to Antwerp (Centraal), car profile:
+
+```bash
+curl "http://localhost:3001/route?src_lon=4.3517&src_lat=50.8503&dst_lon=4.4025&dst_lat=51.2194&mode=car"
+```
+
+Sample response (polyline truncated):
+
+```json
+{
+  "duration_s": 2548.3,
+  "distance_m": 47812.6,
+  "geometry": {
+    "polyline": "_p~iF~ps|U_ulLnnqC_mqNvxq`@..."
+  }
+}
+```
+
+`duration_s` is travel time in seconds; `distance_m` is meters. Default geometry is encoded polyline6. Pass `&geometry=geojson` for a coordinates array, `&steps=true` for turn-by-turn with road names.
+
+## 5. Health check
+
+```bash
+curl http://localhost:3001/health
+```
+
+Returns uptime, per-region node/edge counts, mode list, CRC verification status, and per-region `avoid_cache` stats (hits/misses/size/capacity, see #242). Use it as your Docker `HEALTHCHECK` target — the Dockerfile already wires it.
+
+## Next steps
+
+- [API reference](api.md) — all REST endpoints, query parameters, response shapes
+- [Deployment](deployment.md) — multi-region serving, Flight gRPC, Prometheus, graceful shutdown
+- [Architecture](architecture.md) — the 8-step pipeline, edge-based CCH, PHAST, RAPTOR transit
+- [Troubleshooting](troubleshooting.md) — boot failures, snap errors, CRC mismatches
+- Swagger UI: `http://localhost:3001/swagger-ui/`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,336 @@
+# Troubleshooting
+
+FAQ-style. Each entry: what you see, why it happens, how to fix it.
+
+If you are new to the server, read [Quickstart](quickstart.md) first. For endpoint shapes see the [API reference](api.md), for boot and ops see [Deployment](deployment.md), for the algorithms see [Architecture](architecture.md).
+
+---
+
+## Symptom: `/route` returns 400 `Could not snap source to road network`
+
+The exact strings — `Could not snap source to road network`, `Could not snap destination to road network`, and (multi-region) `No road found within snap distance for source (lon, lat) mode=X` — all come out of the same root cause.
+
+**Diagnosis**
+
+- Coordinate is geometrically far from any sampled road vertex. The packed snap index walks an 8-cell ring around the query point with a hard `MAX_SNAP_DISTANCE_M = 5000.0` m cap (`route/src/server/snap_index.rs`). Points in water, dense forest, or on a building rooftop that is more than 5 km from any sampled vertex will not snap.
+- Wrong region pack loaded. In multi-region mode every loaded region tries its snap; if none succeed you get `No road found within snap distance ...` from `regions.rs` — `DispatchError::NoRegion`. This usually means the container for that country was not mounted.
+- Role-aware snap rejected the candidate for the requested role (#197). `/route` source needs an EBG node with at least one mode-valid outbound arc (`SnapRole::Src` → `has_outbound` bitset). Destination needs inbound. A point near a one-way slip road can be rejected as a source but accepted as a destination, or vice versa.
+- Mode mask filters it out: a foot-only path is invisible to `mode=car`.
+
+**Fix**
+
+1. Hit `/health` and confirm the region you expect is loaded (`regions` list, `nodes_count`, `modes`). Also hit `/regions` for the per-region container path.
+2. Try `/nearest?lon=...&lat=...&mode=car&number=5&radius=5000`. If `/nearest` returns nothing inside 5 km, the point is genuinely off-graph — the snap index will not find it no matter what you do.
+3. Move the coordinate to the actual road centreline. Coordinates from address geocoders often land on building centroids; offset by ~20 m towards the street.
+4. If `/nearest` succeeds but `/route` 400s, the snap candidate was rejected for the role. Try the same coordinate as the *other* endpoint (swap src and dst) — if that works, you are hitting role asymmetry. Use a coordinate closer to a two-way segment.
+
+---
+
+## Symptom: `/table` returns `null` for some pairs
+
+The matrix endpoints return `null` (or `u32::MAX` in Flight) when no path exists between a pair.
+
+**Diagnosis**
+
+- Pre-#197 was 9% null rate on random Belgium-bbox coordinates: most of those were snap-traps in micro-SCCs (a dead-end driveway sampled into the index and the routing core unreachable from there). Post-#197 the K-best snap with connectivity-aware role masks dropped this to under 0.1%.
+- True graph disconnect. Truck mode with truck-restricted base edges, or any mode whose mask carves the graph into multiple components, will legitimately return `null` between components — there is no route.
+- Combo fallback gave up. `/route` and the matrix endpoints try up to `SNAP_K=64` source candidates × 64 destination candidates capped at 400 combos. If all 400 fail, the pair is null.
+
+**Fix**
+
+1. Sanity check with `mode=car` on the same pair. Car has the densest connectivity in the EBG; if car routes and truck does not, the truck base-edge mask is the cause. This is expected and correct.
+2. Move the offending coordinate ~50 m towards a major road. Micro-SCC traps are a property of the snap *index*, not the road network.
+3. Verify both coords pass `/nearest` independently. A null `/nearest` is a hard "off-graph" signal — no amount of K-best will rescue it.
+
+---
+
+## Symptom: First `/route?avoid_polygons=...` is slow (~1 second)
+
+**Diagnosis**
+
+This is expected. Avoid is implemented by sparse CCH recustomization (`route/src/server/avoid.rs`):
+
+1. R-tree spatial query finds EBG edges whose midpoints fall inside the polygon.
+2. Bottom-up + sparse triangle relaxation rebuilds the affected shortcut weights.
+3. The recustomized weight set is cached keyed by `(mode, polygon_hash, exclude_mask)`.
+
+Cache MISS on `/route` is ~780 ms for a tiny polygon (only the recustomization fixed cost) and ~1.2 s for a polygon covering a major motorway corridor like E19. Cache HIT is ~22 ms on `/table` and ~11 ms on `/route` — the recustomized weights are already in the LRU and reused across `/route`, `/table`, `/isochrone`, `/trip`.
+
+**Fix**
+
+- Don't fight it: subsequent calls with byte-identical polygon JSON hit the cache. JSON is canonicalised before hashing (vertex quantisation to 6 decimals, lex-minimum cyclic rotation per ring, polygon sort) so equivalent polygons hash to the same key — see `hash_polygon_json` in `avoid.rs`.
+- Resize the cache via `BUTTERFLY_AVOID_CACHE_CAP` env var. Default is 8 entries, each ~100-200 MB on Belgium, so default ceiling is ~1.6 GB.
+- `/health` surfaces `avoid_cache.hits`, `misses`, `hit_rate`, `size`, `capacity` per region. Watch hit_rate during canary; below 0.5 means callers are sending non-canonical or genuinely varied polygons.
+
+---
+
+## Symptom: `/route?avoid_polygons=...` takes 30+ seconds
+
+**Diagnosis**
+
+You are running pre-#240 code. The original avoid implementation did a full Belgium-wide bottom-up + parallel triangle relaxation on every request (~28 s on Belgium even for a tiny polygon — recorded in CLAUDE.md memory under "P-Sprint Architecture Notes"). The 16-30 s version reflects the original 28 s relaxation cost plus the cache populate.
+
+The cache + sparse-relaxation work (#240, #242, #243) brought MISS down to ~780 ms — ~1.2 s. If you still see 30 s, you do not have those changes.
+
+**Fix**
+
+1. `git log --oneline route/src/server/avoid.rs` — confirm #240+ commits are present.
+2. Rebuild the Docker image. Sparse relaxation is a code-path change, not a runtime flag.
+3. If you are on current code and *still* seeing 30 s, the polygon hash table is thrashing — confirm `/health` shows non-zero `avoid_cache.size` after one call. Zero size means the insert is being immediately evicted (capacity 1 race), which is impossible with `DEFAULT_AVOID_CACHE_CAP=8` unless `BUTTERFLY_AVOID_CACHE_CAP=1` was set.
+
+There is no design path where a small polygon takes 30 s on current code. If you reproduce it, it is a bug.
+
+---
+
+## Symptom: `/table/stream` takes minutes for 50k × 50k
+
+**Diagnosis**
+
+That's the design. On Belgium the May-22 bench measured 9.61 min wall for a 50 000 × 50 000 matrix on `/table/stream`. This is parity with the pre-Flight `/table/stream` numbers documented in CLAUDE.md ("Arrow Streaming - Large Scale"). The bench result is 4.4M distances/sec sustained at this scale.
+
+A 50k × 50k matrix is 2.5 billion cells. At the documented throughput, anything below ~10 minutes would imply a regression somewhere else.
+
+**Fix**
+
+- Use the gRPC Flight `matrix` action instead of REST `/table/stream` if you are building bulk pipelines. Same algorithm, lower transport overhead (no JSON envelope, no HTTP/1 chunking). See [API reference](api.md) for the ticket shape.
+- If wall time is materially worse than 10 min for 50k × 50k Belgium, profile RSS — eviction-thrashing during the streaming write is the usual culprit. The matrix algorithm itself is L3-tiled (#190); transport buffering is the only knob left.
+
+---
+
+## Symptom: 400 response with `route spans regions X → Y; cross-region overlay not yet implemented (#91 Phase 2)`
+
+**Diagnosis**
+
+The two endpoints snapped into *different* loaded regions, and the cross-region overlay is not yet built for this deployment. The HTTP status is actually **501 Not Implemented**, not 400 — `DispatchError::CrossRegion::into_response_parts` in `regions.rs`.
+
+**Fix**
+
+- If you only need one country, load only that container. The dispatcher cannot return `CrossRegion` from a single-region state.
+- If you need multi-country routes, you need the cross-region overlay (`overlay.rs`). It is an opt-in feature; the loader sets `RegionsState::overlay = Some(...)`. Without it, every cross-region pair returns 501.
+- Hit `/regions` first to confirm which region each coordinate snaps into. The dispatcher only ever returns 501 between pairs of region ids that appear in `/regions` — useful for narrowing down which side is mis-located.
+
+---
+
+## Symptom: 400 `No road found within snap distance for source (lon, lat) mode=X`
+
+**Diagnosis**
+
+The dispatcher tried every loaded region's snap for the requested mode and none returned a candidate. This is the multi-region equivalent of `Could not snap source to road network`, with the loaded-region list folded in.
+
+**Fix**
+
+- Hit `/regions` and check that the bbox you care about is actually covered. If you expected `LU` (Luxembourg) to be loaded and it isn't in the list, the container failed to load — check the boot logs.
+- Verify the mode is loaded in *some* region: `/health` shows `modes` for the primary region, `/regions` shows `modes` per region. If your mode is missing everywhere you get `InvalidMode` with the available list — that's a different 400.
+- Multi-region: add the missing container under your `--data-dir`. The discovery pass picks up any `*.butterfly` file in the directory. See [Deployment](deployment.md).
+
+---
+
+## Symptom: 400 `Invalid mode 'X'. Available across loaded regions: ...`
+
+**Diagnosis**
+
+The mode string is not the name of any loaded mode. Modes are discovered from the container's per-mode files; the lookup is case-insensitive (`s_lower` in `parse_mode` and `resolve_mode`).
+
+**Fix**
+
+- Use one of the modes in the error message. Standard packs ship `car`, `bike`, `foot`. Truck and traffic-variant modes (`car_rush_hour`, `car_offpeak`, `car_freeflow`) are present only when those weights were built into the container.
+- The mode list is dynamic. Adding `truck` requires the build pipeline to have produced `way_attrs.truck.bin` and the rest of the per-mode files. See [Architecture](architecture.md) on the declarative model system.
+
+---
+
+## Symptom: `/transit` returns 404 `no transit journey found`
+
+**Diagnosis**
+
+Five candidate causes, in rough order of frequency:
+
+1. Origin or destination is more than the per-mode access radius from any stop. Defaults (`default_access_params` in `transit_handler.rs`): foot 2 km / 20 stops, bike 8 km / 60 stops, car 30 km / 500 stops. Caller can override via `max_access_m`, `max_egress_m`, `max_access_stops`; legacy `max_walk_m` still works for foot. The error message identifies which side: `no transit stops within max_access_m (... m, mode=foot) of origin`.
+2. Origin or destination snapped to the road network fine, but RAPTOR found no journey before the access/egress walk caps. Error: `no access stops reachable within walking time` or `no egress stops reachable within walking time`. Usually means the depart time is outside service hours.
+3. Active calendar is empty for the request date. NeTEx-EPIP publications (STIB) can be weeks stale; the loader remaps today to the same weekday in the latest published period (`netex_epip::compute_active_day_types`) so weekday/weekend semantics survive, but if a feed has *no* active period at all, that operator's services vanish. GTFS is filtered by `ServiceFilter` and behaves the same way.
+4. Feed not loaded. Check the boot log for `Loaded feed ...` lines. If `transit/transfers.bin` is missing, the server rebuilds the transfer graph (3 min cold on Belgium). If it exists but is stale (CCH fingerprint mismatch, feed hash mismatch, algo version drift) it is rejected and rebuilt.
+5. Foot CCH not loaded. RAPTOR access and egress legs require the foot mode for transfers. If the container has no foot weights, the transit subsystem refuses to load.
+
+**Fix**
+
+1. Loosen `max_access_m` / `max_egress_m`. Foot to 5000 is reasonable for first-mile-last-mile experiments.
+2. Try a depart time mid-morning on a weekday (`depart=08:00:00`) — eliminates calendar weirdness.
+3. `ls data/<region>/transit/` should show a `gtfs/` directory with the feeds, optionally `netex/`, and `transfers.bin` after first boot.
+4. If `transfers.bin` is constantly rebuilding, check that the CCH topology and foot weights are not changing across boots. The cache provenance hash includes them.
+
+---
+
+## Symptom: 503 `transit not loaded` or `timetable has zero stops`
+
+**Diagnosis**
+
+`/transit` and `/transit/bulk` return 503 when the server booted without transit (no `transit/` directory under `--data-dir`, or every feed failed to load). `timetable has zero stops` is a stronger variant — the feeds parsed but produced an empty timetable, which is almost always a calendar / service-id mismatch.
+
+**Fix**
+
+- Inspect the boot log. Each feed loader prints success / failure with the feed id.
+- For NeTEx-EPIP, the most common failure is the streaming parser hitting an unexpected element. The file must be raw XML, not a zip wrapper.
+- Empty timetable on a non-empty feed usually means `ServiceFilter` rejected every trip. Confirm the system clock — if the container thinks it's 2099, no service date matches.
+
+---
+
+## Symptom: Out of memory at boot
+
+**Diagnosis**
+
+Steady-state RSS on Belgium is ~24 GB across the road graph (5 M EBG nodes, named-roads HashMap, spatial index) and the transit subsystem (timetable + ULTRA transfer graph + R-tree stop index). If the host has less than ~32 GB total, there is no headroom for the avoid cache, request buffers, and OS page cache.
+
+Boot peaks above steady-state: container open + per-section verify + ULTRA build all hold transient buffers.
+
+**Fix**
+
+- Drop `BUTTERFLY_AVOID_CACHE_CAP=4` to halve the avoid cache ceiling (8 → 4 entries, ~800 MB → ~400 MB).
+- Drop transit feeds you don't need. The `transit/transfers.bin` build is the largest transient allocation; fewer feeds means a smaller graph.
+- Skip transit entirely by removing the `data/<region>/transit/` directory. Boot drops from ~3 min to ~30 s and RSS drops by several gigabytes.
+- For the bench tool only, `--src-tile-size` shrinks the matrix tiles; this does not apply to the server.
+
+---
+
+## Symptom: gRPC Flight client gets `"Ticket format: action:profile:params_json"`
+
+**Diagnosis**
+
+The Flight ticket parser in `flight.rs::parse_ticket` requires exactly two colons separating three fields:
+
+```
+action:profile:params_json
+```
+
+Common failure modes:
+
+- Only one colon: `matrix:{"sources":...}` — missing the profile field. The parser returns `Status::invalid_argument("Ticket format: action:profile:params_json")` at the *first* colon search if there is no colon at all, or at the *second* colon search if there is exactly one.
+- Three or more colons unescaped *outside* the JSON payload: rare in practice because the JSON body is matched as everything after the second colon, so colons inside JSON are fine.
+- Bytes are not UTF-8: returns `Status::invalid_argument("Ticket must be UTF-8")`.
+
+**Fix**
+
+- Format the ticket as `matrix:car:{...}` — three fields, two colons, JSON last.
+- Verify with a known-good action: `route_batch:car:{"queries":[...]}`. If that works, your `matrix` request is malformed; if it also fails, your colon count is wrong.
+
+---
+
+## Symptom: gRPC Flight client errors with `Connection refused`
+
+**Diagnosis**
+
+You are pointing the Flight client at the REST port. REST is **3001** (Axum), Flight is **3002** (tonic). They are separate listeners on separate ports — there is no transport mixing by design.
+
+**Fix**
+
+- Flight URI: `grpc://localhost:3002`. Not `grpc://localhost:3001`, not `http://localhost:3002`.
+- `Server never sent a data message` from your gRPC client usually means the host is wrong (typo, missing port). Verify with `grpcurl -plaintext localhost:3002 list` — should list `arrow.flight.protocol.FlightService`.
+
+---
+
+## Symptom: gRPC Flight ticket returns `Unknown profile 'X'`
+
+**Diagnosis**
+
+`resolve_mode` in `flight.rs` does a case-insensitive lookup against `state.mode_lookup`. Same dynamic mode discovery as REST. The error message includes the sorted list of available modes.
+
+**Fix**
+
+- Use one of the modes from the error message.
+- Profile is the second field of the ticket, not a header or query param. `matrix::{...}` (empty profile) will fail mode lookup with empty available list mismatch.
+
+---
+
+## Symptom: `/health` shows `verify_status=degraded`
+
+**Diagnosis**
+
+One or more per-section CRC verifications failed during lazy verification (`health_handler.rs`, #160). The `verify.failed` array lists the offending sections with `region`, `name`, `reason`. Boot-time eager-CRC failures cause the region to refuse to load entirely — `degraded` means a section was verified *after* the region was up, and that section's CRC did not match the manifest.
+
+**Fix**
+
+- Identify the failing section from the JSON. Reverify the source `.butterfly` container with `sha256sum` against your build records.
+- The container is corrupted. Re-pack it from the step1-step8 directory tree, or re-fetch from your build artifact store.
+- Hot-swap is not supported — restart the server with the rebuilt container.
+- The Prometheus metric `butterfly_route_section_verify_failed_total{section=...}` counts these incidents. Alert on it.
+
+---
+
+## Symptom: `/health` shows `verify_status=pending` and never moves to `verified`
+
+**Diagnosis**
+
+Lazy verification only verifies sections as they are touched on the serve path. A section that no request has touched stays `Unverified`. Cold-boot `/health` will show `pending` until enough traffic has exercised every section.
+
+**Fix**
+
+- Run a small synthetic load that exercises every mode and every endpoint family (`/route`, `/table`, `/isochrone`, `/nearest`).
+- Or accept that `pending` is a normal cold-start state and only alert on `degraded`.
+
+---
+
+## Symptom: Container boot takes 3+ minutes
+
+**Diagnosis**
+
+Transit transfer graph rebuild dominates. ULTRA preprocessing runs bounded multi-source Dijkstra over the foot CCH for every transit stop (66 512 stops on Belgium, ~668 k transfer edges), produces `transit/transfers.bin`, and verifies the provenance hash (CCH fingerprint + feed hash + algo version).
+
+Once `transfers.bin` exists, subsequent boots reuse it: ~30 s instead of ~3 min.
+
+**Fix**
+
+- This is one-time cost; the cache is on disk. Don't blow it away.
+- If you are iterating on the foot CCH (Step 6-8 weights changed), the provenance hash mismatches and ULTRA rebuilds. Expected.
+- To bypass entirely, remove `data/<region>/transit/`. The server runs road-only and skips ULTRA. Boot is ~30 s.
+
+---
+
+## Symptom: `cargo build` fails with workspace error mentioning `geocode`
+
+**Diagnosis**
+
+The geocoder crate was shelved (#254). If your local checkout has a stale `Cargo.lock` referencing the removed crate, or you have a worktree pointing at an old branch, the workspace resolver fails on the missing member.
+
+**Fix**
+
+```bash
+git pull origin main
+cargo clean
+cargo build --workspace
+```
+
+`cargo clean` is required because the lockfile-driven incremental cache holds onto the old member graph.
+
+---
+
+## Symptom: Health endpoint shows `avoid_cache.hit_rate` near zero
+
+**Diagnosis**
+
+Either callers are sending genuinely different polygons (every request unique), or polygon JSON is subtly varying (different coordinate precision, different vertex order, polygons in different orders). The canonicaliser in `hash_polygon_json` handles vertex quantisation to 6 decimals, Booth's lex-min cyclic rotation per ring, and polygon-set sort — but it does *not* paper over reversed winding or extra vertices.
+
+**Fix**
+
+- Have clients pin a stable polygon serialisation. Same vertex count, same winding, same JSON whitespace doesn't matter (the parser normalises) but the *vertex set* must match.
+- Increase `BUTTERFLY_AVOID_CACHE_CAP` if the working set genuinely exceeds 8 distinct polygons. Memory cost is ~100-200 MB per entry.
+- Per-region hit rate is broken out in the `/health` JSON — if one region is 0.95 and another is 0.05, the bad client is hitting only one region.
+
+---
+
+## Symptom: Logs are JSON and unreadable in `docker logs`
+
+**Diagnosis**
+
+Default log format is JSON for production. Configured via `--log-format` (see CLAUDE.md "Production Hardening").
+
+**Fix**
+
+```bash
+docker run ... butterfly-route serve --data-dir /data --port 8080 --log-format text
+```
+
+---
+
+## Still stuck?
+
+- `RUST_LOG=debug` on the server, reproduce the failing request, and the structured log line will name the handler, the region (in multi-region mode), and any snap candidate counts.
+- Compare against [API reference](api.md) for the exact expected request shape.
+- For algorithm-level questions (why does this matrix cell return null, why is this isochrone shape weird) see [Architecture](architecture.md).

--- a/route/README.md
+++ b/route/README.md
@@ -1,0 +1,132 @@
+# butterfly-route
+
+Production-grade routing engine for OSM data. Exact turn-aware edge-based CCH (Customizable Contraction Hierarchies) for car / bike / foot / truck, with a multimodal transit engine (RAPTOR + ULTRA transfers) bolted onto the same process. Ships REST + Arrow Flight gRPC. Deployed on Belgium; see the [workspace README](../README.md) for the rest of the ecosystem.
+
+## What it does
+
+- **Exact turn-aware P2P routing** — bidirectional CCH on the edge-based graph; turn restrictions and penalties are enforced, not approximated.
+- **Distance matrices** — `POST /table` (Bucket M2M, sparse) and Flight `matrix` (K-lane batched PHAST, streams 50k×50k+).
+- **Isochrones** — time / distance thresholds, depart or arrive direction, multi-contour, bulk endpoint, GeoJSON or WKB.
+- **Routing controls** — `avoid_polygons` (R-tree + sparse CCH recustomization), `exclude=toll,ferry,motorway`, bearing hints, traffic profiles (`?traffic=rush_hour`).
+- **Map matching** — HMM + Viterbi (Newson & Krumm) over GPS traces.
+- **TSP / trip optimization** — nearest-neighbour + 2-opt + or-opt.
+- **Multimodal transit** — RAPTOR over merged GTFS + NeTEx-EPIP feeds, ULTRA-preprocessed foot transfer graph, access/egress legs via the road CCH.
+- **Auxiliary** — `/nearest` snap, `/height` SRTM lookup, catchment hulls, multi-region cross-border overlay, Prometheus `/metrics`.
+
+## Build
+
+```bash
+cargo build --release -p butterfly-route
+```
+
+Produces two binaries: `butterfly-route` (pipeline + server) and `butterfly-bench` (benchmark harness).
+
+## Pipeline (build-time)
+
+```mermaid
+flowchart LR
+    PBF[belgium.pbf] --> S1[step1-ingest]
+    S1 --> S2[step2-profile]
+    S2 --> S3[step3-nbg]
+    S3 --> S4[step4-ebg]
+    S4 --> S5[step5-weights]
+    S5 --> S6[step6-order]
+    S6 --> S7[step7-contract]
+    S7 --> S8[step8-customize]
+    S8 --> PACK[pack]
+    PACK --> CTR[*.butterfly container]
+```
+
+Each step writes a `stepN.lock.json` with SHA-256 checksums for reproducibility. NBG is a build-time intermediate; the EBG is the single source of truth for routing.
+
+Example invocation (car mode, Belgium):
+
+```bash
+butterfly-route step1-ingest    --input belgium.pbf --outdir data/step1
+butterfly-route step2-profile   --ways data/step1/ways.raw --relations data/step1/relations.raw --models-dir models --outdir data/step2
+butterfly-route step3-nbg       --nodes data/step1/nodes.sa --ways data/step1/ways.raw --way-attrs car=data/step2/way_attrs.car.bin --outdir data/step3
+butterfly-route step4-ebg       --nbg-csr data/step3/nbg.csr --nbg-geo data/step3/nbg.geo --nbg-node-map data/step3/nbg.node_map --way-attrs car=data/step2/way_attrs.car.bin --turn-rules car=data/step2/turn_rules.car.bin --outdir data/step4
+butterfly-route step5-weights   --ebg-nodes data/step4/ebg.nodes --ebg-csr data/step4/ebg.csr --turn-table data/step4/ebg.turn_table --nbg-geo data/step3/nbg.geo --way-attrs car=data/step2/way_attrs.car.bin --outdir data/step5
+butterfly-route step6-order     --filtered-ebg data/step5/filtered.car.ebg --ebg-nodes data/step4/ebg.nodes --nbg-geo data/step3/nbg.geo --mode car --outdir data/step6
+butterfly-route step7-contract  --filtered-ebg data/step5/filtered.car.ebg --order data/step6/order.car.ebg --weights data/step5/w.car.u32 --turns data/step5/t.car.u32 --mode car --outdir data/step7
+butterfly-route step8-customize --cch-topo data/step7/cch.car.topo --filtered-ebg data/step5/filtered.car.ebg --order data/step6/order.car.ebg --weights data/step5/w.car.u32 --turns data/step5/t.car.u32 --ebg-nodes data/step4/ebg.nodes --mode car --outdir data/step8
+butterfly-route pack            --data-dir data --out belgium.butterfly --region BE
+```
+
+Repeat steps 3-8 with `--way-attrs bike=...`, `--turn-rules bike=...` etc. to add modes. Modes are discovered from the filenames in each step directory; there are no hardcoded mode names in the Rust code. Traffic recustomization (`step8-customize --traffic rush_hour.traffic.json`) emits an extra `cch.w.<mode>_<variant>.u32` and is auto-discovered by `serve` as a synthetic mode (e.g. `car_rush_hour`).
+
+See [Architecture](../docs/architecture.md) for the full edge-based CCH derivation.
+
+## Serve (query-time)
+
+```bash
+butterfly-route serve --data belgium.butterfly --port 3001
+# or, for an unpacked tree:
+butterfly-route serve --data-dir ./data/belgium --port 3001
+```
+
+Boot mmaps the container, builds the spatial index, loads transit feeds if present, and exposes REST on `--port` and Arrow Flight gRPC on `--grpc-port` (defaults to `port + 1`).
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant R as /route handler
+    participant S as Snap (R-tree)
+    participant Q as CCH bidi search
+    participant U as Path unpack
+    C->>R: GET /route?coords=...&avoid_polygons=...
+    R->>S: nearest snap (K-best, bearing-filtered)
+    R->>R: avoid_polygons cache lookup
+    alt cache hit (11ms p50)
+        R->>Q: query on cached recustomized weights
+    else cache miss
+        R->>R: sparse CCH recustomization (R-tree → dirty bitset)
+        R->>Q: query on fresh weights
+    end
+    Q->>U: shortcut unpack → NBG edges
+    U->>C: JSON {geometry, steps, duration, distance}
+```
+
+The `avoid_polygons` fast path is keyed on a hash of the polygon set; cold-path recustomization uses sparse triangle relaxation (~16 s on Belgium) and is cached for subsequent requests. Full endpoint catalogue in [API reference](../docs/api.md).
+
+## Configuration
+
+| Flag / env | Purpose |
+|---|---|
+| `--data <file.butterfly>` | Single-container mmap load (preferred). |
+| `--data-dir <dir>` | Unpacked `step1/`…`step8/` tree (dev). |
+| `--port`, `--grpc-port` | REST and Flight listener ports. |
+| `--transport rest\|grpc\|both` | Restrict to one transport. |
+| `--modes car,bike` | Load a subset of discovered modes. |
+| `--regions BE,LU` | Load a subset of regions from `--data-dir`. |
+| `--overlay <file>` | Cross-region overlay container for inter-region P2P. |
+| `--log-format text\|json` | Structured logging. |
+| `--rss-checkpoints` | Emit `RSS_CHECKPOINT` lines at each boot phase. |
+| `--eager-verify` / `--warmup-on-boot` | CRC verification policy (default: lazy on first access). |
+| `RUST_LOG` | Standard `tracing-subscriber` env filter. |
+
+Full Docker recipe and ops guide in [Deployment](../docs/deployment.md). Quick first-run path in the [Quickstart](../docs/quickstart.md).
+
+## Performance
+
+Belgium, 8 threads, release build. See `bench/route/results/` for raw runs.
+
+| Query | Number |
+|---|---|
+| Matrix 10k×10k (Bucket M2M, source-tiled) | 18.3 s — **1.8× faster than OSRM CH** |
+| Matrix 1000×1000 | 268 ms — 2.56× faster than OSRM |
+| Isochrone 30-min car (block-gated PHAST) | 5 ms p50 |
+| Route P2P with `avoid_polygons` cache hit | 11 ms |
+| Multimodal `/transit` warm | 35 ms p50 |
+| Transit bulk, varied origins | 311 q/s sustained |
+
+The 10k×10k win came from L3-aware source tiling (`matrix/tile_geometry.rs`); the isochrone win came from block-gated downward scan (C1). Full benchmark methodology and OSRM/Valhalla baselines in [Architecture](../docs/architecture.md) and the workspace `CLAUDE.md`.
+
+## Workspace dependencies
+
+- [`butterfly-common`](../butterfly-common) — shared error types.
+- [`butterfly-dl`](../dl) — used for region pack downloads and GTFS feed fetch (`transit-fetch`).
+
+## License
+
+AGPL-3.0-or-later (matches the workspace).


### PR DESCRIPTION
Closes #255-#262.

## What's new

- `docs/quickstart.md` — 60-second Docker + first /route call
- `docs/api.md` — REST + Flight gRPC endpoint reference (1 Mermaid diagram)
- `docs/deployment.md` — env vars, Docker, /health, /metrics, Prometheus (1 Mermaid)
- `docs/architecture.md` — CCH, avoid_polygons BFS, transit (8 Mermaid diagrams)
- `docs/troubleshooting.md` — common failure modes + fixes
- `route/README.md` (new) — per-crate doc with pipeline + serve mermaid diagrams
- `README.md` rewritten (526 → 199 lines): stale perf table fixed (was claiming 3× slower at 100×100 — actually 1.1× faster), avoid_polygons + Flight + transit features added, no geocoder mentions
- `CHANGELOG.md` updated with all 11 PRs from this session

## Constraints honored

- **Mermaid only** for diagrams. 13 Mermaid diagrams across 5 files. Zero PNG/SVG/ASCII.
- **All numbers verified** from CLAUDE.md, bench/route/results/2026-05-22-post-snap-kbest/REPORT.md, or source code.
- **All endpoint shapes** read from route/src/server/*.rs handlers.

## Test plan

- [x] cargo build --release --workspace: clean
- [x] All cross-references use relative paths
- [x] 13 Mermaid diagrams confirmed (none broken)
- [x] No geocode mentions outside the Status section