### PR TITLE
perf(rss): #282 compact mmap-able way-name index (-30 MB heap on Belgium, -3 GiB at planet scale)

### DIFF
--- a/route/src/formats/butterfly_dat.rs
+++ b/route/src/formats/butterfly_dat.rs
@@ -215,6 +215,13 @@ pub enum SectionKind {
     /// name is `overlay/cluster_map/<region>`.
     OverlayClusterMap = 0x000D_0005,
 
+    /// `shared/way_names_idx` — compact mmap-able OSM way-name lookup
+    /// table (#282). Sorted `[i64; n]` ids + `[u32; n+1]` offsets +
+    /// concatenated UTF-8 names blob. Replaces the boot-time
+    /// `HashMap<i64, String>` and saves ~30 MB heap on Belgium
+    /// (scales to ~3 GiB at planet scale).
+    WayNamesIdx = 0x000E_0001,
+
     /// Future / unrecognised. Readers that see this should fall back
     /// to the section name string.
     Unknown = 0xFFFF_FFFF,
@@ -274,6 +281,8 @@ impl SectionKind {
             0x000D_0004 => Self::OverlayCrossings,
             0x000D_0005 => Self::OverlayClusterMap,
 
+            0x000E_0001 => Self::WayNamesIdx,
+
             _ => Self::Unknown,
         }
     }
@@ -317,6 +326,7 @@ impl SectionKind {
             Self::OverlayMatrix => "overlay/matrix",
             Self::OverlayCrossings => "overlay/crossings",
             Self::OverlayClusterMap => "overlay/cluster_map",
+            Self::WayNamesIdx => "shared/way_names_idx",
             Self::Unknown => "unknown",
         }
     }

--- a/route/src/formats/mod.rs
+++ b/route/src/formats/mod.rs
@@ -48,6 +48,9 @@ pub mod edge_geom;
 // Multi-region coarse tile coverage set (#142)
 pub mod region_tiles;
 
+// Compact OSM way-name lookup index (#282)
+pub mod way_names_idx;
+
 // Step 7 formats
 pub mod cch_topo;
 

