### PR TITLE
chore: #309 drop geocode exclude from Cargo.toml (re-rebased after base merge)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,6 @@ members = [
     "dl",
     "route",
 ]
-# #308: butterfly-geocode excluded from the workspace pending full
-# crate removal. The geocoder was shelved in #254 (df77a93) but the
-# crate dir still exists and depends on AddressEntry / address
-# downloads in butterfly-dl that #308 strips. Excluding it from
-# `members` lets dl + route + common build cleanly; full removal is
-# tracked in #309.
-exclude = ["geocode", "geocode-data", "geocode-research", "geocode-training"]
 
 [workspace.package]
 version = "2.0.0"


### PR DESCRIPTION
## Summary

Original PR #312 got auto-closed when its base branch `chore-dl-308-strip-geocoder` was merged + deleted. This is the same commit, rebased onto main.

After #310 merged (which removed the geocode/ dirs themselves), only the workaround comment + `exclude = [...]` line in `Cargo.toml` remained. This PR removes them.

- Removes the obsolete `exclude = ["geocode", "geocode-data", "geocode-research", "geocode-training"]` workaround
- Removes the #308 explanatory comment that no longer applies

Closes #309.

## Test plan

- [x] `cargo build --workspace --release` — clean (19.27s)