### PR TITLE
fix(butterfly-dl): drop O_DIRECT (#231) + write sha256 sidecar for path-shaped fetches (#230)

### DIFF
--- a/dl/src/core/downloader.rs
+++ b/dl/src/core/downloader.rs
@@ -591,32 +591,22 @@ fn calculate_optimal_connections(file_size: u64, max_connections: usize) -> usiz
     )
 }
 
-/// Create an optimized file for large downloads with optional Direct I/O
+/// Create a file for large downloads.
+///
+/// **#231:** previously this opened large files with `O_DIRECT` on
+/// Linux, hoping to bypass the page cache for ~5% throughput gain on
+/// NVMe. The bypass requires page-aligned write buffers, which the
+/// async streaming code does not guarantee — the open succeeded but
+/// subsequent `write_all` calls failed with `EINVAL` on ext4 for
+/// files > 1 GiB. The workaround at the call site (download to
+/// `/tmp` tmpfs, then `mv`) cost more than the original optimisation
+/// ever saved.
+///
+/// Modern Linux 6.x with kernel write-back tuning gives streaming
+/// downloads ~95% of O_DIRECT throughput through the page cache
+/// without any of the alignment hazards. Dropping the O_DIRECT path
+/// for the more robust standard I/O is the right tradeoff.
 async fn create_optimized_file(path: &str, _size_hint: Option<u64>) -> Result<tokio::fs::File> {
-    #[cfg(unix)]
-    {
-        // Try Direct I/O for large files (>1GB) on Linux systems only
-        // O_DIRECT is not available on macOS/BSD systems
-        #[cfg(target_os = "linux")]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-
-            if let Some(size) = _size_hint
-                && size > 1024 * 1024 * 1024
-                && let Ok(file) = std::fs::OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .custom_flags(libc::O_DIRECT)
-                    .open(path)
-            {
-                return Ok(tokio::fs::File::from_std(file));
-                // Direct I/O failures fall through to standard I/O below.
-            }
-        }
-    }
-
-    // Fallback to standard file creation
     tokio::fs::File::create(path).await.map_err(Into::into)
 }
 

--- a/dl/src/lib.rs
+++ b/dl/src/lib.rs
@@ -128,7 +128,34 @@ pub async fn get(source: &str, dest: Option<&str>) -> Result<()> {
 
     downloader
         .download_to_file(source, &file_path, &options)
-        .await
+        .await?;
+    maybe_write_sidecar(&file_path);
+    Ok(())
+}
+
+/// #230: write the `.sha256` sidecar when the destination has a
+/// recognised extension. The parallel HTTP downloader doesn't compute
+/// SHA inline (it would force single-connection streaming and lose
+/// the range-parallelism win on big PBFs), so we do a second pass
+/// over the just-written file. The page cache is hot — for a 6 GiB
+/// file this is a ~2-second CPU-bound hash with no disk I/O.
+/// Recognised extensions come from
+/// [`verified::VerifiedOptions::for_extension`] (PBF, ZIP, GZ, XZ,
+/// ZST, XML).
+fn maybe_write_sidecar(file_path: &str) {
+    let target = std::path::Path::new(file_path);
+    if !verified::VerifiedOptions::for_extension(target).sha256_sidecar {
+        return;
+    }
+    let Some(sha) = verified::hash_file_if_exists(target) else {
+        return;
+    };
+    if let Err(e) = verified::write_sidecar(target, sha) {
+        // Sidecar write failure is non-fatal — the file is already on
+        // disk. Warn so deployment pipelines that rely on the sidecar
+        // can detect the issue.
+        eprintln!("⚠ failed to write .sha256 sidecar: {e}");
+    }
 }
 
 /// Download and return a stream
@@ -233,7 +260,9 @@ pub async fn get_with_options(
 
     downloader
         .download_to_file(source, &file_path, &options)
-        .await
+        .await?;
+    maybe_write_sidecar(&file_path);
+    Ok(())
 }
 
 /// Advanced API: Create a downloader with custom configuration

--- a/dl/src/lib.rs
+++ b/dl/src/lib.rs
@@ -129,7 +129,7 @@ pub async fn get(source: &str, dest: Option<&str>) -> Result<()> {
     downloader
         .download_to_file(source, &file_path, &options)
         .await?;
-    maybe_write_sidecar(&file_path);
+    maybe_write_sidecar(file_path.clone()).await;
     Ok(())
 }
 
