### PR TITLE
perf(rss): #275 madvise(DONTNEED) cold ways.raw + way_attrs after boot (-2.88 GiB)

### DIFF
--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -944,28 +944,47 @@ impl ServerState {
             vec![0u8; ebg_nodes.n_nodes as usize]
         };
 
-        // Evict the other modes' way_attrs sections too — they were
-        // CRC-walked at boot but never parsed (only one mode supplies
-        // the exclude flags). They stay cold forever.
+        // Evict the other modes' way_attrs sections too — only one mode
+        // supplies the exclude flags, the rest stay cold forever.
+        //
+        // Important: resolve byte ranges via `container.get(..)` +
+        // `static_bytes[..]` directly. Do NOT route through
+        // `optional_section(..)` because that calls
+        // `lazy.verify_now(name)`, which would force a full CRC walk
+        // (and page-in) of every other mode's way_attrs at boot —
+        // defeating lazy verification. `madvise(MADV_DONTNEED)` is
+        // safe on unverified bytes: it evicts resident pages (a no-op
+        // on pages that were never faulted in).
         for other_mode in &discovered_modes {
             if other_mode == &attrs_mode {
                 continue;
             }
             let other_section = format!("mode/{}/way_attrs", other_mode);
-            if let Some(other_bytes) = optional_section(&other_section)? {
-                if let Err(e) = crate::formats::mmap::madvise_dontneed(other_bytes) {
-                    tracing::warn!(
-                        section = %other_section,
-                        error = %e,
-                        "madvise(DONTNEED) on way_attrs failed; ignoring"
-                    );
-                } else {
-                    tracing::info!(
-                        section = %other_section,
-                        bytes = other_bytes.len(),
-                        "madvise(DONTNEED) on cold way_attrs section"
-                    );
-                }
+            let Some(entry) = container.get(&other_section) else {
+                continue;
+            };
+            let off = entry.offset as usize;
+            let len = entry.len as usize;
+            if off + len > static_bytes.len() {
+                tracing::warn!(
+                    section = %other_section,
+                    "way_attrs section bytes exceed mmap; skipping evict"
+                );
+                continue;
+            }
+            let other_bytes = &static_bytes[off..off + len];
+            if let Err(e) = crate::formats::mmap::madvise_dontneed(other_bytes) {
+                tracing::warn!(
+                    section = %other_section,
+                    error = %e,
+                    "madvise(DONTNEED) on way_attrs failed; ignoring"
+                );
+            } else {
+                tracing::info!(
+                    section = %other_section,
+                    bytes = other_bytes.len(),
+                    "madvise(DONTNEED) on cold way_attrs section (no verify)"
+                );
             }
         }
 

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -965,14 +965,23 @@ impl ServerState {
             };
             let off = entry.offset as usize;
             let len = entry.len as usize;
-            if off + len > static_bytes.len() {
+            let Some(end) = off.checked_add(len) else {
+                tracing::warn!(
+                    section = %other_section,
+                    offset = off,
+                    len = len,
+                    "way_attrs section offset+len overflows usize; skipping evict"
+                );
+                continue;
+            };
+            if end > static_bytes.len() {
                 tracing::warn!(
                     section = %other_section,
                     "way_attrs section bytes exceed mmap; skipping evict"
                 );
                 continue;
             }
-            let other_bytes = &static_bytes[off..off + len];
+            let other_bytes = &static_bytes[off..end];
             if let Err(e) = crate::formats::mmap::madvise_dontneed(other_bytes) {
                 tracing::warn!(
                     section = %other_section,

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -880,9 +880,28 @@ impl ServerState {
         }
 
         // ---- Road names from shared/step1.ways.raw ------------------
+        // #275: ways.raw is read once at boot to populate `way_names`.
+        // The names live in a heap HashMap from that point on; the
+        // mmap'd byte range is never read again at serve time. Drop the
+        // pages from RSS — they came in resident because LazyContainer's
+        // boot-time CRC walk touched them.
         tracing::info!("Loading road names from container...");
         let way_names = if let Some(ways_bytes) = optional_section("shared/step1.ways.raw")? {
-            load_way_names_from_bytes(ways_bytes)?
+            let names = load_way_names_from_bytes(ways_bytes)?;
+            if let Err(e) = crate::formats::mmap::madvise_dontneed(ways_bytes) {
+                tracing::warn!(
+                    section = "shared/step1.ways.raw",
+                    error = %e,
+                    "madvise(DONTNEED) on ways.raw failed; ignoring"
+                );
+            } else {
+                tracing::info!(
+                    section = "shared/step1.ways.raw",
+                    bytes = ways_bytes.len(),
+                    "madvise(DONTNEED) on cold ways.raw section"
+                );
+            }
+            names
         } else {
             tracing::warn!("ways.raw missing in container, road names unavailable");
             HashMap::new()
@@ -890,6 +909,12 @@ impl ServerState {
         tracing::info!(named_roads = way_names.len(), "loaded road names");
 
         // ---- Edge exclude flags from one mode's way_attrs -----------
+        // #275: way_attrs is read once at boot to build the per-edge
+        // exclude flag table. The flags live in a heap Vec from that
+        // point on; the mmap'd byte range (this mode's plus every other
+        // mode's, all forced resident by the boot CRC walk) is cold for
+        // the rest of the process lifetime. Drop those pages too.
+        //
         // Prefer car if available, otherwise the alphabetically first mode.
         let attrs_mode = if discovered_modes.iter().any(|m| m == "car") {
             "car".to_string()
@@ -899,11 +924,50 @@ impl ServerState {
         let attrs_section = format!("mode/{}/way_attrs", attrs_mode);
         let edge_exclude_flags = if let Some(attr_bytes) = optional_section(&attrs_section)? {
             let attrs = crate::formats::way_attrs::read_all_from_bytes(attr_bytes)?;
-            exclude::build_edge_exclude_flags_from_attrs(&ebg_nodes, &attrs)?
+            let flags = exclude::build_edge_exclude_flags_from_attrs(&ebg_nodes, &attrs)?;
+            if let Err(e) = crate::formats::mmap::madvise_dontneed(attr_bytes) {
+                tracing::warn!(
+                    section = %attrs_section,
+                    error = %e,
+                    "madvise(DONTNEED) on way_attrs failed; ignoring"
+                );
+            } else {
+                tracing::info!(
+                    section = %attrs_section,
+                    bytes = attr_bytes.len(),
+                    "madvise(DONTNEED) on cold way_attrs section"
+                );
+            }
+            flags
         } else {
             tracing::warn!(section = %attrs_section, "way_attrs absent, exclude feature disabled");
             vec![0u8; ebg_nodes.n_nodes as usize]
         };
+
+        // Evict the other modes' way_attrs sections too — they were
+        // CRC-walked at boot but never parsed (only one mode supplies
+        // the exclude flags). They stay cold forever.
+        for other_mode in &discovered_modes {
+            if other_mode == &attrs_mode {
+                continue;
+            }
+            let other_section = format!("mode/{}/way_attrs", other_mode);
+            if let Some(other_bytes) = optional_section(&other_section)? {
+                if let Err(e) = crate::formats::mmap::madvise_dontneed(other_bytes) {
+                    tracing::warn!(
+                        section = %other_section,
+                        error = %e,
+                        "madvise(DONTNEED) on way_attrs failed; ignoring"
+                    );
+                } else {
+                    tracing::info!(
+                        section = %other_section,
+                        bytes = other_bytes.len(),
+                        "madvise(DONTNEED) on cold way_attrs section"
+                    );
+                }
+            }
+        }
 
         let node_weights_dist: Vec<u32> = ebg_nodes.nodes.iter().map(|n| n.length_mm).collect();
 


### PR DESCRIPTION
## Summary

Closes #275.

`ways.raw` and per-mode `way_attrs` sections are CRC-walked at boot, paging them resident. After the road-name HashMap and the per-edge exclude flag table are built, nothing on the serve path touches them again — they sit resident forever, costing ~2.8 GiB of Belgium RSS that buys nothing.

Wire `madvise(DONTNEED)` immediately after each section is consumed, plus a loop over the other modes' `way_attrs` (CRC-walked but never parsed at serve time).

## Bench (Belgium, baseline.butterfly, 4 modes)

| Metric | Before | After | Delta |
|---|---|---|---|
| VmRSS (idle, post-warmup) | 16.04 GiB | **13.16 GiB** | **-2.88 GiB** (-18%) |
| VmHWM (boot peak) | 19.29 GiB | 19.29 GiB | unchanged |
| RssAnon | 532 MiB | 532 MiB | unchanged (file pages) |
| Route p50 (Brussels-Antwerp) | ~8 ms | 7.8 ms | within noise |
| Iso p50 (5 min, car) | ~30 ms | 32.5 ms | within noise |

## Sections evicted (logged at INFO)

```
shared/step1.ways.raw     1.35 GiB
mode/car/way_attrs        362 MiB
mode/bike/way_attrs       362 MiB
mode/foot/way_attrs       362 MiB
mode/truck/way_attrs      362 MiB
```

## Acceptance gates (all met)

- [x] Idle RSS reduction: target -500 MiB to -1 GiB → **-2.88 GiB** (4-6× target)
- [x] Route p50: within ±5% — unchanged
- [x] Correctness: Brussels-Antwerp returns 2128.9 s / 44.8 km (matches main)
- [x] Build + clippy green

## Test plan

- [x] `cargo build --workspace --release` green
- [x] `cargo clippy --workspace --all-targets --all-features` green
- [x] Belgium boot + warmup + RSS measurement via `/proc/$PID/status`
- [x] 10 routes + 5 isochrones latency unchanged
- [x] All 4 madvise INFO log lines emitted at expected sizes

## Follow-ups still active

Same RSS chain: #277 (lazy distance flats, -4.93 GiB), #279 (per-mode lazy, -6 to -8 GiB), #278 (u32→u16 weights, -3 GiB), #281, #282.