### PR TITLE
fix(route): align test_parse_car_model with #211 motorway speed tuning (#311)

### DIFF
--- a/route/src/model/schema.rs
+++ b/route/src/model/schema.rs
@@ -130,7 +130,9 @@ mod tests {
         let model: ModelSchema = serde_json::from_str(&json).unwrap();
         assert_eq!(model.name, "car");
         assert_eq!(model.version, 1);
-        assert_eq!(model.speed.highway.get("motorway"), Some(&110.0));
+        // #87 / PR #211: car motorway speed tuned 110 → 90 km/h to
+        // match OSRM car.lua raw and close the duration bias.
+        assert_eq!(model.speed.highway.get("motorway"), Some(&90.0));
         assert!(model.access.highway.get("motorway") == Some(&true));
         assert!(model.access.highway.get("footway") == Some(&false));
         assert!(model.oneway.respect);


### PR DESCRIPTION
Closes #311.

Single-line test fix. PR #211 (\`fix(route): #87 F1 speed-profile tuning to close OSRM duration bias\`) tuned car \`motorway: 110 → 90\` km/h in \`models/car.model.json\` to match OSRM car.lua raw. The test in \`route/src/model/schema.rs:133\` was not updated and still asserted 110, causing a persistent failure on main since #211 landed.

Update the assertion to 90 (the actual shipped speed) with a comment pointing at the PR.

## Test plan

- [x] \`cargo test -p butterfly-route --release -- model::schema::tests::test_parse_car_model\` passes
- [x] \`cargo build --workspace --release\` clean