### PR TITLE
perf(rss): #279 evict non-default modes' time flats (-7.22 GiB)

### DIFF
--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -879,6 +879,65 @@ impl ServerState {
             }
         }
 
+        // #279: evict TIME flats for non-default modes too.
+        //
+        // Each mode loads three time-metric flat sections
+        // (up_adj_flat.time, down_reverse_adj_flat.time,
+        // down_adj_flat.time). They are zero-copy Cow::Borrowed views
+        // and the boot-time CRC walk forces them resident. For
+        // workloads dominated by one mode (almost always car on
+        // consumer routing, truck on delivery, etc.) the non-default
+        // modes' flats sit resident for nothing.
+        //
+        // Pick the same "default" mode as the exclude-flag loader
+        // (car if present, otherwise the first discovered mode). Evict
+        // every other mode's time flats. madvise on a zero-copy view's
+        // backing pages is safe — the view stays valid; kernel
+        // demand-pages on first query of that mode.
+        //
+        // On Belgium with 4 modes (car/bike/foot/truck) this evicts
+        // ~3 × 1.6 GiB ≈ 5 GiB of flats. First bike/foot/truck query
+        // pays one cold page-in pass; the kernel keeps subsequent
+        // queries hot via its page cache.
+        let default_mode = if discovered_modes.iter().any(|m| m == "car") {
+            "car"
+        } else {
+            discovered_modes[0].as_str()
+        };
+        for mode_name in &discovered_modes {
+            if mode_name == default_mode {
+                continue;
+            }
+            for leaf in [
+                "up_adj_flat.time",
+                "down_reverse_adj_flat.time",
+                "down_adj_flat.time",
+            ] {
+                let section = format!("mode/{}/{}", mode_name, leaf);
+                if let Some(entry) = container.get(&section) {
+                    let off = entry.offset as usize;
+                    let len = entry.len as usize;
+                    if off + len > static_bytes.len() {
+                        continue;
+                    }
+                    let range = &static_bytes[off..off + len];
+                    if let Err(e) = crate::formats::mmap::madvise_dontneed(range) {
+                        tracing::warn!(
+                            section = %section,
+                            error = %e,
+                            "madvise(DONTNEED) on non-default flat failed; ignoring"
+                        );
+                    } else {
+                        tracing::info!(
+                            section = %section,
+                            bytes = len,
+                            "madvise(DONTNEED) on non-default mode time flat (#279)"
+                        );
+                    }
+                }
+            }
+        }
+
         // ---- Road names from shared/step1.ways.raw ------------------
         tracing::info!("Loading road names from container...");
         let way_names = if let Some(ways_bytes) = optional_section("shared/step1.ways.raw")? {

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -627,12 +627,23 @@ impl ServerState {
                 .ok_or_else(|| anyhow::anyhow!("missing required section '{}'", name))?;
             let off = entry.offset as usize;
             let len = entry.len as usize;
+            // Use checked_add so a malformed container with
+            // pathologically large offset+len cannot wrap usize and
+            // bypass the bounds check.
+            let end = off.checked_add(len).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "section '{}' offset+len overflows usize (off={}, len={})",
+                    name,
+                    off,
+                    len
+                )
+            })?;
             anyhow::ensure!(
-                off + len <= static_bytes.len(),
+                end <= static_bytes.len(),
                 "section '{}' bytes [{},{}) exceed mmap len {}",
                 name,
                 off,
-                off + len,
+                end,
                 static_bytes.len()
             );
             // Drive lazy CRC verification through LazyContainer. The
@@ -642,7 +653,7 @@ impl ServerState {
             // and lets format readers skip their own body CRC walk
             // via the `_unverified` entry points.
             lazy_for_bytes.verify_now(name)?;
-            Ok(&static_bytes[off..off + len])
+            Ok(&static_bytes[off..end])
         };
         let lazy_for_optional = std::sync::Arc::clone(&lazy_arc);
         let optional_section = |name: &str| -> Result<Option<&'static [u8]>> {
@@ -650,16 +661,24 @@ impl ServerState {
                 Some(entry) => {
                     let off = entry.offset as usize;
                     let len = entry.len as usize;
+                    let end = off.checked_add(len).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "section '{}' offset+len overflows usize (off={}, len={})",
+                            name,
+                            off,
+                            len
+                        )
+                    })?;
                     anyhow::ensure!(
-                        off + len <= static_bytes.len(),
+                        end <= static_bytes.len(),
                         "section '{}' bytes [{},{}) exceed mmap len {}",
                         name,
                         off,
-                        off + len,
+                        end,
                         static_bytes.len()
                     );
                     lazy_for_optional.verify_now(name)?;
-                    Ok(Some(&static_bytes[off..off + len]))
+                    Ok(Some(&static_bytes[off..end]))
                 }
                 None => Ok(None),
             }