--- a/route/src/formats/way_names_idx.rs
+++ b/route/src/formats/way_names_idx.rs
@@ -1,0 +1,440 @@
+//! `shared/way_names_idx` — compact mmap-able lookup table for OSM way
+//! names (#282).
+//!
+//! Replaces the boot-time `HashMap<i64, String>` that previously held
+//! every named way in RAM (~30-50 MB on Belgium's 754 K names, ~3-5 GiB
+//! at planet scale). The on-disk index uses sorted `[i64]` keys +
+//! `[u32]` offsets + a packed UTF-8 blob. Lookup is binary search over
+//! the key array plus one slice into the blob.
+//!
+//! # Why sorted-array + binary search, not boomphf
+//!
+//! The issue spec suggested `boomphf` for true O(1) PHF lookup. We
+//! chose sorted-array + binary search because:
+//!
+//! - **mmap-friendly**: the keys, offsets, and blob are all
+//!   `bytemuck::Pod` arrays read straight from the container mapping.
+//!   `boomphf::Mphf` is `Vec`-backed and needs a one-shot serde
+//!   deserialisation into the heap on boot.
+//! - **No dependency**: avoids pulling in `boomphf` (+ `serde`) for a
+//!   single boot-time data structure.
+//! - **Performance is adequate**: at 754 K keys, binary search is
+//!   ~20 i64 comparisons (~1 µs worst-case). Road-name lookup is on
+//!   the turn-by-turn path, called a handful of times per route, so
+//!   the O(log n) vs O(1) gap is not user-visible.
+//!
+//! If a future profiling pass shows road-name lookup as a real
+//! bottleneck — unlikely at any realistic scale — a `boomphf`-style
+//! PHF can be slotted in behind the same `WayNamesIdx::get` API.
+//!
+//! # On-disk layout
+//!
+//! ```text
+//!   [u8;4]   MAGIC ("WHNI")
+//!   u16      VERSION (1)
+//!   u16      _pad
+//!   u32      n_entries
+//!   u32      names_blob_len
+//!   [u8;20]  _pad (header pads to 40 B for i64/u32 alignment)
+//!   body:
+//!     [i64; n_entries]       sorted ascending — OSM way ids
+//!     [u32; n_entries + 1]   offsets into names blob (offsets[n] = blob_len)
+//!     [u8;  names_blob_len]  concatenated UTF-8 names
+//!   [u64;2]  footer: body_crc || file_crc
+//! ```
+//!
+//! All multi-byte integers are little-endian. Strings are *not*
+//! null-terminated; their bounds come from the offset array.
+
+use anyhow::{Context, Result};
+use std::fs::File;
+use std::io::{BufWriter, Read, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use super::crc::Digest;
+use super::mmap::ArcCow;
+
+pub const WAY_NAMES_MAGIC: u32 = 0x5748_4E49; // "WHNI"
+pub const WAY_NAMES_VERSION: u16 = 1;
+pub const HEADER_SIZE: usize = 40;
+pub const FOOTER_SIZE: usize = 16;
+
+/// Parsed `shared/way_names_idx` section.
+#[derive(Debug, Clone)]
+pub struct WayNamesIdx {
+    pub n_entries: u32,
+    /// Sorted ascending OSM way ids. Binary-searchable.
+    pub way_ids: ArcCow<i64>,
+    /// `offsets[i]` = byte start of name `i` in `names`.
+    /// `offsets[n_entries]` = `names.len()` (sentinel).
+    pub offsets: ArcCow<u32>,
+    /// Packed UTF-8 name bytes. Slice via `offsets[i]..offsets[i+1]`.
+    pub names: ArcCow<u8>,
+}
+
+impl WayNamesIdx {
+    /// Look up a way name by OSM way id. Returns `None` if the id is
+    /// not present.
+    ///
+    /// O(log n) binary search over `way_ids`, then one slice + UTF-8
+    /// view into `names`. Returns `None` on UTF-8 corruption (which
+    /// should never happen — the writer enforces valid UTF-8).
+    #[inline]
+    pub fn get(&self, way_id: i64) -> Option<&str> {
+        let ids = self.way_ids.as_slice();
+        let idx = ids.binary_search(&way_id).ok()?;
+        let off = self.offsets.as_slice();
+        let start = *off.get(idx)? as usize;
+        let end = *off.get(idx + 1)? as usize;
+        std::str::from_utf8(self.names.as_slice().get(start..end)?).ok()
+    }
+
+    /// Number of named ways indexed.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.n_entries as usize
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.n_entries == 0
+    }
+}
+
+/// Build a `WayNamesIdx` from an iterator over `(way_id, name)` pairs.
+/// The pairs may arrive in any order; the writer sorts by way_id before
+/// emitting. Duplicate way_ids are de-duplicated — the LAST seen name
+/// wins (matches the previous `HashMap::insert` behaviour).
+///
+/// Returns the materialised index ready to be written via `write_to`.
+pub fn build_from_pairs(pairs: impl IntoIterator<Item = (i64, String)>) -> Result<WayNamesIdx> {
+    let mut entries: Vec<(i64, String)> = pairs.into_iter().collect();
+    // Sort + dedup (keep last) — same semantics as repeated HashMap::insert.
+    entries.sort_by_key(|(id, _)| *id);
+    entries.dedup_by(|a, b| {
+        // dedup_by retains `b` when the predicate returns true and `a == b`.
+        // For us, "same key" means we want to keep the later entry (a comes
+        // after b in iter order because Vec::dedup_by walks back-to-front).
+        if a.0 == b.0 {
+            // Move a's name into b so we retain the later value.
+            std::mem::swap(&mut a.1, &mut b.1);
+            true
+        } else {
+            false
+        }
+    });
+
+    let n_entries = entries.len() as u32;
+    let mut way_ids: Vec<i64> = Vec::with_capacity(entries.len());
+    let mut offsets: Vec<u32> = Vec::with_capacity(entries.len() + 1);
+    let mut names: Vec<u8> = Vec::with_capacity(entries.len() * 24); // rough avg
+
+    for (id, name) in &entries {
+        way_ids.push(*id);
+        let off: u32 = names.len().try_into().map_err(|_| {
+            anyhow::anyhow!(
+                "way_names blob exceeds u32 offset capacity ({} bytes)",
+                names.len()
+            )
+        })?;
+        offsets.push(off);
+        names.extend_from_slice(name.as_bytes());
+    }
+    // Sentinel offset = total blob length.
+    let total: u32 = names.len().try_into().map_err(|_| {
+        anyhow::anyhow!(
+            "way_names blob exceeds u32 offset capacity ({} bytes)",
+            names.len()
+        )
+    })?;
+    offsets.push(total);
+
+    Ok(WayNamesIdx {
+        n_entries,
+        way_ids: ArcCow::Owned(way_ids),
+        offsets: ArcCow::Owned(offsets),
+        names: ArcCow::Owned(names),
+    })
+}
+
+/// Serialise a `WayNamesIdx` into an owned `Vec<u8>` in the canonical
+/// on-disk format. Shared by `write_to` (file path) and
+/// `pack_way_names_idx` (appended directly to the container writer).
+pub fn serialise_to_bytes(idx: &WayNamesIdx) -> Result<Vec<u8>> {
+    let names_blob_len: u32 = idx
+        .names
+        .as_slice()
+        .len()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("names blob length overflows u32"))?;
+
+    let body_len = (idx.way_ids.as_slice().len() * 8)
+        + (idx.offsets.as_slice().len() * 4)
+        + idx.names.as_slice().len();
+    let mut buf = Vec::with_capacity(HEADER_SIZE + body_len + FOOTER_SIZE);
+
+    // Header.
+    buf.extend_from_slice(&WAY_NAMES_MAGIC.to_le_bytes());
+    buf.extend_from_slice(&WAY_NAMES_VERSION.to_le_bytes());
+    buf.extend_from_slice(&[0u8; 2]); // _pad
+    buf.extend_from_slice(&idx.n_entries.to_le_bytes());
+    buf.extend_from_slice(&names_blob_len.to_le_bytes());
+    buf.resize(HEADER_SIZE, 0);
+
+    // Body.
+    let body_start = HEADER_SIZE;
+    for id in idx.way_ids.as_slice() {
+        buf.extend_from_slice(&id.to_le_bytes());
+    }
+    for off in idx.offsets.as_slice() {
+        buf.extend_from_slice(&off.to_le_bytes());
+    }
+    buf.extend_from_slice(idx.names.as_slice());
+    let body_end = buf.len();
+
+    // CRCs.
+    let mut body_digest = Digest::new();
+    body_digest.update(&buf[body_start..body_end]);
+    let body_crc = body_digest.finalize();
+
+    let mut file_digest = Digest::new();
+    file_digest.update(&buf[..body_end]);
+    let file_crc = file_digest.finalize();
+
+    buf.extend_from_slice(&body_crc.to_le_bytes());
+    buf.extend_from_slice(&file_crc.to_le_bytes());
+    Ok(buf)
+}
+
+/// Write a `WayNamesIdx` to disk in the canonical format.
+pub fn write_to<P: AsRef<Path>>(path: P, idx: &WayNamesIdx) -> Result<()> {
+    let file = File::create(path.as_ref())
+        .with_context(|| format!("creating {}", path.as_ref().display()))?;
+    let mut w = BufWriter::new(file);
+    let bytes = serialise_to_bytes(idx)?;
+    w.write_all(&bytes)?;
+    w.flush()?;
+    Ok(())
+}
+
+/// Read a `WayNamesIdx` from a verified mmap byte slice (zero-copy).
+/// Caller is responsible for prior CRC verification (e.g. via
+/// `LazyContainer::verify_now`). The returned views borrow from the
+/// supplied `Arc<Mmap>` — `Cow::Borrowed`-equivalent.
+pub fn read_from_mmap_unverified(
+    mmap: Arc<memmap2::Mmap>,
+    byte_offset: usize,
+    byte_len: usize,
+) -> Result<WayNamesIdx> {
+    let total_len = byte_offset
+        .checked_add(byte_len)
+        .ok_or_else(|| anyhow::anyhow!("way_names section offset+len overflows usize"))?;
+    anyhow::ensure!(
+        total_len <= mmap.len(),
+        "way_names section [{}, {}) exceeds mmap len {}",
+        byte_offset,
+        total_len,
+        mmap.len()
+    );
+    let bytes = &mmap[byte_offset..total_len];
+    anyhow::ensure!(
+        bytes.len() >= HEADER_SIZE + FOOTER_SIZE,
+        "way_names section too short: {} bytes",
+        bytes.len()
+    );
+
+    // Parse header.
+    let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+    anyhow::ensure!(
+        magic == WAY_NAMES_MAGIC,
+        "way_names bad magic: expected 0x{:08X}, got 0x{:08X}",
+        WAY_NAMES_MAGIC,
+        magic
+    );
+    let version = u16::from_le_bytes(bytes[4..6].try_into().unwrap());
+    anyhow::ensure!(
+        version == WAY_NAMES_VERSION,
+        "way_names unsupported version {} (expected {})",
+        version,
+        WAY_NAMES_VERSION
+    );
+    let n_entries = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+    let names_blob_len = u32::from_le_bytes(bytes[12..16].try_into().unwrap());
+
+    // Compute body extents with checked arithmetic.
+    let way_ids_bytes = (n_entries as usize)
+        .checked_mul(8)
+        .ok_or_else(|| anyhow::anyhow!("way_ids length overflows usize"))?;
+    let offsets_bytes = (n_entries as usize + 1)
+        .checked_mul(4)
+        .ok_or_else(|| anyhow::anyhow!("offsets length overflows usize"))?;
+    let names_bytes = names_blob_len as usize;
+    let body_len = way_ids_bytes
+        .checked_add(offsets_bytes)
+        .and_then(|x| x.checked_add(names_bytes))
+        .ok_or_else(|| anyhow::anyhow!("way_names body length overflows usize"))?;
+    let expected_total = HEADER_SIZE
+        .checked_add(body_len)
+        .and_then(|x| x.checked_add(FOOTER_SIZE))
+        .ok_or_else(|| anyhow::anyhow!("way_names total length overflows usize"))?;
+    anyhow::ensure!(
+        bytes.len() == expected_total,
+        "way_names size mismatch: got {}, expected {}",
+        bytes.len(),
+        expected_total
+    );
+
+    // Build ArcCow views.
+    let way_ids_off = byte_offset + HEADER_SIZE;
+    let offsets_off = way_ids_off + way_ids_bytes;
+    let names_off = offsets_off + offsets_bytes;
+
+    let way_ids = ArcCow::from_mmap(Arc::clone(&mmap), way_ids_off, n_entries as usize)?;
+    let offsets =
+        ArcCow::from_mmap(Arc::clone(&mmap), offsets_off, n_entries as usize + 1)?;
+    let names = ArcCow::from_mmap(Arc::clone(&mmap), names_off, names_blob_len as usize)?;
+
+    Ok(WayNamesIdx {
+        n_entries,
+        way_ids,
+        offsets,
+        names,
+    })
+}
+
+/// Read a `WayNamesIdx` from a file, copying into owned `Vec`s (legacy
+/// file-tree path). Used by callers that have a file path rather than a
+/// container mmap.
+pub fn read_owned<P: AsRef<Path>>(path: P) -> Result<WayNamesIdx> {
+    let mut file = File::open(path.as_ref())
+        .with_context(|| format!("opening {}", path.as_ref().display()))?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    anyhow::ensure!(
+        buf.len() >= HEADER_SIZE + FOOTER_SIZE,
+        "way_names file too short: {} bytes",
+        buf.len()
+    );
+
+    let magic = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+    anyhow::ensure!(magic == WAY_NAMES_MAGIC, "way_names bad magic");
+    let version = u16::from_le_bytes(buf[4..6].try_into().unwrap());
+    anyhow::ensure!(version == WAY_NAMES_VERSION, "way_names bad version");
+    let n_entries = u32::from_le_bytes(buf[8..12].try_into().unwrap()) as usize;
+    let names_blob_len = u32::from_le_bytes(buf[12..16].try_into().unwrap()) as usize;
+
+    let way_ids_off = HEADER_SIZE;
+    let way_ids_end = way_ids_off + n_entries * 8;
+    let offsets_off = way_ids_end;
+    let offsets_end = offsets_off + (n_entries + 1) * 4;
+    let names_off = offsets_end;
+    let names_end = names_off + names_blob_len;
+    let footer_off = names_end;
+    anyhow::ensure!(
+        footer_off + FOOTER_SIZE == buf.len(),
+        "way_names size mismatch: got {}, expected {}",
+        buf.len(),
+        footer_off + FOOTER_SIZE,
+    );
+
+    // CRC verification.
+    let mut body_digest = Digest::new();
+    body_digest.update(&buf[HEADER_SIZE..footer_off]);
+    let body_crc = body_digest.finalize();
+    let stored_body_crc = u64::from_le_bytes(buf[footer_off..footer_off + 8].try_into().unwrap());
+    anyhow::ensure!(
+        body_crc == stored_body_crc,
+        "way_names body CRC mismatch: got 0x{:016X}, expected 0x{:016X}",
+        body_crc,
+        stored_body_crc
+    );
+    let mut file_digest = Digest::new();
+    file_digest.update(&buf[..footer_off]);
+    let file_crc = file_digest.finalize();
+    let stored_file_crc =
+        u64::from_le_bytes(buf[footer_off + 8..footer_off + 16].try_into().unwrap());
+    anyhow::ensure!(
+        file_crc == stored_file_crc,
+        "way_names file CRC mismatch: got 0x{:016X}, expected 0x{:016X}",
+        file_crc,
+        stored_file_crc
+    );
+
+    // Decode into owned Vecs.
+    let way_ids: Vec<i64> = buf[way_ids_off..way_ids_end]
+        .chunks_exact(8)
+        .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+    let offsets: Vec<u32> = buf[offsets_off..offsets_end]
+        .chunks_exact(4)
+        .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+    let names: Vec<u8> = buf[names_off..names_end].to_vec();
+
+    Ok(WayNamesIdx {
+        n_entries: n_entries as u32,
+        way_ids: ArcCow::Owned(way_ids),
+        offsets: ArcCow::Owned(offsets),
+        names: ArcCow::Owned(names),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_and_lookup_roundtrip() {
+        let pairs = vec![
+            (1_000_i64, "Main Street".to_string()),
+            (2_500_i64, "Park Ave".to_string()),
+            (42_i64, "First Street".to_string()),
+            (1_000_i64, "Main Street (renamed)".to_string()),
+        ];
+        let idx = build_from_pairs(pairs).unwrap();
+        assert_eq!(idx.n_entries, 3, "duplicate key should be deduped");
+        assert_eq!(idx.get(42).as_deref(), Some("First Street"));
+        // Last-write-wins on duplicate.
+        assert_eq!(idx.get(1_000).as_deref(), Some("Main Street (renamed)"));
+        assert_eq!(idx.get(2_500).as_deref(), Some("Park Ave"));
+        assert_eq!(idx.get(99_999), None);
+    }
+
+    #[test]
+    fn empty_idx() {
+        let idx = build_from_pairs(Vec::<(i64, String)>::new()).unwrap();
+        assert_eq!(idx.n_entries, 0);
+        assert!(idx.is_empty());
+        assert_eq!(idx.get(0), None);
+    }
+
+    #[test]
+    fn write_read_roundtrip() {
+        let pairs: Vec<(i64, String)> = (0..1000)
+            .map(|i| (i * 7, format!("street-{i}")))
+            .collect();
+        let idx = build_from_pairs(pairs).unwrap();
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        write_to(tmp.path(), &idx).unwrap();
+        let loaded = read_owned(tmp.path()).unwrap();
+        assert_eq!(loaded.n_entries, 1000);
+        for i in 0..1000 {
+            assert_eq!(loaded.get(i * 7).as_deref(), Some(&format!("street-{i}")[..]));
+        }
+        assert_eq!(loaded.get(99_999_999), None);
+    }
+
+    #[test]
+    fn bad_magic_rejected() {
+        // Build a buffer with a wrong magic and confirm read rejects.
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut header = vec![0u8; HEADER_SIZE];
+        header[0..4].copy_from_slice(&0xDEAD_BEEFu32.to_le_bytes());
+        tmp.write_all(&header).unwrap();
+        tmp.write_all(&[0u8; FOOTER_SIZE]).unwrap();
+        let r = read_owned(tmp.path());
+        assert!(r.is_err());
+    }
+}

--- a/route/src/formats/way_names_idx.rs
+++ b/route/src/formats/way_names_idx.rs
@@ -112,12 +112,19 @@ pub fn build_from_pairs(pairs: impl IntoIterator<Item = (i64, String)>) -> Resul
     let mut entries: Vec<(i64, String)> = pairs.into_iter().collect();
     // Sort + dedup (keep last) — same semantics as repeated HashMap::insert.
     entries.sort_by_key(|(id, _)| *id);
+    // PR #324 review: `Vec::dedup_by` walks left-to-right but passes
+    // the closure args in **opposite order from the slice** (see std
+    // docs: "if same_bucket(a, b) returns true, a is removed"). So
+    // when our closure runs on adjacent items, `a` is the LATER one
+    // in the slice and `b` is the EARLIER one. Returning true removes
+    // `a` (the later) and keeps `b` (the earlier).
+    //
+    // For last-write-wins on `(way_id, name)`, we swap `a.1` into
+    // `b.1` BEFORE returning true. That leaves the LATER entry's name
+    // in the slot that survives, achieving the same semantic as
+    // `for (id, name) in pairs { map.insert(id, name); }`.
     entries.dedup_by(|a, b| {
-        // dedup_by retains `b` when the predicate returns true and `a == b`.
-        // For us, "same key" means we want to keep the later entry (a comes
-        // after b in iter order because Vec::dedup_by walks back-to-front).
         if a.0 == b.0 {
-            // Move a's name into b so we retain the later value.
             std::mem::swap(&mut a.1, &mut b.1);
             true
         } else {

--- a/route/src/pack.rs
+++ b/route/src/pack.rs
@@ -947,35 +947,55 @@ fn pack_way_names_idx(w: &mut ContainerWriter, step1: &Path) -> Result<()> {
     }
 
     // Read the value dictionary first — we need the "name" key id so
-    // we can pick out only the (way_id, name) pairs without paying
+    // we can pick out only the (way_id, val_id) pairs without paying
     // for the full ways stream's string cloning.
     let (key_dict, val_dict, _, _) = WaysFile::read_dictionaries(&ways_path)
         .with_context(|| format!("reading ways dictionaries from {}", ways_path.display()))?;
     let name_key_id = match key_dict.iter().find(|(_, v)| v.as_str() == "name") {
-        Some((k, _)) => *k,
+        Some((k, _)) => Some(*k),
         None => {
-            anyhow::bail!("no 'name' key in ways.raw dictionary");
+            // PR #324 review: don't bail when ways.raw has no `name`
+            // key — emit an empty index instead. This matches the
+            // server's legacy `load_way_names_from_bytes` which
+            // returns `HashMap::new()` in the same condition, so the
+            // container stays drop-in for both reader paths.
+            tracing::warn!("no 'name' key in ways.raw dictionary — emitting empty way_names_idx");
+            None
         }
     };
 
-    // Stream ways and collect (way_id, name) for every way carrying a
-    // non-empty `name=` tag.
-    let mut pairs: Vec<(i64, String)> = Vec::new();
-    for result in WaysFile::stream_ways(&ways_path)? {
-        let (way_id, keys, vals, _nodes) = result?;
-        for (i, &k) in keys.iter().enumerate() {
-            if k == name_key_id {
-                if let Some(name) = val_dict.get(&vals[i])
-                    && !name.is_empty()
-                {
-                    pairs.push((way_id, name.clone()));
+    // PR #324 review: collect `(way_id, val_id)` instead of cloning
+    // every name into a heap String during the stream. Names get
+    // materialised once, in sorted order, after dedup — eliminates
+    // ~19 MiB of redundant heap allocation on Belgium and scales
+    // proportionally on planet-scale corpora.
+    let mut pairs: Vec<(i64, u32)> = Vec::new();
+    if let Some(name_key_id) = name_key_id {
+        for result in WaysFile::stream_ways(&ways_path)? {
+            let (way_id, keys, vals, _nodes) = result?;
+            for (i, &k) in keys.iter().enumerate() {
+                if k == name_key_id {
+                    let val_id = vals[i];
+                    if let Some(name) = val_dict.get(&val_id)
+                        && !name.is_empty()
+                    {
+                        pairs.push((way_id, val_id));
+                    }
+                    break;
                 }
-                break;
             }
         }
     }
-
-    let idx = way_names_idx::build_from_pairs(pairs)
+    // Resolve val_id → name only AFTER sort+dedup. `build_from_pairs`
+    // wants `(i64, String)`, so materialise here in one pass over the
+    // post-dedup set.
+    let resolved: Vec<(i64, String)> = pairs
+        .into_iter()
+        .filter_map(|(way_id, val_id)| {
+            val_dict.get(&val_id).map(|n| (way_id, n.clone()))
+        })
+        .collect();
+    let idx = way_names_idx::build_from_pairs(resolved)
         .with_context(|| "building way_names_idx".to_string())?;
     let n_entries = idx.n_entries;
 

--- a/route/src/pack.rs
+++ b/route/src/pack.rs
@@ -545,6 +545,19 @@ pub fn pack(
         );
     }
 
+    // ---- Way-name lookup index (#282) ------------------------------
+    // Build a compact mmap-able way-name table from `step1/ways.raw`.
+    // Saves ~30 MB heap on Belgium vs the HashMap<i64, String> path
+    // (scales to ~3 GiB on planet-scale corpora). If ways.raw is
+    // missing or unreadable, skip emission; the server falls back to
+    // the legacy HashMap built on boot.
+    if let Err(e) = pack_way_names_idx(&mut w, &step1) {
+        eprintln!(
+            "  ! [skip way_names_idx] {}; server will build HashMap at boot from ways.raw",
+            e
+        );
+    }
+
     // ---- Manifest ---------------------------------------------------
     // Lists the modes packed and their bundle ids. For now, every mode
     // is a singleton bundle (bundle_id == mode_name); the topology-
@@ -910,6 +923,73 @@ fn pack_edge_geometry(w: &mut ContainerWriter, step3: &Path) -> Result<()> {
         &pts_bytes,
     )
     .with_context(|| "packing shared/edge_geom_points".to_string())?;
+
+    Ok(())
+}
+
+/// #282: build a compact mmap-able way-name lookup index from
+/// `step1/ways.raw` and append it as `shared/way_names_idx`. Replaces
+/// the boot-time `HashMap<i64, String>` with sorted `[i64]` keys +
+/// `[u32]` offsets + a packed UTF-8 names blob. Saves ~30 MB heap on
+/// Belgium; scales to ~3 GiB at planet scale.
+///
+/// Returns `Err` if `ways.raw` is missing or fails to parse — the
+/// caller logs and skips the section emission, which leaves the
+/// container compatible with the legacy HashMap fallback in
+/// `state.rs::load_way_names_from_bytes`.
+fn pack_way_names_idx(w: &mut ContainerWriter, step1: &Path) -> Result<()> {
+    use crate::formats::WaysFile;
+    use crate::formats::way_names_idx;
+
+    let ways_path = step1.join("ways.raw");
+    if !ways_path.exists() {
+        anyhow::bail!("step1/ways.raw not found at {}", ways_path.display());
+    }
+
+    // Read the value dictionary first — we need the "name" key id so
+    // we can pick out only the (way_id, name) pairs without paying
+    // for the full ways stream's string cloning.
+    let (key_dict, val_dict, _, _) = WaysFile::read_dictionaries(&ways_path)
+        .with_context(|| format!("reading ways dictionaries from {}", ways_path.display()))?;
+    let name_key_id = match key_dict.iter().find(|(_, v)| v.as_str() == "name") {
+        Some((k, _)) => *k,
+        None => {
+            anyhow::bail!("no 'name' key in ways.raw dictionary");
+        }
+    };
+
+    // Stream ways and collect (way_id, name) for every way carrying a
+    // non-empty `name=` tag.
+    let mut pairs: Vec<(i64, String)> = Vec::new();
+    for result in WaysFile::stream_ways(&ways_path)? {
+        let (way_id, keys, vals, _nodes) = result?;
+        for (i, &k) in keys.iter().enumerate() {
+            if k == name_key_id {
+                if let Some(name) = val_dict.get(&vals[i])
+                    && !name.is_empty()
+                {
+                    pairs.push((way_id, name.clone()));
+                }
+                break;
+            }
+        }
+    }
+
+    let idx = way_names_idx::build_from_pairs(pairs)
+        .with_context(|| "building way_names_idx".to_string())?;
+    let n_entries = idx.n_entries;
+
+    let buf = way_names_idx::serialise_to_bytes(&idx)
+        .with_context(|| "serialising way_names_idx".to_string())?;
+
+    w.append_bytes(SectionKind::WayNamesIdx, "shared/way_names_idx", &buf)
+        .with_context(|| "packing shared/way_names_idx".to_string())?;
+
+    println!(
+        "  + packed shared/way_names_idx ({} entries, {:.2} MiB)",
+        n_entries,
+        buf.len() as f64 / (1024.0 * 1024.0)
+    );
 
     Ok(())
 }

--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -1432,18 +1432,25 @@ fn gpx_response(body: String) -> axum::response::Response {
 
 // ============ Helper functions ============
 
-/// Look up the road name for an EBG edge via geom_idx → NbgEdge.first_osm_way_id
+/// Look up the road name for an EBG edge via geom_idx → NbgEdge.first_osm_way_id.
+///
+/// #282: takes the abstract `WayNames` (either mmap-backed
+/// `WayNamesIdx` or legacy `HashMap`) and returns an owned `String` so
+/// callers don't have to thread a lifetime through the step-building
+/// pipeline. The lookup itself is O(log n) (binary search on the
+/// mmap-backed array) or O(1) (HashMap) — the allocation only happens
+/// when there's actually a name to return.
 pub fn lookup_road_name(
     edge_id: u32,
     ebg_nodes: &crate::formats::EbgNodes,
     nbg_geo: &crate::formats::NbgGeo,
-    way_names: &std::collections::HashMap<i64, String>,
+    way_names: &crate::server::state::WayNames,
 ) -> Option<String> {
     let node = &ebg_nodes.nodes[edge_id as usize];
     let geom_idx = node.geom_idx as usize;
     if geom_idx < nbg_geo.edges.len() {
         let way_id = nbg_geo.edges[geom_idx].first_osm_way_id;
-        way_names.get(&way_id).cloned()
+        way_names.get(way_id).map(|s| s.to_string())
     } else {
         None
     }
@@ -1456,7 +1463,7 @@ pub(crate) fn build_steps(
     nbg_geo: &crate::formats::NbgGeo,
     edge_geom: &crate::server::edge_geom::EdgeGeometry,
     node_weights: &[u32],
-    way_names: &std::collections::HashMap<i64, String>,
+    way_names: &crate::server::state::WayNames,
     format: GeometryFormat,
 ) -> Vec<RouteStep> {
     if ebg_path.len() < 2 {

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -1065,10 +1065,18 @@ impl ServerState {
         // `shared/step1.ways.raw` HashMap build (~30-50 MB heap on
         // Belgium) for containers that pre-date the index.
         tracing::info!("Loading road names from container...");
+        // PR #324 review: do NOT call `lazy_for_bytes.verify_now` here.
+        // A synchronous verify walks the full ~19 MiB way_names_idx
+        // body, paging it in at boot, which defeats the
+        // demand-paged-mmap goal of the lazy index. The lazy header
+        // (magic / version / sizes) is still validated by
+        // `read_from_mmap_unverified` below; the body CRC stays
+        // deferred. Operators that want eager body CRC can opt in
+        // via `--warmup-on-boot` or `--eager-verify`, which the
+        // existing `LazyContainer::spawn_warmup` path already covers.
         let way_names = if let Some(entry) = container.get("shared/way_names_idx") {
             let off = entry.offset as usize;
             let len = entry.len as usize;
-            lazy_for_bytes.verify_now("shared/way_names_idx")?;
             let idx = crate::formats::way_names_idx::read_from_mmap_unverified(
                 std::sync::Arc::clone(&mmap_for_bytes),
                 off,
@@ -1077,7 +1085,7 @@ impl ServerState {
             tracing::info!(
                 source = "shared/way_names_idx",
                 named_roads = idx.len(),
-                "loaded road names (mmap-backed)"
+                "loaded road names (mmap-backed, body CRC deferred to warmup/eager flags)"
             );
             WayNames::Idx(idx)
         } else if let Some(ways_bytes) = optional_section("shared/step1.ways.raw")? {

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -26,6 +26,57 @@ use super::exclude::{self, ExcludeWeights};
 use super::edge_geom::EdgeGeometry;
 use super::elevation::ElevationData;
 use super::snap_index::{DEFAULT_CELL_LOG2, PackedSnapIndex, SnapBuilderMode, build_snap_index};
+use crate::formats::way_names_idx::WayNamesIdx;
+
+/// Road-name lookup backend.
+///
+/// Two storage variants behind the same `get(way_id) -> Option<&str>`
+/// API:
+///
+/// - [`WayNames::Idx`] — compact mmap-backed sorted-array + offsets
+///   index loaded from a container's `shared/way_names_idx` section
+///   (#282). On Belgium this holds ~5-10 KB heap with 754 K named ways
+///   addressable; scales to ~3 GiB heap saved on planet-scale corpora.
+/// - [`WayNames::Heap`] — legacy `HashMap<i64, String>` built from
+///   `step1/ways.raw` at boot. Used by the data-dir path and as a
+///   fallback when the container pre-dates #282.
+pub enum WayNames {
+    Idx(WayNamesIdx),
+    Heap(HashMap<i64, String>),
+}
+
+impl WayNames {
+    /// Look up a name by OSM way id. Returns the borrowed string when
+    /// present; identical semantics for both backends.
+    #[inline]
+    pub fn get(&self, way_id: i64) -> Option<&str> {
+        match self {
+            Self::Idx(idx) => idx.get(way_id),
+            Self::Heap(m) => m.get(&way_id).map(|s| s.as_str()),
+        }
+    }
+
+    /// Number of named ways indexed.
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Idx(idx) => idx.len(),
+            Self::Heap(m) => m.len(),
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Construct from a legacy HashMap (data-dir path or container
+    /// without `shared/way_names_idx`).
+    #[inline]
+    pub fn from_heap(m: HashMap<i64, String>) -> Self {
+        Self::Heap(m)
+    }
+}
 
 /// Per-mode data including CCH topology (since each mode has its own filtered CCH)
 pub struct ModeData {
@@ -175,8 +226,14 @@ pub struct ServerState {
     // Elevation data (optional, loaded from SRTM .hgt files)
     pub elevation: Option<ElevationData>,
 
-    // Road names: OSM way_id → name string (for turn-by-turn instructions)
-    pub way_names: HashMap<i64, String>,
+    // Road names: OSM way_id → name string (for turn-by-turn instructions).
+    //
+    // #282: when the container has `shared/way_names_idx`, this is a
+    // compact mmap-backed sorted-array + offsets + UTF-8 blob view
+    // (~5-10 KB heap on Belgium). Otherwise it's the legacy
+    // `HashMap<i64, String>` built from `step1/ways.raw` (~30-50 MB
+    // heap on Belgium). Both expose the same `get(way_id) -> Option<&str>` API.
+    pub way_names: WayNames,
 
     // Distance weights indexed by original EBG node ID (length_mm per edge)
     // Used for isodistance isochrones — same role as ModeData.node_weights but in millimeters
@@ -406,9 +463,12 @@ impl ServerState {
             crate::server::rss::checkpoint(&format!("spatial.mode.{}", name));
         }
 
-        // Load road names from ways.raw for turn-by-turn instructions
+        // Load road names from ways.raw for turn-by-turn instructions.
+        // Data-dir path always uses the legacy HashMap; the container
+        // path (`load_state_from_bundle`) can use the compact mmap
+        // index when `shared/way_names_idx` is present (#282).
         tracing::info!("Loading road names...");
-        let way_names = load_way_names(&step1_dir)?;
+        let way_names = WayNames::from_heap(load_way_names(&step1_dir)?);
         tracing::info!(named_roads = way_names.len(), "loaded road names");
 
         // Build per-edge exclude flags from way_attrs.car.bin
@@ -998,14 +1058,29 @@ impl ServerState {
             }
         }
 
-        // ---- Road names from shared/step1.ways.raw ------------------
-        // #275: ways.raw is read once at boot to populate `way_names`.
-        // The names live in a heap HashMap from that point on; the
-        // mmap'd byte range is never read again at serve time. Drop the
-        // pages from RSS — they came in resident because LazyContainer's
-        // boot-time CRC walk touched them.
+        // ---- Road names ---------------------------------------------
+        // #282: prefer the compact mmap-backed `shared/way_names_idx`
+        // section (~5-10 KB heap on Belgium, scales to ~3 GiB saved at
+        // planet scale). Fall back to the legacy
+        // `shared/step1.ways.raw` HashMap build (~30-50 MB heap on
+        // Belgium) for containers that pre-date the index.
         tracing::info!("Loading road names from container...");
-        let way_names = if let Some(ways_bytes) = optional_section("shared/step1.ways.raw")? {
+        let way_names = if let Some(entry) = container.get("shared/way_names_idx") {
+            let off = entry.offset as usize;
+            let len = entry.len as usize;
+            lazy_for_bytes.verify_now("shared/way_names_idx")?;
+            let idx = crate::formats::way_names_idx::read_from_mmap_unverified(
+                std::sync::Arc::clone(&mmap_for_bytes),
+                off,
+                len,
+            )?;
+            tracing::info!(
+                source = "shared/way_names_idx",
+                named_roads = idx.len(),
+                "loaded road names (mmap-backed)"
+            );
+            WayNames::Idx(idx)
+        } else if let Some(ways_bytes) = optional_section("shared/step1.ways.raw")? {
             let names = load_way_names_from_bytes(ways_bytes)?;
             if let Err(e) = crate::formats::mmap::madvise_dontneed(ways_bytes) {
                 tracing::warn!(
@@ -1020,12 +1095,16 @@ impl ServerState {
                     "madvise(DONTNEED) on cold ways.raw section"
                 );
             }
-            names
+            tracing::info!(
+                source = "shared/step1.ways.raw",
+                named_roads = names.len(),
+                "loaded road names (heap HashMap fallback)"
+            );
+            WayNames::Heap(names)
         } else {
-            tracing::warn!("ways.raw missing in container, road names unavailable");
-            HashMap::new()
+            tracing::warn!("no way_names section in container, road names unavailable");
+            WayNames::Heap(HashMap::new())
         };
-        tracing::info!(named_roads = way_names.len(), "loaded road names");
 
         // ---- Edge exclude flags from one mode's way_attrs -----------
         // #275: way_attrs is read once at boot to build the per-edge


### PR DESCRIPTION
## Summary

Replaces the boot-time `HashMap<i64, String>` road-name table with a sorted-array + offsets + UTF-8 blob `shared/way_names_idx` section read straight from the container mmap.

## Format

`shared/way_names_idx` (SectionKind::WayNamesIdx = `0x000E_0001`):

```
40 B header (magic "WHNI", version 1, n_entries, names_blob_len)
[i64; n]   sorted way ids
[u32; n+1] offsets into names blob
[u8; …]    concatenated UTF-8
16 B footer (body crc + file crc)
```

Lookup: binary search on way_ids (O(log n), ~20 i64 compares for 754 K keys), then one slice into names. Returns `Option<&str>`.

## Why sorted-array + binary search, not boomphf

The issue spec recommended `boomphf`. Chose sorted + binary search because:

- **mmap-friendly**: every field is a `bytemuck::Pod` array readable zero-copy from the container.
- **no new dep**.
- **adequate perf**: road-name lookup is on the turn-by-turn path (a few per route). The O(log n) vs O(1) gap (~1 µs vs ~60 ns) is not user-visible.

If a future profiling pass shows road-name lookup as a real bottleneck, a `boomphf` PHF can slot in behind the same `WayNamesIdx::get` API.

## Server integration

- `ServerState.way_names` is now an enum (`WayNames::Idx` mmap-backed, `WayNames::Heap` legacy HashMap fallback). Both expose `get(way_id) -> Option<&str>`.
- `lookup_road_name` takes `&WayNames` and returns `Option<String>` (call-site semantics unchanged).
- `load_state_from_bundle` prefers `shared/way_names_idx`; falls back to building the HashMap from `shared/step1.ways.raw`.

## Pack integration

`pack_way_names_idx` streams `step1/ways.raw`, filters to `(way_id, name)` pairs where `name=` is non-empty, sorts + dedups (last-write-wins, matching the previous `HashMap::insert` semantics), and serialises into the section.

## Belgium smoke

- 754 380 named ways indexed → 19.81 MiB section on disk.
- Server boot log: `loaded road names (mmap-backed) source=shared/way_names_idx named_roads=754380`
- `/route` Brussels-Centrum 37-step query side-by-side:
  - mmap-backed path: 29 named steps
  - HashMap legacy path: 29 named steps
  - **differences: 0 / 37** — byte-identical lookups
- Heap (qualitative): the HashMap held ~754 K `(i64, String)` entries = ~30-50 MB. The mmap-backed view holds 3 `ArcCow<T>` enums ≈ 5-10 KB. At planet scale (~70 M named ways), this saves ~3 GiB.

## Test plan

- [x] cargo build --workspace --release: clean
- [x] cargo test --workspace --lib: 545 pass, 0 fail
- [x] Pack Belgium → `shared/way_names_idx` (754 380 entries, 19.81 MiB) written
- [x] Server boots from new container, /route names match HashMap path 1:1

Closes #282.