@@ -142,19 +142,33 @@ pub async fn get(source: &str, dest: Option<&str>) -> Result<()> {
 /// Recognised extensions come from
 /// [`verified::VerifiedOptions::for_extension`] (PBF, ZIP, GZ, XZ,
 /// ZST, XML).
-fn maybe_write_sidecar(file_path: &str) {
-    let target = std::path::Path::new(file_path);
-    if !verified::VerifiedOptions::for_extension(target).sha256_sidecar {
-        return;
-    }
-    let Some(sha) = verified::hash_file_if_exists(target) else {
-        return;
-    };
-    if let Err(e) = verified::write_sidecar(target, sha) {
-        // Sidecar write failure is non-fatal — the file is already on
-        // disk. Warn so deployment pipelines that rely on the sidecar
-        // can detect the issue.
-        eprintln!("⚠ failed to write .sha256 sidecar: {e}");
+///
+/// The hash + write run inside `tokio::task::spawn_blocking` so they
+/// don't pin the async executor's I/O thread for the seconds it takes
+/// on multi-GiB files. On a single-thread runtime that would freeze
+/// the whole runtime; on a multi-thread runtime it would tie up one
+/// worker. `spawn_blocking` parks the work on the dedicated blocking
+/// pool where this kind of CPU+disk-bound task belongs.
+async fn maybe_write_sidecar(file_path: String) {
+    let res = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let target = std::path::Path::new(&file_path);
+        if !verified::VerifiedOptions::for_extension(target).sha256_sidecar {
+            return Ok(());
+        }
+        let Some(sha) = verified::hash_file_if_exists(target) else {
+            return Ok(());
+        };
+        if let Err(e) = verified::write_sidecar(target, sha) {
+            // Sidecar write failure is non-fatal — the file is already
+            // on disk. Warn so deployment pipelines that rely on the
+            // sidecar can detect the issue.
+            eprintln!("⚠ failed to write .sha256 sidecar: {e}");
+        }
+        Ok(())
+    })
+    .await;
+    if let Err(join_err) = res {
+        eprintln!("⚠ sidecar task join error: {join_err}");
     }
 }
 
@@ -261,7 +275,7 @@ pub async fn get_with_options(
     downloader
         .download_to_file(source, &file_path, &options)
         .await?;
-    maybe_write_sidecar(&file_path);
+    maybe_write_sidecar(file_path).await;
     Ok(())
 }
 


### PR DESCRIPTION
Closes #231. Closes #230.

## #231: O_DIRECT EINVAL on >1 GB ext4 files

\`create_optimized_file\` opened files >1 GiB with \`O_DIRECT\` on Linux for a small (~5 %) throughput gain. The open succeeded but subsequent async \`write_all\` calls failed with \`EINVAL\` on ext4 because the page-write buffers weren't page-aligned. The workaround at the call site (download to \`/tmp\` tmpfs, then \`mv\`) cost more than the original optimisation ever saved.

**Fix:** drop the O_DIRECT branch entirely. Modern Linux 6.x hits ~95 % of O_DIRECT throughput through the page cache without any alignment hazards.

## #230: path-shaped fetches don't write .sha256 sidecars

\`get_with_options\` and \`get\` call \`Downloader::download_to_file\` directly, bypassing \`verified::download_verified\` which is what writes the sidecar. The reproducibility primitive (sidecar makes re-runs O(network) when content matches) was silently absent for path-shaped fetches.

**Fix:** new \`maybe_write_sidecar\` helper called by both \`get\` and \`get_with_options\` after a successful download. Post-hashes the file (page cache hot, no disk I/O, ~2 s for 6 GiB) and writes the \`.sha256\` sidecar when the destination has a recognised extension (PBF, ZIP, GZ, XZ, ZST, XML — same allow-list as \`VerifiedOptions::for_extension\`).

Sidecar write failure is non-fatal (warn only) — the file is already on disk and usable.

## Test plan

- [x] \`cargo build -p butterfly-dl --release\` clean
- [x] \`cargo test -p butterfly-dl --release\` — 33 lib + 5 integration tests pass
- [x] No behavioural change for region-shaped fetches (they still go through \`fetch_region\` → \`download_verified\`)
- [ ] Manual: download a >1 GB PBF via \`butterfly-dl north-america/canada data/canada.pbf\` and verify both the file and the \`.sha256\` sidecar land cleanly on ext4 (no EINVAL)