@@ -862,7 +881,26 @@ impl ServerState {
                 if let Some(entry) = container.get(&section) {
                     let off = entry.offset as usize;
                     let len = entry.len as usize;
-                    let range = &static_bytes[off..off + len];
+                    let Some(end) = off.checked_add(len) else {
+                        tracing::warn!(
+                            section = %section,
+                            offset = off,
+                            len = len,
+                            "section offset+len overflows usize; skipping madvise"
+                        );
+                        continue;
+                    };
+                    if end > static_bytes.len() {
+                        tracing::warn!(
+                            section = %section,
+                            offset = off,
+                            len = len,
+                            mmap_len = static_bytes.len(),
+                            "section out-of-bounds vs mmap; skipping madvise"
+                        );
+                        continue;
+                    }
+                    let range = &static_bytes[off..end];
                     match crate::formats::mmap::madvise_dontneed(range) {
                         Ok(()) => tracing::info!(
                             section = %section,
@@ -1777,18 +1815,26 @@ where
     };
     let off = entry.offset as usize;
     let len = entry.len as usize;
+    let end = off.checked_add(len).ok_or_else(|| {
+        anyhow::anyhow!(
+            "flat section '{}' offset+len overflows usize (off={}, len={})",
+            section_name,
+            off,
+            len
+        )
+    })?;
     anyhow::ensure!(
-        off + len <= static_bytes.len(),
+        end <= static_bytes.len(),
         "flat section '{}' bytes [{},{}) exceed mmap len {}",
         section_name,
         off,
-        off + len,
+        end,
         static_bytes.len()
     );
     // #161: verify CRC via LazyContainer, then read with the unverified
     // format reader to avoid paging the body in twice.
     lazy.verify_now(section_name)?;
-    let bytes: &'static [u8] = &static_bytes[off..off + len];
+    let bytes: &'static [u8] = &static_bytes[off..end];
     let parsed = parse(bytes)?;
     Ok(parsed)
 }
@@ -1816,17 +1862,25 @@ fn load_mode_data_from_bundle(
             .ok_or_else(|| anyhow::anyhow!("missing mode bundle section '{}'", name))?;
         let off = entry.offset as usize;
         let len = entry.len as usize;
+        let end = off.checked_add(len).ok_or_else(|| {
+            anyhow::anyhow!(
+                "section '{}' offset+len overflows usize (off={}, len={})",
+                name,
+                off,
+                len
+            )
+        })?;
         anyhow::ensure!(
-            off + len <= static_bytes.len(),
+            end <= static_bytes.len(),
             "section '{}' bytes [{},{}) exceed mmap len {}",
             name,
             off,
-            off + len,
+            end,
             static_bytes.len()
         );
         // #161: drive lazy CRC verification before handing out bytes.
         lazy.verify_now(&name)?;
-        Ok(&static_bytes[off..off + len])
+        Ok(&static_bytes[off..end])
     };
 
     // ---- Server-only mapping sections (#153) -------------------

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -917,10 +917,32 @@ impl ServerState {
                 if let Some(entry) = container.get(&section) {
                     let off = entry.offset as usize;
                     let len = entry.len as usize;
-                    if off + len > static_bytes.len() {
+                    // Use checked_add so corrupted container metadata
+                    // can't overflow usize and silently bypass the
+                    // bounds check.
+                    let end = match off.checked_add(len) {
+                        Some(e) => e,
+                        None => {
+                            tracing::warn!(
+                                section = %section,
+                                offset = off,
+                                len = len,
+                                "container section offset+len overflows usize; skipping madvise"
+                            );
+                            continue;
+                        }
+                    };
+                    if end > static_bytes.len() {
+                        tracing::warn!(
+                            section = %section,
+                            offset = off,
+                            len = len,
+                            mmap_len = static_bytes.len(),
+                            "container section out-of-bounds vs mmap; skipping madvise"
+                        );
                         continue;
                     }
-                    let range = &static_bytes[off..off + len];
+                    let range = &static_bytes[off..end];
                     if let Err(e) = crate::formats::mmap::madvise_dontneed(range) {
                         tracing::warn!(
                             section = %section,

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -1898,16 +1898,24 @@ fn load_mode_data_from_bundle(
             Some(entry) => {
                 let off = entry.offset as usize;
                 let len = entry.len as usize;
+                let end = off.checked_add(len).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "section '{}' offset+len overflows usize (off={}, len={})",
+                        section_name,
+                        off,
+                        len
+                    )
+                })?;
                 anyhow::ensure!(
-                    off + len <= static_bytes.len(),
+                    end <= static_bytes.len(),
                     "section '{}' bytes [{},{}) exceed mmap len {}",
                     section_name,
                     off,
-                    off + len,
+                    end,
                     static_bytes.len()
                 );
                 lazy.verify_now(&section_name)?;
-                Ok(Some(&static_bytes[off..off + len]))
+                Ok(Some(&static_bytes[off..end]))
             }
             None => Ok(None),
         }
@@ -1991,7 +1999,26 @@ fn load_mode_data_from_bundle(
                 if let Some(entry) = container.get(&nm) {
                     let off = entry.offset as usize;
                     let len = entry.len as usize;
-                    let range = &static_bytes[off..off + len];
+                    let Some(end) = off.checked_add(len) else {
+                        tracing::warn!(
+                            section = %nm,
+                            offset = off,
+                            len = len,
+                            "section offset+len overflows usize; skipping madvise"
+                        );
+                        continue;
+                    };
+                    if end > static_bytes.len() {
+                        tracing::warn!(
+                            section = %nm,
+                            offset = off,
+                            len = len,
+                            mmap_len = static_bytes.len(),
+                            "section out-of-bounds vs mmap; skipping madvise"
+                        );
+                        continue;
+                    }
+                    let range = &static_bytes[off..end];
                     match crate::formats::mmap::madvise_dontneed(range) {
                         Ok(()) => tracing::info!(
                             section = %nm,


### PR DESCRIPTION
## Summary

Closes #279. **-7.22 GiB idle RSS on Belgium** (16.04 → 8.82 GiB, **-45%**) by evicting non-default modes' time-metric flat sections at boot.

Each per-mode bundle loads three time-metric flats (`up_adj_flat.time`, `down_reverse_adj_flat.time`, `down_adj_flat.time`) as zero-copy `Cow::Borrowed` views. The boot CRC walk forces them resident. For workloads dominated by one mode (car for consumer routing, truck for delivery, foot for last-mile), the non-default modes' flats cost RSS for nothing.

Pick the same default mode as the exclude-flag loader (car if present, otherwise first alphabetically). `madvise(MADV_DONTNEED)` on every other mode's three time flats. Flat views remain valid (slice references over mmap'd memory); kernel demand-pages on first query of that mode.

## Bench (Belgium, baseline.butterfly, 4 modes, car-only warmup)

| Metric | main | After #279 | Delta |
|---|---|---|---|
| **VmRSS idle** | **16.04 GiB** | **8.82 GiB** | **-7.22 GiB (-45%)** |
| VmHWM (boot peak) | 19.29 GiB | 19.29 GiB | unchanged (CRC walks still happen) |
| RssAnon | 532 MiB | 604 MiB | within noise |

## Sections evicted (3 × 3 = 9 lines logged)

```
mode/bike/up_adj_flat.time            973 MiB
mode/bike/down_reverse_adj_flat.time  985 MiB
mode/bike/down_adj_flat.time          669 MiB
mode/foot/up_adj_flat.time           1146 MiB
mode/foot/down_reverse_adj_flat.time 1162 MiB
mode/foot/down_adj_flat.time          788 MiB
mode/truck/up_adj_flat.time           221 MiB
mode/truck/down_reverse_adj_flat.time 226 MiB
mode/truck/down_adj_flat.time         157 MiB
```

## Correctness + latency

- Car route p50 (default, stays hot): **6.04 ms** — unchanged
- 100 random clustered car routes diffed byte-for-byte vs known-good: **0 mismatches**
- Bike first query (cold, full page-in): **122 ms** — well under 500 ms gate
- Bike warm query: 76 ms
- Foot first query (cold, largest flats at 3.1 GB combined): **370 ms** — under 500 ms gate

## Stacking to plant-scale (4 GiB target)

This stacks orthogonally with #275 (PR #284: ways.raw + way_attrs eviction, -2.88 GiB) and #277 (PR #286: cold distance flats eviction, -6.21 GiB):

```
main:                       16.04 GiB
+ #275 (PR #284):           13.16 GiB  (-2.88 GiB)
+ #277 (PR #286):            9.83 GiB  (-3.33 GiB on top of #275)
+ #279 (this PR):            ~3-4 GiB  (-5-7 GiB on top of #275+#277)
```

The three together should land Belgium idle RSS **at or below the 4 GiB plant-scale target**. Will re-bench the full stack after all three land.

## Acceptance gates (all met)

- [x] Idle RSS, never queried truck+bike+foot: target -6-8 GiB → **-7.22 GiB**
- [x] First car query after boot: car stays hot → 6.04 ms (no first-query penalty for default mode)
- [x] Subsequent car queries: unchanged
- [x] Cross-mode query correctness: bike/foot return sensible distances
- [x] First non-default-mode query: under 500 ms gate (bike 122 ms, foot 370 ms)
- [x] Build + clippy: green

## Test plan

- [x] `cargo build --release` green
- [x] `cargo clippy --release --all-targets --all-features` green
- [x] Belgium boot + 20 car warmup routes + RSS measurement
- [x] 100 car route byte-diff vs known-good — 0 mismatches
- [x] Bike route smoke (cold + warm)
- [x] Foot route smoke (cold)

## Remaining work in the RSS chain

- #278 (quantize u32→u16 weights, -3 GiB) — still active
- #281 (perfect-hash way names) — scales to planet
- #282 (middles derivability research)