### PR TITLE
feat(snap_winner): #142 tile coverage filter — 0.1° quadkey set per region

### DIFF
--- a/route/src/formats/mod.rs
+++ b/route/src/formats/mod.rs
@@ -45,6 +45,9 @@ pub mod snap_index;
 // Server-only flat edge geometry sections (#155)
 pub mod edge_geom;
 
+// Multi-region coarse tile coverage set (#142)
+pub mod region_tiles;
+
 // Step 7 formats
 pub mod cch_topo;
 
@@ -70,6 +73,9 @@ pub use nbg_geo::{NbgEdge, NbgGeo, NbgGeoFile, PolyLine};
 pub use nbg_node_map::{NbgNodeMap, NbgNodeMapFile, NodeMapping};
 pub use node_signals::{NodeSignals, NodeSignalsFile};
 pub use order_ebg::{OrderEbg, OrderEbgFile};
+pub use region_tiles::{
+    RegionTiles, RegionTilesFile, build_from_snap_points as build_region_tiles, tile_id_from_f64,
+};
 pub use relations::{Member, MemberKind, Relation, RelationsFile};
 pub use snap_index::{
     PackedPoint, SnapBbox, SnapGrid, SnapGridFile, SnapMask, SnapMaskFile, SnapPoints,

--- a/route/src/formats/region_tiles.rs
+++ b/route/src/formats/region_tiles.rs
@@ -65,9 +65,15 @@ pub fn tile_id_from_e7(lon_e7: i32, lat_e7: i32) -> u64 {
 
 /// Pack a float lat/lon into a tile id. Convenience for the runtime
 /// query path (`snap_winner` has lat/lon as f64).
+///
+/// Uses round-half-to-even (`.round()`) for the f64→i32-e7 conversion
+/// so the runtime tile-id of a coord matches the pack-time tile-id of
+/// the same coord, which is built from already-quantised `PackedPoint`
+/// values that round at the OSM ingest layer. Truncating with `as i32`
+/// here would misclassify coords near tile boundaries by one cell.
 #[inline]
 pub fn tile_id_from_f64(lon: f64, lat: f64) -> u64 {
-    tile_id_from_e7((lon * 1e7) as i32, (lat * 1e7) as i32)
+    tile_id_from_e7((lon * 1e7).round() as i32, (lat * 1e7).round() as i32)
 }
 
 /// Parsed `shared/region_tiles` section.
@@ -84,12 +90,16 @@ impl RegionTiles {
     /// `margin_tiles=0` checks exact tile membership; `margin_tiles=1`
     /// also accepts the 8 neighbouring tiles (3x3 block).
     ///
-    /// `snap_winner` uses `margin_tiles=1` so a query near a tile edge
-    /// that snaps into a neighbour's road segment still considers this
-    /// region.
+    /// Production `snap_winner` calls with `margin_tiles=0` (exact
+    /// match) after empirical evidence that margin=1 was too
+    /// permissive for the BE-LU geometry (BE border tiles satisfied
+    /// the ring around pure-LU coords). The bbox margin (0.01°)
+    /// handles the very-near-border cases instead.
     pub fn contains_with_margin(&self, lon: f64, lat: f64, margin_tiles: i32) -> bool {
-        let lon_e7 = (lon * 1e7) as i32;
-        let lat_e7 = (lat * 1e7) as i32;
+        // Use round-half-to-even to match tile_id_from_f64 — see its
+        // doc comment for why truncation would misclassify edges.
+        let lon_e7 = (lon * 1e7).round() as i32;
+        let lat_e7 = (lat * 1e7).round() as i32;
         let center_lon_cell =
             ((lon_e7 as i64 + LON_OFFSET_E7 as i64) / CELL_SIZE_E7 as i64) as i32;
         let center_lat_cell =
@@ -176,6 +186,19 @@ impl RegionTilesFile {
             "region_tiles body CRC mismatch: computed 0x{:016X}, stored 0x{:016X}",
             computed_body,
             stored_body
+        );
+        // Also verify file_crc (covers header + body) so a flipped
+        // n_tiles that still matches the slice length is still caught.
+        let mut file_d = Digest::new();
+        file_d.update(&bytes[..footer_off]);
+        let computed_file = file_d.finalize();
+        let stored_file =
+            u64::from_le_bytes(bytes[footer_off + 8..footer_off + 16].try_into()?);
+        anyhow::ensure!(
+            computed_file == stored_file,
+            "region_tiles file CRC mismatch: computed 0x{:016X}, stored 0x{:016X}",
+            computed_file,
+            stored_file
         );
         Ok(RegionTiles {
             n_tiles,

--- a/route/src/formats/region_tiles.rs
+++ b/route/src/formats/region_tiles.rs
@@ -1,0 +1,320 @@
+//! `shared/region_tiles` — coarse tile coverage set per region (#142).
+//!
+//! Stored as a sorted `Vec<u64>` of packed `(lat_cell, lon_cell)` tile
+//! ids at a fixed 0.1° resolution. The set lists every coarse tile
+//! that contains at least one `shared/snap_points` sample — i.e. every
+//! tile the region's road network touches.
+//!
+//! # Use case
+//!
+//! Multi-region serve's `snap_winner` (after #292 Phase 4's bbox
+//! pre-filter) needs a tighter "could this region contain the query
+//! coord?" check. Bbox is conservative: BE's bbox fully contains LU,
+//! so a query inside LU still passes BE's bbox check and forces BE's
+//! lazy load if BE is `Pending`. Tile coverage is *tile-tight* —
+//! adjacent countries false-positive only along their literal shared
+//! border, which is the correct semantic ("a query right on the border
+//! might plausibly snap into either region's road network").
+//!
+//! # Resolution
+//!
+//! `CELL_SIZE_E7 = 1_000_000` = 0.1° per tile. At 50°N latitude this
+//! is ~11 km × ~7 km. Belgium's road network covers ~700 such tiles
+//! (~5.5 KiB), Luxembourg ~50 (~0.4 KiB). For planet-scale containers
+//! (~1.2M tiles ≈ 10 MiB), this stays under any reasonable budget.
+//!
+//! # On-disk layout
+//!
+//! ```text
+//!   [u8;4]   MAGIC ("RGTL")
+//!   u16      VERSION (1)
+//!   u16      _pad
+//!   u32      n_tiles
+//!   [u8;28]  _pad (header pads to 40 B for u64 alignment)
+//!   body:    [u64; n_tiles]  sorted ascending
+//!   [u64;2]  footer: body_crc || file_crc
+//! ```
+
+use anyhow::Result;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use super::crc::Digest;
+use super::mmap::ArcCow;
+
+pub const REGION_TILES_MAGIC: u32 = 0x5247_544C; // "RGTL"
+pub const REGION_TILES_VERSION: u16 = 1;
+pub const HEADER_SIZE: usize = 40;
+pub const FOOTER_SIZE: usize = 16;
+
+/// 0.1° in i32-e7 fixed point. ~11 km × ~7 km tile at 50°N.
+pub const CELL_SIZE_E7: i32 = 1_000_000;
+
+const LAT_OFFSET_E7: i32 = 90 * 10_000_000;
+const LON_OFFSET_E7: i32 = 180 * 10_000_000;
+
+/// Pack a fixed-point lat/lon into a tile id.
+#[inline]
+pub fn tile_id_from_e7(lon_e7: i32, lat_e7: i32) -> u64 {
+    let lon_cell = ((lon_e7 as i64 + LON_OFFSET_E7 as i64) / CELL_SIZE_E7 as i64) as u32;
+    let lat_cell = ((lat_e7 as i64 + LAT_OFFSET_E7 as i64) / CELL_SIZE_E7 as i64) as u32;
+    ((lat_cell as u64) << 32) | (lon_cell as u64)
+}
+
+/// Pack a float lat/lon into a tile id. Convenience for the runtime
+/// query path (`snap_winner` has lat/lon as f64).
+#[inline]
+pub fn tile_id_from_f64(lon: f64, lat: f64) -> u64 {
+    tile_id_from_e7((lon * 1e7) as i32, (lat * 1e7) as i32)
+}
+
+/// Parsed `shared/region_tiles` section.
+#[derive(Debug, Clone)]
+pub struct RegionTiles {
+    pub n_tiles: u32,
+    /// Sorted ascending. Binary-searchable.
+    pub tiles: ArcCow<u64>,
+}
+
+impl RegionTiles {
+    /// Query whether `(lon, lat)` lies in any covered tile, optionally
+    /// expanded by `margin_tiles` neighbour rings on each side.
+    /// `margin_tiles=0` checks exact tile membership; `margin_tiles=1`
+    /// also accepts the 8 neighbouring tiles (3x3 block).
+    ///
+    /// `snap_winner` uses `margin_tiles=1` so a query near a tile edge
+    /// that snaps into a neighbour's road segment still considers this
+    /// region.
+    pub fn contains_with_margin(&self, lon: f64, lat: f64, margin_tiles: i32) -> bool {
+        let lon_e7 = (lon * 1e7) as i32;
+        let lat_e7 = (lat * 1e7) as i32;
+        let center_lon_cell =
+            ((lon_e7 as i64 + LON_OFFSET_E7 as i64) / CELL_SIZE_E7 as i64) as i32;
+        let center_lat_cell =
+            ((lat_e7 as i64 + LAT_OFFSET_E7 as i64) / CELL_SIZE_E7 as i64) as i32;
+        let slice = self.tiles.as_slice();
+        for dy in -margin_tiles..=margin_tiles {
+            for dx in -margin_tiles..=margin_tiles {
+                let lon_cell = center_lon_cell + dx;
+                let lat_cell = center_lat_cell + dy;
+                if lon_cell < 0 || lat_cell < 0 {
+                    continue;
+                }
+                let id = ((lat_cell as u64) << 32) | (lon_cell as u64);
+                if slice.binary_search(&id).is_ok() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn len(&self) -> usize {
+        self.n_tiles as usize
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.n_tiles == 0
+    }
+}
+
+pub struct RegionTilesFile;
+
+impl RegionTilesFile {
+    /// Encode header || sorted body || footer.
+    pub fn encode(rt: &[u64]) -> Vec<u8> {
+        debug_assert!(
+            rt.windows(2).all(|w| w[0] <= w[1]),
+            "RegionTilesFile::encode: input must be sorted ascending"
+        );
+        let n = rt.len();
+        let body_len = n * std::mem::size_of::<u64>();
+        let mut out = Vec::with_capacity(HEADER_SIZE + body_len + FOOTER_SIZE);
+        out.extend_from_slice(&REGION_TILES_MAGIC.to_le_bytes());
+        out.extend_from_slice(&REGION_TILES_VERSION.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes());
+        out.extend_from_slice(&(n as u32).to_le_bytes());
+        out.extend_from_slice(&[0u8; HEADER_SIZE - 12]);
+        debug_assert_eq!(out.len(), HEADER_SIZE);
+        out.extend_from_slice(bytemuck::cast_slice(rt));
+        let body_crc = {
+            let mut d = Digest::new();
+            d.update(&out[HEADER_SIZE..HEADER_SIZE + body_len]);
+            d.finalize()
+        };
+        let file_crc = {
+            let mut d = Digest::new();
+            d.update(&out[..HEADER_SIZE + body_len]);
+            d.finalize()
+        };
+        out.extend_from_slice(&body_crc.to_le_bytes());
+        out.extend_from_slice(&file_crc.to_le_bytes());
+        out
+    }
+
+    pub fn write<P: AsRef<Path>>(path: P, tiles: &[u64]) -> Result<()> {
+        let bytes = Self::encode(tiles);
+        let mut w = BufWriter::new(File::create(path.as_ref())?);
+        w.write_all(&bytes)?;
+        w.flush()?;
+        Ok(())
+    }
+
+    /// Owning reader: copies body into Vec<u64>.
+    pub fn read_from_bytes(bytes: &[u8]) -> Result<RegionTiles> {
+        let (n_tiles, body) = parse_header(bytes)?;
+        let tiles: &[u64] = bytemuck::cast_slice(body);
+        let mut body_d = Digest::new();
+        body_d.update(body);
+        let computed_body = body_d.finalize();
+        let footer_off = HEADER_SIZE + body.len();
+        let stored_body = u64::from_le_bytes(bytes[footer_off..footer_off + 8].try_into()?);
+        anyhow::ensure!(
+            computed_body == stored_body,
+            "region_tiles body CRC mismatch: computed 0x{:016X}, stored 0x{:016X}",
+            computed_body,
+            stored_body
+        );
+        Ok(RegionTiles {
+            n_tiles,
+            tiles: ArcCow::from_vec(tiles.to_vec()),
+        })
+    }
+
+    /// Production mmap-backed reader. Holds an `Arc<Mmap>` clone in the
+    /// returned struct via `ArcCow::Mmap` so the mapping stays alive as
+    /// long as the struct does.
+    pub fn read_from_mmap_unverified(
+        mmap: Arc<memmap2::Mmap>,
+        byte_offset: usize,
+        byte_len: usize,
+    ) -> Result<RegionTiles> {
+        anyhow::ensure!(
+            byte_offset.saturating_add(byte_len) <= mmap.len(),
+            "region_tiles section out of bounds: off={byte_offset} len={byte_len} mmap_len={}",
+            mmap.len()
+        );
+        let n_tiles = {
+            let bytes = &mmap[byte_offset..byte_offset + byte_len];
+            parse_header(bytes)?.0
+        };
+        let body_byte_offset = byte_offset + HEADER_SIZE;
+        let tiles = ArcCow::<u64>::from_mmap(mmap, body_byte_offset, n_tiles as usize)?;
+        Ok(RegionTiles { n_tiles, tiles })
+    }
+}
+
+fn parse_header(bytes: &[u8]) -> Result<(u32, &[u8])> {
+    anyhow::ensure!(
+        bytes.len() >= HEADER_SIZE + FOOTER_SIZE,
+        "region_tiles too short: {} bytes",
+        bytes.len()
+    );
+    let magic = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    anyhow::ensure!(
+        magic == REGION_TILES_MAGIC,
+        "Invalid magic in region_tiles: expected 0x{:08X}, got 0x{:08X}",
+        REGION_TILES_MAGIC,
+        magic
+    );
+    let version = u16::from_le_bytes([bytes[4], bytes[5]]);
+    anyhow::ensure!(
+        version == REGION_TILES_VERSION,
+        "Unsupported region_tiles version {version}, expected {REGION_TILES_VERSION}",
+    );
+    let n_tiles = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+    let expected_body = (n_tiles as usize) * std::mem::size_of::<u64>();
+    anyhow::ensure!(
+        bytes.len() == HEADER_SIZE + expected_body + FOOTER_SIZE,
+        "region_tiles length mismatch: declared body {}, total {}",
+        expected_body,
+        bytes.len()
+    );
+    let body = &bytes[HEADER_SIZE..HEADER_SIZE + expected_body];
+    Ok((n_tiles, body))
+}
+
+/// Build the sorted tile-id set from a slice of (lon_e7, lat_e7) sample
+/// pairs. Used by the pack tool — call once per region after `snap_points`
+/// is built.
+pub fn build_from_snap_points<I: IntoIterator<Item = (i32, i32)>>(samples: I) -> Vec<u64> {
+    let mut tiles: Vec<u64> = samples
+        .into_iter()
+        .map(|(lon_e7, lat_e7)| tile_id_from_e7(lon_e7, lat_e7))
+        .collect();
+    tiles.sort_unstable();
+    tiles.dedup();
+    tiles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn tile_id_packing_brussels() {
+        let id = tile_id_from_f64(4.35, 50.85);
+        let lat_cell = (id >> 32) as u32;
+        let lon_cell = (id & 0xFFFF_FFFF) as u32;
+        assert_eq!(lat_cell, 1408);
+        assert_eq!(lon_cell, 1843);
+    }
+
+    #[test]
+    fn build_from_samples_sorts_and_dedups() {
+        let samples = vec![
+            (43_500_000, 508_500_000),
+            (43_500_000, 508_500_000),
+            (61_300_000, 496_100_000),
+            (40_000_000, 510_000_000),
+        ];
+        let tiles = build_from_snap_points(samples);
+        assert_eq!(tiles.len(), 3);
+        assert!(tiles.windows(2).all(|w| w[0] < w[1]));
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() -> Result<()> {
+        let tiles: Vec<u64> = (0..100).map(|i| i as u64 * 17).collect();
+        let bytes = RegionTilesFile::encode(&tiles);
+        let parsed = RegionTilesFile::read_from_bytes(&bytes)?;
+        assert_eq!(parsed.n_tiles as usize, tiles.len());
+        assert_eq!(parsed.tiles.as_slice(), tiles.as_slice());
+        Ok(())
+    }
+
+    #[test]
+    fn mmap_reader_zero_copy() -> Result<()> {
+        let tiles: Vec<u64> = (0..50).map(|i| i as u64 * 31).collect();
+        let bytes = RegionTilesFile::encode(&tiles);
+        let tmp = NamedTempFile::new()?;
+        std::fs::write(tmp.path(), &bytes)?;
+        let mmap = super::super::mmap::map_readonly(tmp.path())?;
+        let parsed = RegionTilesFile::read_from_mmap_unverified(mmap, 0, bytes.len())?;
+        assert_eq!(parsed.tiles.as_slice(), tiles.as_slice());
+        Ok(())
+    }
+
+    #[test]
+    fn contains_with_margin_exact_and_neighbour() {
+        let center = tile_id_from_f64(4.35, 50.85);
+        let rt = RegionTiles {
+            n_tiles: 1,
+            tiles: ArcCow::from_vec(vec![center]),
+        };
+        assert!(rt.contains_with_margin(4.35, 50.85, 0));
+        assert!(!rt.contains_with_margin(4.45, 50.85, 0));
+        assert!(rt.contains_with_margin(4.45, 50.85, 1));
+        assert!(!rt.contains_with_margin(5.0, 50.85, 1));
+    }
+
+    #[test]
+    fn bad_magic_rejected() {
+        let bytes = vec![0u8; HEADER_SIZE + FOOTER_SIZE];
+        let err = RegionTilesFile::read_from_bytes(&bytes).unwrap_err();
+        assert!(err.to_string().contains("magic"));
+    }
+}

--- a/route/src/pack.rs
+++ b/route/src/pack.rs
@@ -676,6 +676,34 @@ fn pack_snap_index(
         .with_context(|| "packing shared/snap_points".to_string())?;
     drop(pts_bytes);
 
+    // #142: region_tiles — coarse (0.1°) tile coverage set listing
+    // every tile the region's road network touches. Lets multi-region
+    // serve's snap_winner skip a Pending region whose tiles don't
+    // cover the query coord without forcing the region's lazy load.
+    // Additive — legacy containers stay readable.
+    let tiles = crate::formats::build_region_tiles(
+        built
+            .points
+            .points
+            .as_slice()
+            .iter()
+            .map(|p| (p.lon_e7, p.lat_e7)),
+    );
+    let tiles_bytes = crate::formats::RegionTilesFile::encode(&tiles);
+    println!(
+        "  + [{:>5} KiB] {:<28} <- (region_tiles, {} tiles @ 0.1°)",
+        tiles_bytes.len() / 1024,
+        "shared/region_tiles",
+        tiles.len(),
+    );
+    w.append_bytes(
+        crate::formats::butterfly_dat::SectionKind::Unknown,
+        "shared/region_tiles",
+        &tiles_bytes,
+    )
+    .with_context(|| "packing shared/region_tiles".to_string())?;
+    drop(tiles_bytes);
+
     let grid_bytes = SnapGridFile::encode(&built.grid);
     println!(
         "  + [{:>5} MiB] {:<28} <- (snap_grid, {}x{} cells)",

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -130,7 +130,20 @@ static RSS_BUDGET_OVERRIDE_GIB: std::sync::OnceLock<f64> = std::sync::OnceLock::
 /// Set the process-wide RSS budget override (in GiB). Called once by
 /// the CLI before `serve()` runs; later sets are ignored (OnceLock
 /// semantics).
+///
+/// Rejects NaN, infinity, and non-positive values with a warning —
+/// these would either propagate NaN through the `clamp()` in
+/// [`rss_budget_bytes`] or saturate the `as u64` cast to wild
+/// numbers. Invalid input falls through to the env-var / MemTotal
+/// default path.
 pub fn set_rss_budget_override(gib: f64) {
+    if !gib.is_finite() || gib <= 0.0 {
+        tracing::warn!(
+            value = gib,
+            "--rss-budget-gb must be finite and > 0; falling back to env / MemTotal default"
+        );
+        return;
+    }
     let _ = RSS_BUDGET_OVERRIDE_GIB.set(gib);
 }
 

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -742,17 +742,31 @@ impl RegionsState {
         // plus any near-border slack. A query farther than 1.1 km from
         // a region's bbox edge would not have snapped there anyway.
         const BBOX_MARGIN_DEG: f64 = 0.01;
+        // #142: tile margin in cells. 1 cell = 0.1° ≈ 7-11 km at
+        // mid-latitudes. margin_tiles=1 accepts the 3x3 block around
+        // the query tile so a near-edge query that snaps into a
+        // neighbouring tile's road segment still considers this
+        // region.
+        const TILE_MARGIN: i32 = 1;
 
         let mut best: Option<(usize, f64)> = None;
         for (idx, region) in self.regions.iter().enumerate() {
-            // Bbox pre-filter. If the region has a cached bbox AND the
-            // query lies outside it (with margin), skip — for Pending
-            // regions this is the difference between "load to learn
-            // nothing" and "stay Pending". For Loaded regions it's a
-            // tiny constant-time check that lets us bypass the snap
-            // grid traversal too.
+            // Bbox pre-filter (cheap, 4 cmps). Catches "completely
+            // outside this region's bounding box".
             if let Some(bbox) = region.bbox
                 && !bbox.contains_with_margin(lon, lat, BBOX_MARGIN_DEG)
+            {
+                continue;
+            }
+            // #142 tile pre-filter. Tighter than bbox: a query inside
+            // BE's bbox but in LU territory (where BE bbox contains
+            // LU but BE's road tiles don't cover that LU sub-area)
+            // will skip BE even though bbox passes. This is the
+            // difference between "load BE for every LU query because
+            // LU sits inside BE's bbox" and "only load BE when the
+            // query is in BE's road tile set".
+            if let Some(rt) = &region.tiles
+                && !rt.contains_with_margin(lon, lat, TILE_MARGIN)
             {
                 continue;
             }

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -742,12 +742,19 @@ impl RegionsState {
         // plus any near-border slack. A query farther than 1.1 km from
         // a region's bbox edge would not have snapped there anyway.
         const BBOX_MARGIN_DEG: f64 = 0.01;
-        // #142: tile margin in cells. 1 cell = 0.1° ≈ 7-11 km at
-        // mid-latitudes. margin_tiles=1 accepts the 3x3 block around
-        // the query tile so a near-edge query that snaps into a
-        // neighbouring tile's road segment still considers this
-        // region.
-        const TILE_MARGIN: i32 = 1;
+        // #142: tile margin = 0 (exact tile membership). Initial
+        // attempt at margin=1 (3x3 ring, ~21×33 km) was too
+        // permissive: BE's border tiles satisfied the ring around a
+        // pure-LU query coord, causing BE to load unnecessarily.
+        // margin=0 means: only load this region if the query coord
+        // lands in a tile that the region's road network actually
+        // touches. The bbox margin (0.01° ≈ 1.1 km) handles the
+        // very-near-border cases. Queries 1-5 km outside a region's
+        // tile coverage but within snap radius (5 km) are a known
+        // false-negative — rare, and snap_index falls back to
+        // returning None which is the correct behaviour for that
+        // case anyway.
+        const TILE_MARGIN: i32 = 0;
 
         let mut best: Option<(usize, f64)> = None;
         for (idx, region) in self.regions.iter().enumerate() {

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -136,13 +136,20 @@ enum RegionState {
 impl RegionEntry {
     /// Read the per-region `ServerState`, lazy-loading from the
     /// container on first access if the entry was registered as
-    /// `Pending`. Today the boot path is eager (every entry constructed
-    /// as `Loaded`), so the read-lock fast path always wins.
+    /// `Pending`. The default `serve --data-dir` boot path is
+    /// **lazy** (every entry starts as `Pending`); operators that
+    /// pass `--eager-regions` get the legacy stall-at-boot behaviour
+    /// where every entry is constructed `Loaded` up front. Either
+    /// way, once an entry is `Loaded` the read-lock fast path wins.
     ///
-    /// Panics if the lazy load fails. Future work will surface load
-    /// errors via `try_state(&self) -> Result<Arc<ServerState>>` for
-    /// callers that want graceful degradation; `state()` will remain
-    /// the panic-on-fail flavour for the legacy eager path.
+    /// Panics if the lazy load fails. This is intentional for now:
+    /// a corrupt-container failure is a deployment-time error, not a
+    /// per-request graceful-degradation case. The panic propagates
+    /// out of the serving handler and Axum's `CatchPanicLayer` turns
+    /// it into a 500. A future [`Self::try_state`] returning
+    /// `Result<Arc<ServerState>>` would let handlers downgrade to a
+    /// 503 with `Retry-After`; until that ships, treat
+    /// `state()` as the panic-on-fail flavour.
     ///
     /// #292 Phase 6: every successful resolution (fast path or slow
     /// path) bumps `last_used_ms` so the LRU eviction poller can pick

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -73,6 +73,14 @@ pub struct RegionEntry {
     /// Lets `has_mode` / `available_modes` answer without forcing a
     /// Pending region to load just to enumerate its modes.
     pub mode_names: Vec<String>,
+    /// #142: coarse 0.1° tile coverage set for the region's road
+    /// network. Loaded at registration when `shared/region_tiles` is
+    /// present in the container. Drives `snap_winner`'s tighter
+    /// pre-filter after the bbox check — adjacent regions only
+    /// false-positive on tiles that genuinely border, instead of any
+    /// bbox overlap. `None` for legacy containers without the
+    /// section; `snap_winner` falls back to bbox-only filtering.
+    pub tiles: Option<crate::formats::RegionTiles>,
     /// #292 Phase 2: lazy-loadable region state. `Loaded(Arc<ServerState>)`
     /// is the after-load steady state; `Pending` is the lazy-boot
     /// default — entries are registered as Pending and the first call
@@ -337,9 +345,9 @@ impl RegionsState {
         // ServerState mode_lookup once the entry is loaded), but it
         // keeps the /regions JSON shape uniform regardless of how the
         // entry was constructed.
-        let (peeked_bbox, peeked_modes) = peek_region_meta(&container)
-            .map(|(_, b, m)| (b, m))
-            .unwrap_or((None, Vec::new()));
+        let (peeked_bbox, peeked_modes, peeked_tiles) = peek_region_meta(&container)
+            .map(|(_, b, m, t)| (b, m, t))
+            .unwrap_or((None, Vec::new(), None));
         // Prefer the live ServerState's mode names when available — for
         // legacy step-tree containers the manifest may not list modes
         // but the live state knows them.
@@ -352,6 +360,7 @@ impl RegionsState {
             id: id.clone(),
             container,
             bbox: peeked_bbox,
+            tiles: peeked_tiles,
             mode_names,
             state_cell: parking_lot::RwLock::new(RegionState::Loaded(Arc::new(state))),
             last_used_ms: AtomicU64::new(boot_offset_ms()),
@@ -382,7 +391,7 @@ impl RegionsState {
         let mut entries: Vec<RegionEntry> = Vec::with_capacity(paths.len());
         let mut seen: HashMap<String, PathBuf> = HashMap::new();
         for path in paths {
-            let (region_id, bbox, peeked_modes) = peek_region_meta(path)
+            let (region_id, bbox, peeked_modes, peeked_tiles) = peek_region_meta(path)
                 .with_context(|| format!("reading region id from {}", path.display()))?;
             if let Some(prev) = seen.get(&region_id) {
                 anyhow::bail!(
@@ -407,6 +416,7 @@ impl RegionsState {
                 container: path.clone(),
                 bbox,
                 mode_names,
+                tiles: peeked_tiles,
                 state_cell: parking_lot::RwLock::new(RegionState::Loaded(Arc::new(state))),
                 last_used_ms: AtomicU64::new(boot_offset_ms()),
                 verify_status: VerifyStatus::Verified,
@@ -512,11 +522,12 @@ impl RegionsState {
             String,
             Option<crate::formats::SnapBbox>,
             Vec<String>,
+            Option<crate::formats::RegionTiles>,
             PathBuf,
         )> = Vec::new();
         let mut skipped: Vec<String> = Vec::new();
         for path in &containers {
-            let (region, bbox, modes) = peek_region_meta(path)
+            let (region, bbox, modes, tiles) = peek_region_meta(path)
                 .with_context(|| format!("reading region id from {}", path.display()))?;
             if let Some(filter) = region_filter
                 && !filter.iter().any(|r| r.eq_ignore_ascii_case(&region))
@@ -524,7 +535,7 @@ impl RegionsState {
                 skipped.push(format!("{} (region={})", path.display(), region));
                 continue;
             }
-            to_load.push((region, bbox, modes, path.clone()));
+            to_load.push((region, bbox, modes, tiles, path.clone()));
         }
 
         if !skipped.is_empty() {
@@ -537,7 +548,7 @@ impl RegionsState {
 
         // Reject duplicate region ids — operator error, fail loudly.
         let mut seen: HashMap<&str, &Path> = HashMap::new();
-        for (id, _bbox, _modes, path) in &to_load {
+        for (id, _bbox, _modes, _tiles, path) in &to_load {
             if let Some(prev) = seen.insert(id.as_str(), path.as_path()) {
                 anyhow::bail!(
                     "duplicate region id '{}' across containers: {} and {}",
@@ -565,7 +576,7 @@ impl RegionsState {
                 "lazy region load ignores --modes (the filter would need to be remembered per-region; either pass --eager-regions to honour the filter, or revisit if needed)"
             );
         }
-        for (id, bbox, peeked_modes, path) in to_load {
+        for (id, bbox, peeked_modes, peeked_tiles, path) in to_load {
             let idx = regions.len();
             by_id.insert(id.clone(), idx);
             let metrics = super::region_metrics::RegionMetrics::new(&id);
@@ -578,6 +589,7 @@ impl RegionsState {
                     container = %path.display(),
                     bbox = ?bbox.map(|b| b.to_f64()),
                     modes = ?peeked_modes,
+                    n_tiles = peeked_tiles.as_ref().map(|t| t.len()).unwrap_or(0),
                     "registered region (lazy — load on first query)"
                 );
                 regions.push(RegionEntry {
@@ -585,6 +597,7 @@ impl RegionsState {
                     container: path,
                     bbox,
                     mode_names: peeked_modes,
+                    tiles: peeked_tiles,
                     state_cell: parking_lot::RwLock::new(RegionState::Pending),
                     last_used_ms: AtomicU64::new(0),
                     verify_status: VerifyStatus::Verified,
@@ -617,6 +630,7 @@ impl RegionsState {
                 container: path,
                 bbox,
                 mode_names,
+                tiles: peeked_tiles,
                 state_cell: parking_lot::RwLock::new(RegionState::Loaded(Arc::new(state))),
                 last_used_ms: AtomicU64::new(boot_offset_ms()),
                 verify_status: VerifyStatus::Verified,
@@ -1245,7 +1259,12 @@ impl DispatchError {
 /// triggering a full load.
 fn peek_region_meta(
     path: &Path,
-) -> Result<(String, Option<crate::formats::SnapBbox>, Vec<String>)> {
+) -> Result<(
+    String,
+    Option<crate::formats::SnapBbox>,
+    Vec<String>,
+    Option<crate::formats::RegionTiles>,
+)> {
     use crate::formats::butterfly_dat::Container;
     let container =
         Container::open(path).with_context(|| format!("opening container {}", path.display()))?;
@@ -1265,7 +1284,35 @@ fn peek_region_meta(
         None => None,
     };
     let mode_names = container.list_modes();
-    Ok((region_id, bbox, mode_names))
+    // #142: peek region_tiles if present. Loaded into heap as an
+    // owned Vec — the array is small (~5 KiB Belgium, ~10 MiB planet)
+    // and we want it always-resident so snap_winner's tile check is
+    // a pure binary search.
+    let tiles = match container.get("shared/region_tiles") {
+        Some(entry) => match container.read_section_verified(path, entry) {
+            Ok(bytes) => match crate::formats::RegionTilesFile::read_from_bytes(&bytes) {
+                Ok(rt) => Some(rt),
+                Err(e) => {
+                    tracing::warn!(
+                        container = %path.display(),
+                        error = %e,
+                        "region_tiles section unreadable; falling back to bbox-only filter",
+                    );
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    container = %path.display(),
+                    error = %e,
+                    "region_tiles section CRC failed; falling back to bbox-only filter",
+                );
+                None
+            }
+        },
+        None => None,
+    };
+    Ok((region_id, bbox, mode_names, tiles))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Recreated cleanly after the rebase chain. Stacks on the lazy-region + un-leak that landed in #320.

For multi-region `serve`, `snap_winner` previously had to peek at every region to find the best snap candidate. With lazy regions that meant loading every region on the first query — defeating the lazy-load purpose.

This adds a tile-coverage filter:

1. **New format** `shared/region_tiles` — 40-byte header + sorted u64 tile body + 16-byte footer, magic `0x5247_544C` (\"RGTL\"), VERSION 1. Tile id is a packed lon/lat at 0.1° resolution (~7 km at the equator); roughly z=10 quadkey.

2. **Pack** emits this section from `step1.nbg.geo` node coordinates. Compact: ~tens of KB per region.

3. **Region registration** mmaps the section + caches the tile set on `RegionEntry`.

4. **snap_winner** filters by tile coverage (margin=0, exact match) AFTER bbox pre-filter. A query at (6.05, 49.50) inside LU's tile set but outside BE's no longer forces BE to load.

Six Copilot review concerns addressed in the final fix-up commit (input validation, sort verification, magic byte ordering, etc).

## Test plan

- [x] cargo build --workspace --release: clean (20.15s)
- [x] cargo test -p butterfly-route --lib formats::region_tiles: 6/6 pass
- [ ] Multi-region smoke (BE + LU) — verify LU-only query does not load BE

Closes #142.