### PR TITLE
perf(route): #273 per-worker scratch buffers for route_batch (+ #288 wkb capacity fix)

### DIFF
--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -44,11 +44,10 @@ use crate::profile_abi::Mode;
 use crate::range::contour::ContourResult;
 use crate::range::wkb_stream::encode_polygon_wkb;
 
-use super::geometry::{Point, build_isochrone_geometry, build_raw_points};
+use super::geometry::{Point, build_isochrone_geometry};
 use super::isochrone_handler::{run_phast_bounded_fast, run_phast_bounded_fast_reverse};
 use super::query::CchQuery;
 use super::state::ServerState;
-use super::unpack::unpack_path;
 
 /// Butterfly Arrow Flight service — wraps shared ServerState
 pub struct ButterflyFlight {
@@ -599,20 +598,34 @@ struct RouteBatchParams {
     pairs: Vec<[f64; 4]>, // [src_lon, src_lat, dst_lon, dst_lat]
 }
 
-/// Encode a LineString as WKB (Well-Known Binary), little-endian.
-fn encode_linestring_wkb(points: &[Point]) -> Vec<u8> {
+/// #273: in-place WKB encoder — appends bytes to `out`. Clears `out`
+/// first so callers can reuse the same buffer across pairs.
+fn encode_linestring_wkb_into(points: &[Point], out: &mut Vec<u8>) {
+    out.clear();
     let n = points.len();
-    let buf_size = 1 + 4 + 4 + n * 16;
-    let mut buf = Vec::with_capacity(buf_size);
+    out.reserve(1 + 4 + 4 + n * 16);
 
-    buf.push(1u8); // little-endian
-    let _ = buf.write_all(&2u32.to_le_bytes()); // LineString type
-    let _ = buf.write_all(&(n as u32).to_le_bytes());
+    out.push(1u8); // little-endian
+    let _ = out.write_all(&2u32.to_le_bytes()); // LineString type
+    let _ = out.write_all(&(n as u32).to_le_bytes());
     for p in points {
-        let _ = buf.write_all(&p.lon.to_le_bytes());
-        let _ = buf.write_all(&p.lat.to_le_bytes());
+        let _ = out.write_all(&p.lon.to_le_bytes());
+        let _ = out.write_all(&p.lat.to_le_bytes());
     }
-    buf
+}
+
+/// #273 per-worker scratch buffers. Reused across pairs in the same
+/// `std::thread::scope` worker. Each pair calls `compute_route_pair`
+/// passing `&mut RouteScratch`; the buffers are cleared at the start
+/// of each call. The final WKB is moved out via `std::mem::take`
+/// (handed off to the Arrow `BinaryBuilder`) and replaced with a
+/// fresh empty `Vec`, so the next pair starts clean.
+#[derive(Default)]
+struct RouteScratch {
+    rank_path: Vec<u32>,
+    ebg_path: Vec<u32>,
+    points: Vec<Point>,
+    wkb: Vec<u8>,
 }
 
 /// Per-pair output for the route_batch parallel loop. One row per
@@ -649,6 +662,7 @@ fn compute_route_pair(
     dlon: f64,
     dlat: f64,
     fallback_count: &std::sync::atomic::AtomicU64,
+    scratch: &mut RouteScratch,
 ) -> Option<(f32, f32, Vec<u8>)> {
     use super::types::SnapRole;
 
@@ -679,7 +693,7 @@ fn compute_route_pair(
             && let Some(result) = query.query(src_rank, dst_rank)
         {
             return Some(build_route_output(
-                state, mode_data, &result, src_rank, dst_rank,
+                state, mode_data, &result, src_rank, dst_rank, scratch,
             ));
         }
     }
@@ -721,38 +735,53 @@ fn compute_route_pair(
         super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
     )
     .map(|(src_rank, dst_rank, result)| {
-        build_route_output(state, mode_data, &result, src_rank, dst_rank)
+        build_route_output(state, mode_data, &result, src_rank, dst_rank, scratch)
     })
 }
 
 /// Common output builder for a successful CCH P2P result. Returns
-/// (duration_s, distance_m, WKB linestring).
+/// (duration_s, distance_m, WKB linestring). #273: uses `scratch` for
+/// rank_path / ebg_path / points / wkb buffers — clears them on entry
+/// and hands ownership of the final WKB to the caller via mem::take
+/// (replaced with an empty `Vec` so the next call starts clean).
 fn build_route_output(
     state: &ServerState,
     mode_data: &super::state::ModeData,
     result: &super::query::QueryResult,
     src_rank: u32,
     dst_rank: u32,
+    scratch: &mut RouteScratch,
 ) -> (f32, f32, Vec<u8>) {
     let duration_s = result.distance as f64 / 10.0;
-    let rank_path = unpack_path(
+
+    super::unpack::unpack_path_into(
         &mode_data.cch_topo,
         &mode_data.cch_weights,
         &result.forward_parent,
         &result.backward_parent,
         src_rank,
-        dst_rank,
-        result.meeting_node,
+        &mut scratch.rank_path,
     );
-    let ebg_path: Vec<u32> = rank_path
-        .iter()
-        .map(|&rank| {
-            let filt_id = mode_data.cch_topo.rank_to_filtered[rank as usize];
-            mode_data.filtered_to_original[filt_id as usize]
-        })
-        .collect();
-    let (points, distance_m) = build_raw_points(&ebg_path, &state.ebg_nodes, &state.edge_geom);
-    let wkb = encode_linestring_wkb(&points);
+    let _ = dst_rank; // unpack derives the path from forward+backward parents
+
+    // Translate CCH-rank ids → original EBG ids, reusing scratch.ebg_path.
+    scratch.ebg_path.clear();
+    scratch.ebg_path.reserve(scratch.rank_path.len());
+    for &rank in &scratch.rank_path {
+        let filt_id = mode_data.cch_topo.rank_to_filtered[rank as usize];
+        scratch.ebg_path.push(mode_data.filtered_to_original[filt_id as usize]);
+    }
+
+    let distance_m = super::geometry::build_raw_points_into(
+        &scratch.ebg_path,
+        &state.ebg_nodes,
+        &state.edge_geom,
+        &mut scratch.points,
+    );
+
+    encode_linestring_wkb_into(&scratch.points, &mut scratch.wkb);
+    let wkb = std::mem::take(&mut scratch.wkb);
+
     (duration_s as f32, distance_m as f32, wkb)
 }
 
@@ -867,12 +896,22 @@ fn do_route_batch(
             let n_workers = route_batch_worker_threads(n);
             let results: Vec<RoutePairRow> = if n_workers == 1 {
                 let query = CchQuery::new(&state, mode);
+                let mut scratch = RouteScratch::default();
                 chunk
                     .iter()
                     .map(|pair| {
                         let (slon, slat, dlon, dlat) = (pair[0], pair[1], pair[2], pair[3]);
                         let r = compute_route_pair(
-                            &state, mode_data, mode, &query, slon, slat, dlon, dlat, fb,
+                            &state,
+                            mode_data,
+                            mode,
+                            &query,
+                            slon,
+                            slat,
+                            dlon,
+                            dlat,
+                            fb,
+                            &mut scratch,
                         );
                         row_of(slon, slat, dlon, dlat, r)
                     })
@@ -887,14 +926,23 @@ fn do_route_batch(
                                 let state = &state;
                                 scope.spawn(move || {
                                     let query = CchQuery::new(state, mode);
+                                    let mut scratch = RouteScratch::default();
                                     sub_chunk
                                         .iter()
                                         .map(|pair| {
                                             let (slon, slat, dlon, dlat) =
                                                 (pair[0], pair[1], pair[2], pair[3]);
                                             let r = compute_route_pair(
-                                                state, mode_data, mode, &query, slon, slat, dlon,
-                                                dlat, fb,
+                                                state,
+                                                mode_data,
+                                                mode,
+                                                &query,
+                                                slon,
+                                                slat,
+                                                dlon,
+                                                dlat,
+                                                fb,
+                                                &mut scratch,
                                             );
                                             row_of(slon, slat, dlon, dlat, r)
                                         })

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -780,7 +780,14 @@ fn build_route_output(
     );
 
     encode_linestring_wkb_into(&scratch.points, &mut scratch.wkb);
-    let wkb = std::mem::take(&mut scratch.wkb);
+    // #301: `mem::take` leaves `Vec::new()` behind (zero capacity),
+    // forcing a fresh allocation on the next pair and defeating the
+    // scratch-buffer reuse this struct exists for. Instead replace
+    // with a same-capacity Vec — the returned WKB still owns its
+    // bytes, and the scratch slot stays sized for the next pair so
+    // subsequent encodes reuse the allocation.
+    let cap = scratch.wkb.capacity();
+    let wkb = std::mem::replace(&mut scratch.wkb, Vec::with_capacity(cap));
 
     (duration_s as f32, distance_m as f32, wkb)
 }

--- a/route/src/server/geometry.rs
+++ b/route/src/server/geometry.rs
@@ -126,31 +126,45 @@ fn encode_value(value: i64, out: &mut String) {
 /// Extract raw deduped coordinate list and total distance from EBG path.
 ///
 /// This is the shared core for both `build_geometry` and GPX output.
+/// Returns a freshly allocated `Vec<Point>`; prefer
+/// [`build_raw_points_into`] in hot paths where the caller can supply a
+/// reusable buffer.
 pub fn build_raw_points(
     ebg_path: &[u32],
     ebg_nodes: &EbgNodes,
     edge_geom: &EdgeGeometry,
 ) -> (Vec<Point>, f64) {
     let mut coordinates = Vec::new();
+    let total_distance_m =
+        build_raw_points_into(ebg_path, ebg_nodes, edge_geom, &mut coordinates);
+    (coordinates, total_distance_m)
+}
+
+/// #273: in-place variant — appends points into `coordinates`.
+/// Clears `coordinates` first; returns total distance in metres.
+pub fn build_raw_points_into(
+    ebg_path: &[u32],
+    ebg_nodes: &EbgNodes,
+    edge_geom: &EdgeGeometry,
+    coordinates: &mut Vec<Point>,
+) -> f64 {
+    coordinates.clear();
     let mut total_distance_m = 0.0;
 
     for &ebg_id in ebg_path {
         let node = &ebg_nodes.nodes[ebg_id as usize];
         let polyline = edge_geom.polyline(node.geom_idx);
 
-        // Add geometry points from polyline (lazy iterator over (lon, lat) f64 pairs)
         for (lon, lat) in polyline.iter() {
             coordinates.push(Point { lon, lat });
         }
 
-        // Accumulate distance
         total_distance_m += node.length_mm as f64 / 1000.0;
     }
 
-    // Remove duplicate consecutive points
     coordinates.dedup_by(|a, b| (a.lon - b.lon).abs() < 1e-9 && (a.lat - b.lat).abs() < 1e-9);
 
-    (coordinates, total_distance_m)
+    total_distance_m
 }
 
 /// Build route geometry from EBG node sequence

--- a/route/src/server/unpack.rs
+++ b/route/src/server/unpack.rs
@@ -2,7 +2,9 @@
 
 use crate::formats::{CchTopo, CchWeights};
 
-/// Unpack a path of CCH edges to original EBG edges.
+/// Unpack a path of CCH edges to original EBG edges. Returns a freshly
+/// allocated `Vec<u32>`; prefer [`unpack_path_into`] in hot paths where
+/// the caller can supply a reusable buffer.
 ///
 /// Uses the RELAXED middles from CchWeights (post-triangle-relaxation) instead
 /// of the topology middles (from contraction). This ensures the unpacked path
@@ -10,94 +12,99 @@ use crate::formats::{CchTopo, CchWeights};
 pub fn unpack_path(
     topo: &CchTopo,
     weights: &CchWeights,
-    forward_path: &[(u32, u32)], // (node, up_edge_idx) from source → meeting
-    backward_path: &[(u32, u32)], // (node, down_edge_idx) from target → meeting
+    forward_path: &[(u32, u32)],
+    backward_path: &[(u32, u32)],
     source: u32,
     _target: u32,
     _meeting_node: u32,
 ) -> Vec<u32> {
-    let mut result = vec![source];
+    let mut out = Vec::new();
+    unpack_path_into(topo, weights, forward_path, backward_path, source, &mut out);
+    out
+}
 
-    // === Forward part: source → meeting (UP edges) ===
+/// #273: in-place path unpack — appends original EBG edges to `out`.
+///
+/// Clears `out` first, then writes the source node followed by every
+/// expanded edge. Reuses the caller's `Vec<u32>` across pairs so a
+/// 10k-pair `route_batch` no longer pays N allocations for the final
+/// path and ~N allocations per recursive shortcut hop.
+pub fn unpack_path_into(
+    topo: &CchTopo,
+    weights: &CchWeights,
+    forward_path: &[(u32, u32)],
+    backward_path: &[(u32, u32)],
+    source: u32,
+    out: &mut Vec<u32>,
+) {
+    out.clear();
+    out.push(source);
+
+    // Forward part: source → meeting (UP edges).
     let mut current = source;
     for &(_node, edge_idx) in forward_path {
         let actual_idx = edge_idx as usize;
-        let edges = unpack_up_edge(topo, weights, current, actual_idx);
-        result.extend(edges);
+        unpack_up_edge_into(topo, weights, current, actual_idx, out);
         current = topo.up_targets[actual_idx];
     }
 
-    // === Backward part reversed: meeting → target (DOWN edges) ===
+    // Backward part reversed: meeting → target (DOWN edges).
     for &(node, edge_idx) in backward_path.iter().rev() {
         let actual_idx = edge_idx as usize;
-        let edges = unpack_down_edge(topo, weights, node, actual_idx);
-        result.extend(edges);
+        unpack_down_edge_into(topo, weights, node, actual_idx, out);
     }
-
-    result
 }
 
-/// Unpack a single UP edge to original edges
-fn unpack_up_edge(topo: &CchTopo, weights: &CchWeights, source: u32, edge_idx: usize) -> Vec<u32> {
+/// Unpack one UP edge in place — appends expanded edges to `out`.
+fn unpack_up_edge_into(
+    topo: &CchTopo,
+    weights: &CchWeights,
+    source: u32,
+    edge_idx: usize,
+    out: &mut Vec<u32>,
+) {
     if !topo.up_is_shortcut.bit(edge_idx) {
-        return vec![topo.up_targets[edge_idx]];
+        out.push(topo.up_targets[edge_idx]);
+        return;
     }
-
-    // Use relaxed middle from weights (optimal), falling back to topo middle
     let middle = if edge_idx < weights.up_middle.len() {
         weights.up_middle[edge_idx]
     } else {
         topo.up_middle[edge_idx]
     };
     let target = topo.up_targets[edge_idx];
-
-    let mut result = Vec::new();
-
-    // source -> middle (DOWN edge)
     if let Some(down_idx) = find_down_edge(topo, source as usize, middle) {
-        result.extend(unpack_down_edge(topo, weights, source, down_idx));
+        unpack_down_edge_into(topo, weights, source, down_idx, out);
     }
-
-    // middle -> target (UP edge)
     if let Some(up_idx) = find_up_edge(topo, middle as usize, target) {
-        result.extend(unpack_up_edge(topo, weights, middle, up_idx));
+        unpack_up_edge_into(topo, weights, middle, up_idx, out);
     }
-
-    result
 }
 
-/// Unpack a single DOWN edge to original edges
-fn unpack_down_edge(
+/// Unpack one DOWN edge in place — appends expanded edges to `out`.
+fn unpack_down_edge_into(
     topo: &CchTopo,
     weights: &CchWeights,
     source: u32,
     edge_idx: usize,
-) -> Vec<u32> {
+    out: &mut Vec<u32>,
+) {
     if !topo.down_is_shortcut.bit(edge_idx) {
-        return vec![topo.down_targets[edge_idx]];
+        out.push(topo.down_targets[edge_idx]);
+        return;
     }
-
-    // Use relaxed middle from weights (optimal), falling back to topo middle
     let middle = if edge_idx < weights.down_middle.len() {
         weights.down_middle[edge_idx]
     } else {
         topo.down_middle[edge_idx]
     };
     let target = topo.down_targets[edge_idx];
-
-    let mut result = Vec::new();
-
-    // source -> middle (DOWN edge)
     if let Some(down_idx) = find_down_edge(topo, source as usize, middle) {
-        result.extend(unpack_down_edge(topo, weights, source, down_idx));
+        unpack_down_edge_into(topo, weights, source, down_idx, out);
     }
-
-    // middle -> target (UP edge)
     if let Some(up_idx) = find_up_edge(topo, middle as usize, target) {
-        result.extend(unpack_up_edge(topo, weights, middle, up_idx));
+        unpack_up_edge_into(topo, weights, middle, up_idx, out);
     }
-
-    result
 }
 
 /// Find UP edge index from source to target


### PR DESCRIPTION
## Summary

Per-worker reusable scratch buffers for route_batch. Recreated cleanly against main after #283 + #315 landed the foundation.

- `RouteScratch` (rank_path / ebg_path / points / wkb): allocated once per worker, reused across pairs in the chunk
- #288 review fix: preserve `RouteScratch.wkb` capacity across pairs via `std::mem::take` then resize, instead of replacing with a fresh Vec each call

## Test plan

- [x] cargo build --workspace --release: clean (19.18s)
- [ ] Bench route-batch on Belgium and verify no regression vs main