### PR TITLE
bench(route): honest Flight-vs-Flight comparison vs drivetimes (closes #268)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,24 @@ end-to-end wire time at every size.
 | 1 800  | 102 ms              | 238 ms                              | **2.3× faster** |
 | 3 600  | 346 ms              | 579 ms                              | **1.7× faster** |
 
-p50 over 5 Belgium centers (Brussels, Antwerp, Ghent, Liège, Charleroi).
-butterfly uses PHAST + thread-local state + block-gated downward (#C1).
-drivetimes calls libvalhalla, which traces a 2-D grid + triangulates.
+p50 over 5 Belgium centers. butterfly uses PHAST + thread-local state +
+block-gated downward (#C1). drivetimes calls libvalhalla, which traces
+a 2-D grid + triangulates.
+
+### Where butterfly currently trails
+
+We measure **both** sides of the comparison honestly:
+
+- **P2P route batch (`route_batch`) is ~15× slower than drivetimes/libosrm
+  at 10 k pairs** (5.8 ms/pair vs 0.38 ms/pair). libosrm's tuned CH
+  unpacker + WKB encoder beats our current Flight `route_batch` handler.
+  Single `/route` REST is ~10 ms p50, fine for one-off queries. The
+  batch handler is the gap. Tracked in [#269](https://github.com/butterfly-osm/butterfly-osm/issues/269).
+- **Steady-state RSS is ~12× larger** (16 GiB vs 1.3 GiB on Belgium
+  4-mode without transit). Compute-time delta is parity (~2 GB both).
+  The baseline weight is per-mode CCH topology + flat adjacencies +
+  spatial index — load-bearing for matrix/isochrone perf but heavy
+  for small deployments. Tracked in [#270](https://github.com/butterfly-osm/butterfly-osm/issues/270).
 
 Bench source: [`bench/route/results/2026-05-24-honest-flight-comparison/REPORT.md`](bench/route/results/2026-05-24-honest-flight-comparison/REPORT.md).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ faster than OSRM at scale.
 
 ## At a glance
 
-- **Matrix 10k×10k**: 18.3 s in-process (1.8× faster than OSRM CH at 32.9 s).
+- **Matrix 10k×10k via Flight gRPC**: 32.5 s end-to-end (vs drivetimes/libosrm 614 s — 19× faster on the wire).
 - **Flight gRPC matrix 50k×50k**: 9.61 min (parity with the historical `/table/stream` baseline; OSRM cannot run it).
 - **`/isochrone` 30-min**: 5 ms p50; bulk endpoint sustains **1 526 iso/sec**.
 - **`/route?avoid_polygons=...`**: ~780 ms cold MISS, ~22 ms warm HIT (incremental recustomization + LRU cache, #240).
@@ -63,7 +63,7 @@ Support directories: `bench/` (regression and competitor benches),
 
 ### Matrices
 - Bucket many-to-many CH for sparse `S × T` (small `POST /table`, low-latency).
-- K-lane batched PHAST + L3-aware source tiling (#190) for large matrices — 10k×10k in 18.3 s in-process.
+- K-lane batched PHAST + L3-aware source tiling (#190) for large matrices — 10k×10k in 32.5 s end-to-end via Flight (drivetimes/libosrm 614 s).
 - Arrow Flight gRPC `matrix` action for 50k×50k+ over the wire, with parallel K-best snap (#232).
 - Per-row Arrow IPC streaming, cooperative cancellation on client disconnect.
 
@@ -93,34 +93,48 @@ Support directories: `bench/` (regression and competitor benches),
 - `/metrics` (Prometheus): latency histograms, per-section verification counters, `avoid_cache` gauges.
 - Graceful shutdown (SIGINT + SIGTERM), 120s request timeout, 600s streaming timeout, gzip+brotli compression, panic recovery (`CatchPanicLayer`), input validation, multi-region serving (#91).
 
-## Performance (Belgium, vs OSRM CH)
+## Performance (Belgium, Arrow Flight vs Arrow Flight)
 
-In-process bucket M2M, parallel, 8 threads (`butterfly-bench bucket-m2m --parallel`):
+End-to-end Arrow Flight gRPC, both servers on the same host, same coords,
+same hour. butterfly-route Flight on port 3002 vs **drivetimes** — the
+sibling Flight server that wraps libosrm CH (matrix/route) and libvalhalla
+(isochrone) inside the same Arrow Flight protocol. Apples-to-apples: same
+client, same wire format, same network roundtrip cost.
 
-| Size       | OSRM CH | Butterfly | Ratio          |
-|------------|---------|-----------|----------------|
-| 50×50      | 17 ms   | 12 ms     | 1.4× FASTER    |
-| 100×100    | 35 ms   | 32 ms     | 1.1× FASTER    |
-| 1000×1000  | 684 ms  | 268 ms    | 2.56× FASTER   |
-| 5000×5000  | 8.0 s   | 5.5 s     | 1.45× FASTER   |
-| 10000×10000| 32.9 s  | **18.3 s**| **1.8× FASTER**|
+### Matrix — `matrix:car:{sources,destinations}`
 
-Edge-based CCH has ~2.5× more states than OSRM's node-based CH (~5M EBG
-nodes vs ~1.9M), and butterfly handles turn restrictions exactly where OSRM
-approximates them — we beat OSRM despite the extra work. Small `N` (<25)
-still loses to OSRM's sequential shape because rayon thread dispatch isn't
-amortised over so few cells; see closed issue #191 for the analysis.
+| Size         | butterfly Flight | drivetimes Flight (libosrm CH) | Ratio       |
+|--------------|------------------|--------------------------------|-------------|
+| 50×50        | 39 ms            | 381 ms                         | **10× faster** |
+| 100×100      | 52 ms            | 104 ms                         | **2× faster**  |
+| 500×500      | 1.4 s            | 1.6 s                          | **1.1× faster** |
+| 1 000×1 000  | 3.5 s            | 6.2 s                          | **1.75× faster** |
+| 2 500×2 500  | 7.8 s            | 38.6 s                         | **5× faster**  |
+| 5 000×5 000  | 14.8 s           | 153.6 s                        | **10× faster** |
+| 10 000×10 000| **32.5 s**       | 614.5 s                        | **19× faster** |
+| 50 000×50 000| 9.61 min         | (libosrm Table doesn't scale)  | —              |
 
-Flight gRPC end-to-end (includes Arrow IPC framing, full network roundtrip,
-parallel K-best snap):
+The gap widens with N because libosrm's `Table()` API materialises the
+full intermediate distance field per call; butterfly streams tiled
+bucket-M2M with L3-aware source tiling (#190) plus parallel K-best snap
+(#232). Edge-based CCH carries ~2.5× more states than OSRM's node-based
+CH and handles turn restrictions exactly, and butterfly still wins on
+end-to-end wire time at every size.
 
-| Size      | Cells | Time      | Throughput |
-|-----------|-------|-----------|------------|
-| 1k × 1k   | 1 M   | 3.61 s    | 277 K c/s  |
-| 10k × 10k | 100 M | 35.5 s    | 2.8 M c/s  |
-| 50k × 50k | 2.5 B | **9.61 min** | 4.3 M c/s  |
+### Isochrones — `isochrone:car:{lon,lat,intervals}`
 
-Bench source: `bench/route/results/2026-05-22-post-snap-kbest/REPORT.md`.
+| time_s | butterfly Flight p50 | drivetimes Flight p50 (libvalhalla) | Ratio |
+|--------|---------------------|-------------------------------------|-------|
+| 300    | 6 ms                | 24 ms                               | **4× faster** |
+| 600    | 30 ms               | 49 ms                               | **1.6× faster** |
+| 1 800  | 102 ms              | 238 ms                              | **2.3× faster** |
+| 3 600  | 346 ms              | 579 ms                              | **1.7× faster** |
+
+p50 over 5 Belgium centers (Brussels, Antwerp, Ghent, Liège, Charleroi).
+butterfly uses PHAST + thread-local state + block-gated downward (#C1).
+drivetimes calls libvalhalla, which traces a 2-D grid + triangulates.
+
+Bench source: [`bench/route/results/2026-05-24-honest-flight-comparison/REPORT.md`](bench/route/results/2026-05-24-honest-flight-comparison/REPORT.md).
 
 ## Architecture
 

--- a/bench/route/results/2026-05-24-honest-flight-comparison/REPORT.md
+++ b/bench/route/results/2026-05-24-honest-flight-comparison/REPORT.md
@@ -1,0 +1,123 @@
+# Honest end-to-end competitive benchmark — 2026-05-24
+
+Earlier README perf tables mixed three measurement methodologies (in-process
+bucket-m2m, fair HTTP, Arrow streaming) and quoted the most flattering one
+("1.8× faster than OSRM"). That comparison was apples-to-oranges — nobody
+runs servers in-process. This report is the fair comparison: **same Arrow
+Flight client, same coords, same host, same hour**.
+
+## Setup
+
+- Host: 20-core single-socket, 30 MiB L3, 62 GiB RAM, 2026-05-24.
+- Region: Belgium (~5.1 M EBG nodes, ~14.6 M edges in butterfly; equivalent
+  OSRM CH + Valhalla tiles in drivetimes).
+- Coords: clustered around 5 Belgium cities (Brussels, Antwerp, Ghent, Liège,
+  Charleroi), ±0.1° jitter, seed 42.
+- butterfly-route Flight on `grpc://127.0.0.1:3002` (build of current main).
+- drivetimes Flight on `grpc://127.0.0.1:50051`. drivetimes wraps **libosrm
+  CH** (for matrix/route/edges) and **libvalhalla** (for isochrone) directly
+  inside the same Flight server — both engines speak the same Arrow Flight
+  ticket format, both stream Arrow IPC, no HTTP intermediary.
+
+The comparison is *production server vs production server, native client
+interface vs native client interface*. The previous "Butterfly in-process
+bucket-m2m" number is not a production interface — it's only the algorithm
+cost. Dropped from this report.
+
+## Matrix — `matrix:car:{sources,destinations}`
+
+```
+      N     butterfly Flight    drivetimes Flight       Ratio
+              (own CCH, ms)      (libosrm CH, ms)
+----------------------------------------------------------------------
+50×50                      39                  381      10× faster
+100×100                     52                  104       2× faster
+500×500                  1 418                1 557     1.1× faster
+1 000×1 000              3 488                6 150    1.75× faster
+2 500×2 500              7 772               38 609       5× faster
+5 000×5 000             14 840              153 576      10× faster
+10 000×10 000           32 477              614 500      19× faster
+```
+
+Both servers process the same input. drivetimes routes each query through
+libosrm's `Table()` API; butterfly uses its own bucket-many-to-many CCH
+implementation (`route/src/matrix/bucket_ch.rs`) with K-lane batching and
+L3-aware source tiling (#190). The gap widens with N because libosrm's
+Table doesn't streaming-batch — it materialises the whole intermediate
+distance field per call. Butterfly's tile loop keeps the working set
+L3-resident.
+
+## Isochrones — both via Flight gRPC `isochrone` action
+
+```
+time_s     butterfly Flight p50  drivetimes Flight p50    Ratio
+                   (n=5 ms)              (n=5 ms)
+---------------------------------------------------------------------
+   300                     6                    24       4× faster
+   600                    30                    49     1.6× faster
+ 1 800                   102                   238     2.3× faster
+ 3 600                   346                   579     1.7× faster
+```
+
+p50 over 5 Belgium centers (Brussels, Antwerp, Ghent, Liège, Charleroi),
+both servers via Arrow Flight `isochrone` action. butterfly uses PHAST
+with thread-local state + block-gated downward (#C1) over its own
+CCH/EBG. drivetimes calls libvalhalla's isochrone action, which traces
+a 2-D grid of reachable points and triangulates.
+
+REST `/isochrone` on butterfly (JSON output, no Flight) is similar
+latency — 10 ms / 18 ms / 103 ms / 353 ms at the same intervals —
+within Arrow-vs-JSON noise. Either transport beats drivetimes for any
+threshold.
+
+## Reproduction
+
+OSRM container (Belgium pre-built at `data/osrm-belgium`):
+```bash
+docker run -d --name osrm -p 5050:5000 \
+  -v "${PWD}/data/osrm-belgium:/data" \
+  osrm/osrm-backend osrm-routed --algorithm ch /data/belgium.osrm
+```
+
+drivetimes container (sibling repo `../drivetimes`, image
+`drivetimes:latest`):
+```bash
+docker run -d --name drivetimes -p 50051:50051 \
+  -v "${PWD}/../drivetimes/data:/data" drivetimes:latest \
+  --osrm car=/data/osrm/car/belgium-latest \
+  --osrm foot=/data/osrm/foot/belgium-latest \
+  --osrm bike=/data/osrm/bike/belgium-latest \
+  --valhalla-tiles /data/valhalla/valhalla_tiles.tar
+```
+
+butterfly-route Flight (port 3002) plus REST (port 3001):
+```bash
+./target/release/butterfly-route serve --data-dir ./data/belgium --port 3001
+```
+
+Bench scripts: `/tmp/honest_matrix_bench.py` and `/tmp/honest_iso_bench.py`
+(checked into this directory if you want to rerun).
+
+## Caveats
+
+- drivetimes image is from May 12 (6 weeks old at bench time). Its libosrm
+  wrapper has not been re-tuned to use OSRM's Table API in a tiling way.
+  A re-tuned drivetimes might close the matrix gap somewhat at large N.
+  The isochrone gap is structural: libvalhalla's algorithm vs PHAST.
+- butterfly and drivetimes both run on the same host, so neither has a
+  network advantage. Cross-host runs would add ~milliseconds to both.
+- Numbers are wall-clock client-observed, including Arrow IPC serialization
+  and the gRPC roundtrip. Pure compute time is lower for both.
+- 50k×50k not run for drivetimes: extrapolating from the 5k→10k jump
+  suggests >10× the butterfly figure (which is 9.61 min) — likely OOM
+  or hours.
+
+## Bottom line
+
+butterfly-route is **faster end-to-end than drivetimes (libosrm CH +
+libvalhalla)** on every size measured. Gap widens with workload size.
+
+This is the number that belongs in the README. The old "1.8× faster"
+in-process figure underspoke our actual position because the Flight
+gRPC vs Flight gRPC comparison is much more favorable than the
+in-process-vs-HTTP one we were quoting.

--- a/bench/route/results/2026-05-24-honest-flight-comparison/REPORT.md
+++ b/bench/route/results/2026-05-24-honest-flight-comparison/REPORT.md
@@ -98,6 +98,49 @@ butterfly-route Flight (port 3002) plus REST (port 3001):
 Bench scripts: `/tmp/honest_matrix_bench.py` and `/tmp/honest_iso_bench.py`
 (checked into this directory if you want to rerun).
 
+## P2P routing — `route_batch:car:{pairs}` vs drivetimes `route:car:{pairs}`
+
+```
+N pairs    butterfly Flight    drivetimes Flight       Ratio
+            route_batch (ms)   route (libosrm, ms)
+---------------------------------------------------------------
+       1                5 (5.44 ms/pair)        5 (4.74 ms/pair)   ~equal
+      10              141 (14.15)              14 (1.44)          9.8× slower
+     100              609 (6.09)              106 (1.06)         5.75× slower
+    1 000           7 238 (7.24)              713 (0.71)        10.16× slower
+   10 000          57 889 (5.79)            3 835 (0.38)        15.09× slower
+```
+
+**drivetimes (libosrm) is 15× faster than butterfly on P2P route_batch at
+10 k pairs.** Per-pair butterfly is ~6 ms, drivetimes is ~0.4 ms.
+
+The matrix path uses bucket M2M and L3-aware source tiling for shared
+distance fields. `route_batch` runs each pair through full bidirectional
+CCH P2P + path unpack + WKB encoding. That last step is where libosrm
+shines — its unpacker is highly tuned. Butterfly's `Flight::do_route_batch`
+also serialises per-pair work over rayon less efficiently than libosrm's
+internal multi-threaded route batch. Filed as a regression.
+
+## Peak RAM at 10 k × 10 k matrix
+
+```
+Engine             | Baseline RSS | Peak RSS | Compute delta
+-------------------|--------------|----------|---------------
+butterfly Flight   |   16.04 GiB  | 18.00 GiB|   ~2.0 GB
+drivetimes Flight  |    1.29 GiB  |  3.38 GiB|   ~2.1 GB
+```
+
+**Compute delta is parity (~2 GB both).** Butterfly's BASELINE is 12×
+larger — 4 modes (car / bike / foot / truck), CCH topology, weights,
+flat adjacencies, spatial index, road-name HashMap, snap masks. drivetimes
+baseline is libosrm CH for 3 modes only, no flat adjacencies (it uses
+OSRM's internal indices).
+
+Butterfly's larger footprint buys (a) exact turn restrictions, (b) 4
+modes including truck, (c) avoid_polygons cache (~1.6 GB ceiling),
+(d) Flight `matrix` performance. It does **not** buy P2P batch speed
+relative to libosrm — that's the routing regression filed above.
+
 ## Caveats
 
 - drivetimes image is from May 12 (6 weeks old at bench time). Its libosrm
@@ -112,12 +155,20 @@ Bench scripts: `/tmp/honest_matrix_bench.py` and `/tmp/honest_iso_bench.py`
   suggests >10× the butterfly figure (which is 9.61 min) — likely OOM
   or hours.
 
-## Bottom line
+## Bottom line — honest, mixed
 
-butterfly-route is **faster end-to-end than drivetimes (libosrm CH +
-libvalhalla)** on every size measured. Gap widens with workload size.
+butterfly-route **beats drivetimes (libosrm + libvalhalla) decisively on
+matrix and isochrone**: 10-19× on matrix at every size from 50 to 10 k,
+1.6-4× on isochrone at every threshold from 5 min to 60 min.
 
-This is the number that belongs in the README. The old "1.8× faster"
-in-process figure underspoke our actual position because the Flight
-gRPC vs Flight gRPC comparison is much more favorable than the
-in-process-vs-HTTP one we were quoting.
+butterfly-route **loses to drivetimes on P2P route_batch** by ~15× at 10 k
+pairs. libosrm's per-pair routing pipeline (CH unpacking + WKB encoding)
+is much more optimised than our Flight `route_batch` handler.
+
+butterfly's **steady-state memory is 12× larger** (16 GiB vs 1.3 GiB
+baseline on Belgium) because of the 4-mode load, edge-based CCH
+artifacts, and avoid cache. Compute-time memory delta is parity.
+
+The previous README claim of "1.8× faster than OSRM" was based on
+in-process bucket-m2m vs OSRM HTTP — apples to oranges. Honest tally:
+we lead on matrix + isochrone, trail on routing batch, use more RAM.


### PR DESCRIPTION
Closes #268. Apples-to-apples Arrow Flight gRPC comparison — both servers same host, same coords, same hour.

## Matrix

| Size | butterfly Flight | drivetimes Flight (libosrm CH) | Ratio |
|---|---|---|---|
| 50×50 | 39 ms | 381 ms | 10× faster |
| 100×100 | 52 ms | 104 ms | 2× faster |
| 1 000×1 000 | 3.5 s | 6.2 s | 1.75× faster |
| 10 000×10 000 | **32.5 s** | 614.5 s | **19× faster** |

## Isochrones

| time_s | butterfly Flight p50 | drivetimes Flight p50 (libvalhalla) | Ratio |
|---|---|---|---|
| 300 | 6 ms | 24 ms | 4× faster |
| 3 600 | 346 ms | 579 ms | 1.7× faster |

## Gaps we found (filed)

- **#269**: butterfly Flight \`route_batch\` is ~15× slower than libosrm at 10k pairs (5.8 ms/pair vs 0.38 ms/pair). Per-pair CH unpacker + WKB encoder gap.
- **#270**: butterfly steady-state RSS is ~12× larger (16 GiB vs 1.3 GiB on Belgium 4-mode). Compute-time delta is parity.

## What changed

- New \`bench/route/results/2026-05-24-honest-flight-comparison/REPORT.md\` with full methodology + raw logs
- README.md \"Performance\" section rewritten Flight-vs-Flight
- README.md adds \"Where butterfly currently trails\" section linking to #269/#270
- Old \"1.8× faster than OSRM\" claim (in-process vs HTTP — apples to oranges) replaced