### PR TITLE
docs: address PR #264 review feedback (2 inline fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ flowchart LR
     end
 
     subgraph serve[Serve]
-        REST[REST :3001<br/>route · matrix · isochrone<br/>transit · trip · nearest · height]
+        REST[REST :3001<br/>route · table · isochrone<br/>transit · trip · nearest · height]
         FLIGHT[Flight gRPC :3002<br/>matrix · route_batch<br/>isochrone · catchment<br/>transit_bulk · edges_batch]
     end
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,12 +23,12 @@ cd /path/to/butterfly-osm
 docker build -t butterfly-route .
 ```
 
-No pre-built images are published yet — build locally. The published
-runtime layer is ~200 MB (slim Debian + the static-ish Rust binary +
-curl + certs); the multi-stage builder layer is fat but never shipped.
-The 26 GB figure cited elsewhere refers to the mounted Belgium data
-volume (the packed `*.butterfly` container), not the image. Build takes
-5–10 min cold, seconds warm.
+No pre-built images are published yet — build locally. The locally-
+built runtime layer is ~200 MB (slim Debian + the static-ish Rust
+binary + curl + certs); the multi-stage builder layer is fat but
+never shipped. The 26 GB figure cited elsewhere refers to the mounted
+Belgium data volume (the packed `*.butterfly` container), not the
+image. Build takes 5–10 min cold, seconds warm.
 
 ## 3. Run the server
 


### PR DESCRIPTION
Two inline issues Copilot flagged on PR #264:
1. quickstart.md: 'No pre-built images are published yet' contradicted 'The published runtime layer'. Reworded to 'locally-built runtime layer is ~200 MB'.
2. README.md: Architecture Mermaid diagram still listed `matrix` as a REST endpoint. Updated to `route · table · isochrone · ...` (Flight `matrix` action label stays — correct on gRPC side).