### PR TITLE
perf(rss): #306 PR 2 — u16 codec for CCH time weights (-25% disk on car/bike)

### DIFF
--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -3037,8 +3037,8 @@ fn run_bucket_m2m_bench(
 
     println!("Loading CCH weights from {:?}...", weights_path);
     let weights = CchWeightsFile::read(&weights_path)?;
-    let up_inf = weights.up.iter().filter(|&&w| w == u32::MAX).count();
-    let down_inf = weights.down.iter().filter(|&&w| w == u32::MAX).count();
+    let up_inf = weights.up.iter().filter(|&w| w == u32::MAX).count();
+    let down_inf = weights.down.iter().filter(|&w| w == u32::MAX).count();
     println!(
         "  ✓ {} up weights ({} INF = {:.1}%), {} down weights ({} INF = {:.1}%)",
         weights.up.len(),
@@ -3294,7 +3294,7 @@ fn run_p2p_query(
             let end = topo.up_offsets[u as usize + 1] as usize;
             for i in start..end {
                 let v = topo.up_targets[i];
-                let w = weights.up[i];
+                let w = weights.up.get(i);
                 if w == u32::MAX {
                     continue;
                 }

--- a/route/src/bench/weight_profile.rs
+++ b/route/src/bench/weight_profile.rs
@@ -335,10 +335,10 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
         BTreeMap::new();
     for (i, mode_name) in state.mode_names.iter().enumerate() {
         let mode_data = &state.modes[i];
-        let t_up = compute_static_stats(&mode_data.cch_weights.up);
-        let t_dn = compute_static_stats(&mode_data.cch_weights.down);
-        let d_up = compute_static_stats(&mode_data.cch_weights_dist.up);
-        let d_dn = compute_static_stats(&mode_data.cch_weights_dist.down);
+        let t_up = compute_static_stats(&mode_data.cch_weights.up.iter().collect::<Vec<u32>>());
+        let t_dn = compute_static_stats(&mode_data.cch_weights.down.iter().collect::<Vec<u32>>());
+        let d_up = compute_static_stats(&mode_data.cch_weights_dist.up.iter().collect::<Vec<u32>>());
+        let d_dn = compute_static_stats(&mode_data.cch_weights_dist.down.iter().collect::<Vec<u32>>());
         println!(
             "  - {}: time up p99={} p99.9={} max={} inf={}; \
              dist up p99={} p99.9={} max={} inf={}",
@@ -363,10 +363,10 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
         BTreeMap::new();
     for (i, mode_name) in state.mode_names.iter().enumerate() {
         let mode_data = &state.modes[i];
-        let t_up = compute_block_stats(&mode_data.cch_weights.up, BLOCK_SIZES);
-        let t_dn = compute_block_stats(&mode_data.cch_weights.down, BLOCK_SIZES);
-        let d_up = compute_block_stats(&mode_data.cch_weights_dist.up, BLOCK_SIZES);
-        let d_dn = compute_block_stats(&mode_data.cch_weights_dist.down, BLOCK_SIZES);
+        let t_up = compute_block_stats(&mode_data.cch_weights.up.iter().collect::<Vec<u32>>(), BLOCK_SIZES);
+        let t_dn = compute_block_stats(&mode_data.cch_weights.down.iter().collect::<Vec<u32>>(), BLOCK_SIZES);
+        let d_up = compute_block_stats(&mode_data.cch_weights_dist.up.iter().collect::<Vec<u32>>(), BLOCK_SIZES);
+        let d_dn = compute_block_stats(&mode_data.cch_weights_dist.down.iter().collect::<Vec<u32>>(), BLOCK_SIZES);
         let summary = |b: &BlockStats| -> String {
             let mut s = Vec::new();
             for sz in BLOCK_SIZES {
@@ -1988,7 +1988,7 @@ fn compute_tie_stats(
 
             for i_xm in down_start..down_end {
                 let x = topo.down_targets[i_xm] as usize;
-                let w_xm = weights.down[i_xm];
+                let w_xm = weights.down.get(i_xm);
                 if w_xm == u32::MAX {
                     continue;
                 }
@@ -1999,7 +1999,7 @@ fn compute_tie_stats(
                     if y == x {
                         continue;
                     }
-                    let w_my = weights.up[i_my];
+                    let w_my = weights.up.get(i_my);
                     if w_my == u32::MAX {
                         continue;
                     }
@@ -2066,14 +2066,20 @@ fn compute_tie_stats(
 /// the edge doesn't exist. The targets slice is sorted ascending
 /// per CCH invariants, so we use binary search.
 #[inline]
-fn find_edge_weight(u: usize, v: usize, offsets: &[u64], targets: &[u32], weights: &[u32]) -> u32 {
+fn find_edge_weight(
+    u: usize,
+    v: usize,
+    offsets: &[u64],
+    targets: &[u32],
+    weights: &butterfly_route::formats::WeightArray,
+) -> u32 {
     let start = offsets[u] as usize;
     let end = offsets[u + 1] as usize;
     if start >= end {
         return u32::MAX;
     }
     match targets[start..end].binary_search(&(v as u32)) {
-        Ok(idx) => weights[start + idx],
+        Ok(idx) => weights.get(start + idx),
         Err(_) => u32::MAX,
     }
 }

--- a/route/src/customization.rs
+++ b/route/src/customization.rs
@@ -1013,53 +1013,65 @@ fn write_cch_weights(
     mode: Mode,
 ) -> Result<()> {
     use crate::formats::crc::Digest;
+    use crate::formats::WeightWidth;
 
     const MAGIC: u32 = 0x43434857; // "CCHW"
-    // v2: contents are in seconds (time) or meters (distance) — was
-    // deciseconds / millimeters in v1 (#297). The on-disk layout is
-    // unchanged (opaque u32 pass-through of step 5's unit); only the
-    // semantic meaning of the integers differs.
-    const VERSION: u16 = 2;
+    // #306 PR 2 v3: per-direction body width.
+    //   bit 0 of header byte 7 → up body is u16 (else u32)
+    //   bit 1 of header byte 7 → down body is u16 (else u32)
+    // Step 8 picks the smallest fitting width per direction. The
+    // u16::MAX sentinel in the compact variant maps back to u32::MAX
+    // (the "no edge" marker) on read.
+    const VERSION: u16 = 3;
+
+    // Decide per-direction width based on max value (excluding the
+    // u32::MAX "no edge" sentinel — that's encoded as u16::MAX on
+    // the u16 path).
+    let up_width = WeightWidth::choose(up_weights);
+    let down_width = WeightWidth::choose(down_weights);
+
+    let mut width_flags = 0u8;
+    if up_width == WeightWidth::U16 {
+        width_flags |= 0x01;
+    }
+    if down_width == WeightWidth::U16 {
+        width_flags |= 0x02;
+    }
 
     let mut writer = BufWriter::new(File::create(path)?);
     let mut crc_digest = Digest::new();
 
-    // Header (32 bytes)
+    // Header (32 bytes): magic(4) | version(2) | mode(1) | flags(1)
+    //                  | n_up(8)  | n_down(8) | reserved(8)
     let magic_bytes = MAGIC.to_le_bytes();
     let version_bytes = VERSION.to_le_bytes();
     let mode_byte = mode.0;
-    let reserved = 0u8;
     let n_up = (up_weights.len() as u64).to_le_bytes();
     let n_down = (down_weights.len() as u64).to_le_bytes();
     let padding = [0u8; 8];
 
     writer.write_all(&magic_bytes)?;
     writer.write_all(&version_bytes)?;
-    writer.write_all(&[mode_byte, reserved])?;
+    writer.write_all(&[mode_byte, width_flags])?;
     writer.write_all(&n_up)?;
     writer.write_all(&n_down)?;
     writer.write_all(&padding)?;
 
     crc_digest.update(&magic_bytes);
     crc_digest.update(&version_bytes);
-    crc_digest.update(&[mode_byte, reserved]);
+    crc_digest.update(&[mode_byte, width_flags]);
     crc_digest.update(&n_up);
     crc_digest.update(&n_down);
     crc_digest.update(&padding);
 
-    for &w in up_weights {
-        let bytes = w.to_le_bytes();
-        writer.write_all(&bytes)?;
-        crc_digest.update(&bytes);
-    }
+    // Write body at chosen width per direction. `u32::MAX` (no edge)
+    // collapses to `u16::MAX` in the compact path so the read-side
+    // sentinel mapping reconstructs `u32::MAX` losslessly.
+    write_weights_body(&mut writer, &mut crc_digest, up_weights, up_width)?;
+    write_weights_body(&mut writer, &mut crc_digest, down_weights, down_width)?;
 
-    for &w in down_weights {
-        let bytes = w.to_le_bytes();
-        writer.write_all(&bytes)?;
-        crc_digest.update(&bytes);
-    }
-
-    // Write relaxed middle arrays (after weights, before CRC)
+    // Write relaxed middle arrays — stay at u32 (middle node ids
+    // address `n_filtered_nodes` which planet-scale exceeds 65 535).
     for &m in up_middle {
         let bytes = m.to_le_bytes();
         writer.write_all(&bytes)?;
@@ -1076,6 +1088,39 @@ fn write_cch_weights(
     writer.write_all(&crc.to_le_bytes())?;
 
     writer.flush()?;
+    Ok(())
+}
+
+/// Emit a weight body at the chosen width, updating the CRC.
+fn write_weights_body<W: std::io::Write>(
+    writer: &mut W,
+    crc_digest: &mut crate::formats::crc::Digest,
+    weights: &[u32],
+    width: crate::formats::WeightWidth,
+) -> Result<()> {
+    use crate::formats::WeightWidth;
+    match width {
+        WeightWidth::U32 => {
+            for &w in weights {
+                let bytes = w.to_le_bytes();
+                writer.write_all(&bytes)?;
+                crc_digest.update(&bytes);
+            }
+        }
+        WeightWidth::U16 => {
+            for &w in weights {
+                // u32::MAX → u16::MAX sentinel.
+                let v16: u16 = if w == u32::MAX {
+                    u16::MAX
+                } else {
+                    w as u16
+                };
+                let bytes = v16.to_le_bytes();
+                writer.write_all(&bytes)?;
+                crc_digest.update(&bytes);
+            }
+        }
+    }
     Ok(())
 }
 

--- a/route/src/customization.rs
+++ b/route/src/customization.rs
@@ -1067,8 +1067,12 @@ fn write_cch_weights(
     // Write body at chosen width per direction. `u32::MAX` (no edge)
     // collapses to `u16::MAX` in the compact path so the read-side
     // sentinel mapping reconstructs `u32::MAX` losslessly.
+    // Each u16 body is padded to a 4-byte boundary so the following
+    // arrays (the other direction's body + u32 middles) stay aligned.
     write_weights_body(&mut writer, &mut crc_digest, up_weights, up_width)?;
+    write_padding(&mut writer, &mut crc_digest, up_width, up_weights.len())?;
     write_weights_body(&mut writer, &mut crc_digest, down_weights, down_width)?;
+    write_padding(&mut writer, &mut crc_digest, down_width, down_weights.len())?;
 
     // Write relaxed middle arrays — stay at u32 (middle node ids
     // address `n_filtered_nodes` which planet-scale exceeds 65 535).
@@ -1120,6 +1124,24 @@ fn write_weights_body<W: std::io::Write>(
                 crc_digest.update(&bytes);
             }
         }
+    }
+    Ok(())
+}
+
+/// Emit 0-3 zero bytes so the next array begins on a 4-byte boundary.
+/// u32 bodies are already 4-aligned; only u16 needs 2 bytes of pad
+/// when `n` is odd.
+fn write_padding<W: std::io::Write>(
+    writer: &mut W,
+    crc_digest: &mut crate::formats::crc::Digest,
+    width: crate::formats::WeightWidth,
+    n: usize,
+) -> Result<()> {
+    let pad = width.padded_body_bytes(n) - width.bytes_per_entry() * n;
+    if pad > 0 {
+        let zeros = [0u8; 4];
+        writer.write_all(&zeros[..pad])?;
+        crc_digest.update(&zeros[..pad]);
     }
     Ok(())
 }

--- a/route/src/formats/cch_weights.rs
+++ b/route/src/formats/cch_weights.rs
@@ -83,15 +83,22 @@ impl WeightWidth {
         (raw + 3) & !3
     }
 
-    /// `WeightWidth::U16` iff every value in `weights` fits in `u16`.
-    /// `u32::MAX` (the "no edge" sentinel) maps to `u16::MAX` on the
-    /// compact path — that round-trip is lossless, so the sentinel
-    /// itself doesn't force U32.
+    /// `WeightWidth::U16` iff every value in `weights` fits losslessly
+    /// in the compact path. The compact encoding reserves `u16::MAX`
+    /// as the "no edge" sentinel for `u32::MAX`, so:
+    ///
+    /// - `u32::MAX` (sentinel) → encodes to `u16::MAX` losslessly
+    /// - real finite weights must be `< u16::MAX = 65 535`; a real
+    ///   value of 65 535 would alias the sentinel on round-trip
+    ///   (read-back would widen to `u32::MAX`), so it forces U32
+    /// - anything above `u16::MAX` (excluding the sentinel) also
+    ///   forces U32
     #[inline]
     pub fn choose(weights: &[u32]) -> Self {
+        let max_finite_inline = u16::MAX as u32 - 1; // 65_534
         if weights
             .iter()
-            .all(|&w| w == u32::MAX || w <= u16::MAX as u32)
+            .all(|&w| w == u32::MAX || w <= max_finite_inline)
         {
             Self::U16
         } else {
@@ -702,4 +709,72 @@ fn parse_header(header: &[u8]) -> Result<CchWeightsHeader> {
         up_width,
         down_width,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn width_choose_picks_u16_for_small_values() {
+        let w = vec![0u32, 1, 100, 65_534];
+        assert_eq!(WeightWidth::choose(&w), WeightWidth::U16);
+    }
+
+    #[test]
+    fn width_choose_picks_u16_with_sentinel() {
+        // u32::MAX (no-edge sentinel) maps to u16::MAX losslessly.
+        let w = vec![0u32, u32::MAX, 100, u32::MAX];
+        assert_eq!(WeightWidth::choose(&w), WeightWidth::U16);
+    }
+
+    #[test]
+    fn width_choose_forces_u32_on_real_65535() {
+        // Real weight = 65_535 (u16::MAX) would alias the sentinel
+        // on round-trip — must force U32.
+        let w = vec![0u32, 65_535, 100];
+        assert_eq!(WeightWidth::choose(&w), WeightWidth::U32);
+    }
+
+    #[test]
+    fn width_choose_forces_u32_on_overflow() {
+        let w = vec![0u32, 100_000, 100];
+        assert_eq!(WeightWidth::choose(&w), WeightWidth::U32);
+    }
+
+    #[test]
+    fn padded_body_bytes_aligns_to_4() {
+        assert_eq!(WeightWidth::U16.padded_body_bytes(0), 0);
+        assert_eq!(WeightWidth::U16.padded_body_bytes(1), 4); // 2 → pad 2
+        assert_eq!(WeightWidth::U16.padded_body_bytes(2), 4); // 4 aligned
+        assert_eq!(WeightWidth::U16.padded_body_bytes(3), 8); // 6 → pad 2
+        assert_eq!(WeightWidth::U16.padded_body_bytes(4), 8); // 8 aligned
+        assert_eq!(WeightWidth::U32.padded_body_bytes(1), 4);
+        assert_eq!(WeightWidth::U32.padded_body_bytes(2), 8);
+    }
+
+    #[test]
+    fn weight_array_u16_sentinel_round_trip() {
+        // Manually build U16 storage including the sentinel; ensure
+        // get() widens it back to u32::MAX.
+        let arr = WeightArray::U16(ArcCow::from_vec(vec![1u16, 2, u16::MAX, 65_534]));
+        assert_eq!(arr.get(0), 1);
+        assert_eq!(arr.get(1), 2);
+        assert_eq!(arr.get(2), u32::MAX);
+        assert_eq!(arr.get(3), 65_534);
+        // Iter widens identically.
+        let vals: Vec<u32> = arr.iter().collect();
+        assert_eq!(vals, vec![1, 2, u32::MAX, 65_534]);
+    }
+
+    #[test]
+    fn weight_array_to_mut_widens_u16_to_u32() {
+        let mut arr = WeightArray::U16(ArcCow::from_vec(vec![1u16, u16::MAX, 100]));
+        let v = arr.to_mut_vec();
+        assert_eq!(v.as_slice(), &[1u32, u32::MAX, 100]);
+        // Mutation persists through subsequent reads.
+        v[0] = 999;
+        assert_eq!(arr.get(0), 999);
+        assert!(matches!(arr.width(), WeightWidth::U32));
+    }
 }

--- a/route/src/formats/cch_weights.rs
+++ b/route/src/formats/cch_weights.rs
@@ -74,12 +74,25 @@ impl WeightWidth {
         }
     }
 
-    /// `WeightWidth::U16` iff every value in `weights` fits in `u16`
-    /// (including the `u32::MAX` "no edge" sentinel — but u16::MAX
-    /// reserves nothing, so a `u32::MAX` sentinel forces `U32`).
+    /// Number of bytes occupied by a body of `n` entries at this width,
+    /// padded up to the next 4-byte boundary so the following `u32`
+    /// arrays (middles) stay aligned for `bytemuck::cast_slice`.
+    #[inline]
+    pub fn padded_body_bytes(self, n: usize) -> usize {
+        let raw = self.bytes_per_entry() * n;
+        (raw + 3) & !3
+    }
+
+    /// `WeightWidth::U16` iff every value in `weights` fits in `u16`.
+    /// `u32::MAX` (the "no edge" sentinel) maps to `u16::MAX` on the
+    /// compact path — that round-trip is lossless, so the sentinel
+    /// itself doesn't force U32.
     #[inline]
     pub fn choose(weights: &[u32]) -> Self {
-        if weights.iter().all(|&w| w <= u16::MAX as u32) {
+        if weights
+            .iter()
+            .all(|&w| w == u32::MAX || w <= u16::MAX as u32)
+        {
             Self::U16
         } else {
             Self::U32
@@ -349,17 +362,16 @@ impl CchWeightsFile {
         } = parse_header(header)?;
 
         // Layout v3 (with optional middle arrays):
-        //   header(32) | up(width_up·n_up) | down(width_down·n_down)
-        //              | [v2/v3 middles: up_middle(4·n_up) | down_middle(4·n_down)]
+        //   header(32) | up(width_up·n_up [+0-2 pad]) | down(width_down·n_down [+0-2 pad])
+        //              | [v3 middles: up_middle(4·n_up) | down_middle(4·n_down)]
         //              | footer(16)
-        let up_bytes = up_width
-            .bytes_per_entry()
-            .checked_mul(n_up)
-            .ok_or_else(|| anyhow::anyhow!("cch.weights up byte len overflow for n_up={n_up}"))?;
-        let down_bytes = down_width
-            .bytes_per_entry()
-            .checked_mul(n_down)
-            .ok_or_else(|| anyhow::anyhow!("cch.weights down byte len overflow for n_down={n_down}"))?;
+        //
+        // u16 bodies are padded up to a 4-byte boundary so the
+        // following arrays (the other direction's body and the u32
+        // middles) stay aligned for `bytemuck::cast_slice` /
+        // `ArcCow::<u32>::from_mmap`.
+        let up_bytes = up_width.padded_body_bytes(n_up);
+        let down_bytes = down_width.padded_body_bytes(n_down);
         let body_no_middle = up_bytes
             .checked_add(down_bytes)
             .ok_or_else(|| anyhow::anyhow!("cch.weights body size overflow"))?;
@@ -448,11 +460,12 @@ impl CchWeightsFile {
         } = parse_header(header)?;
 
         // v3 layout (with optional middles, per-direction body width):
-        //   header(32) | up(width_up·n_up) | down(width_down·n_down)
+        //   header(32) | up(width_up·n_up [+0-2 pad]) | down(width_down·n_down [+0-2 pad])
         //              | [up_middle(4·n_up) | down_middle(4·n_down)]
         //              | footer(16)
-        let up_bytes = up_width.bytes_per_entry() * n_up;
-        let down_bytes = down_width.bytes_per_entry() * n_down;
+        // u16 bodies pad up to 4-byte boundary — see `padded_body_bytes`.
+        let up_bytes = up_width.padded_body_bytes(n_up);
+        let down_bytes = down_width.padded_body_bytes(n_down);
         let no_middle_len = HEADER_LEN + up_bytes + down_bytes + FOOTER_LEN;
         let with_middle_len = no_middle_len + 4 * (n_up + n_down);
         let has_middles = match bytes.len() {
@@ -467,12 +480,15 @@ impl CchWeightsFile {
         };
 
         let up_off = HEADER_LEN;
-        let up_end = up_off + up_bytes;
+        let up_end = up_off + up_bytes; // includes padding
         let down_off = up_end;
         let down_end = down_off + down_bytes;
 
-        let up_body = &bytes[up_off..up_end];
-        let down_body = &bytes[down_off..down_end];
+        // Read only the actual data bytes (skip any 0-2 byte tail pad).
+        let up_data = up_width.bytes_per_entry() * n_up;
+        let down_data = down_width.bytes_per_entry() * n_down;
+        let up_body = &bytes[up_off..up_off + up_data];
+        let down_body = &bytes[down_off..down_off + down_data];
         let up_vec: Vec<u32> = match up_width {
             WeightWidth::U16 => decode_u16_to_u32_vec(up_body),
             WeightWidth::U32 => bytemuck::cast_slice::<u8, u32>(up_body).to_vec(),
@@ -534,33 +550,36 @@ impl CchWeightsFile {
             down_width,
         } = parse_header(&header)?;
 
-        // Read up weights at width.
-        let up_byte_count = up_width.bytes_per_entry() * n_up;
-        let mut up_body = vec![0u8; up_byte_count];
+        // Read up weights body (padded to next 4-byte boundary).
+        let up_padded_count = up_width.padded_body_bytes(n_up);
+        let up_data_count = up_width.bytes_per_entry() * n_up;
+        let mut up_body = vec![0u8; up_padded_count];
         reader.read_exact(&mut up_body)?;
         crc_digest.update(&up_body);
+        // Decode only the actual data bytes (skip the 0-2 byte tail pad).
         let up_vec: Vec<u32> = match up_width {
-            WeightWidth::U16 => decode_u16_to_u32_vec(&up_body),
-            WeightWidth::U32 => up_body
+            WeightWidth::U16 => decode_u16_to_u32_vec(&up_body[..up_data_count]),
+            WeightWidth::U32 => up_body[..up_data_count]
                 .chunks_exact(4)
                 .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
                 .collect(),
         };
 
-        // Read down weights at width.
-        let down_byte_count = down_width.bytes_per_entry() * n_down;
-        let mut down_body = vec![0u8; down_byte_count];
+        // Read down weights body (padded).
+        let down_padded_count = down_width.padded_body_bytes(n_down);
+        let down_data_count = down_width.bytes_per_entry() * n_down;
+        let mut down_body = vec![0u8; down_padded_count];
         reader.read_exact(&mut down_body)?;
         crc_digest.update(&down_body);
         let down_vec: Vec<u32> = match down_width {
-            WeightWidth::U16 => decode_u16_to_u32_vec(&down_body),
-            WeightWidth::U32 => down_body
+            WeightWidth::U16 => decode_u16_to_u32_vec(&down_body[..down_data_count]),
+            WeightWidth::U32 => down_body[..down_data_count]
                 .chunks_exact(4)
                 .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
                 .collect(),
         };
 
-        let no_middle_len = HEADER_LEN + up_byte_count + down_byte_count + FOOTER_LEN;
+        let no_middle_len = HEADER_LEN + up_padded_count + down_padded_count + FOOTER_LEN;
         let with_middle_len = no_middle_len + 4 * (n_up + n_down);
 
         let (up_middle, down_middle): (Vec<u32>, Vec<u32>) = match file_len {

--- a/route/src/formats/cch_weights.rs
+++ b/route/src/formats/cch_weights.rs
@@ -37,24 +37,234 @@ use super::mmap::ArcCow;
 const MAGIC: u32 = 0x43434857; // "CCHW"
 const HEADER_LEN: usize = 32;
 const FOOTER_LEN: usize = 16;
-/// Current on-disk version. v2 stores body in seconds (time weights)
-/// or meters (distance weights). v1 stored deciseconds / millimeters
-/// and is rejected — re-run step 8 to regenerate.
-const VERSION: u16 = 2;
+/// Current on-disk version. v3 (#306 PR 2) carries a per-direction
+/// `width_flags` byte in header byte 7 that lets the body be encoded
+/// as `[u16]` or `[u32]` independently for UP/DOWN edges. v2 stored
+/// body in seconds (time weights) or meters (distance weights) at
+/// fixed u32; v3 readers still accept v2 (width = u32 implied). v1
+/// stored deciseconds / millimeters and is rejected — re-run step 8
+/// to regenerate.
+const VERSION: u16 = 3;
+const VERSION_V2: u16 = 2;
+
+/// Width flags packed into header byte 7 (v3+):
+/// - bit 0: up body width  (0 = u32, 1 = u16)
+/// - bit 1: down body width (0 = u32, 1 = u16)
+const UP_COMPACT_FLAG: u8 = 0x01;
+const DOWN_COMPACT_FLAG: u8 = 0x02;
+
+/// Per-direction body width for a CCH weights file (#306 PR 2).
+///
+/// At write time, step 8 picks `U16` when the direction's max value
+/// fits losslessly in `u16` (≤ 65 535). On Belgium that's car and
+/// bike for time weights; foot stays `U32` until PR 3's u24+overflow
+/// table lands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WeightWidth {
+    U16,
+    U32,
+}
+
+impl WeightWidth {
+    #[inline]
+    pub fn bytes_per_entry(self) -> usize {
+        match self {
+            Self::U16 => 2,
+            Self::U32 => 4,
+        }
+    }
+
+    /// `WeightWidth::U16` iff every value in `weights` fits in `u16`
+    /// (including the `u32::MAX` "no edge" sentinel — but u16::MAX
+    /// reserves nothing, so a `u32::MAX` sentinel forces `U32`).
+    #[inline]
+    pub fn choose(weights: &[u32]) -> Self {
+        if weights.iter().all(|&w| w <= u16::MAX as u32) {
+            Self::U16
+        } else {
+            Self::U32
+        }
+    }
+}
+
+/// Per-direction weight array — either compact u16 or wide u32.
+///
+/// The hot routing path doesn't read [`CchWeights`] directly (see
+/// codex review on #279); access is through pre-built
+/// `UpAdjFlat` / `DownReverseAdjFlat` that embed the weights inline.
+/// CchWeights stays resident in `ModeData` mainly for unpack, validators,
+/// and recustomization, so the storage backing matters for steady-state
+/// RSS but not for routing latency.
+///
+/// Mmap-backed variants borrow from the live `Arc<Mmap>` covering the
+/// container; widening to `u32` happens on read via [`Self::get`].
+/// After madvise(DONTNEED) on the container section, the mmap pages
+/// are evictable — only the small enum wrapper stays on the heap.
+#[derive(Debug, Clone)]
+pub enum WeightArray {
+    /// Compact `u16` storage. Reader uses `u16::MAX` as the
+    /// "no edge" sentinel (same role as `u32::MAX` in the U32 variant
+    /// — by convention this is widened back to `u32::MAX` by `get`).
+    U16(ArcCow<u16>),
+    /// Native `u32` storage. Used when the direction's max value
+    /// doesn't fit in `u16` (foot mode on Belgium, all distance
+    /// arrays until PR 3 lands the u24 codec).
+    U32(ArcCow<u32>),
+}
+
+impl WeightArray {
+    /// Read entry `i`, widening to `u32`. The `u16::MAX` sentinel in
+    /// the compact variant maps back to `u32::MAX` so the
+    /// "no edge" semantic survives a round-trip.
+    #[inline]
+    pub fn get(&self, i: usize) -> u32 {
+        match self {
+            Self::U16(arr) => {
+                let v = arr.as_slice()[i];
+                if v == u16::MAX { u32::MAX } else { v as u32 }
+            }
+            Self::U32(arr) => arr.as_slice()[i],
+        }
+    }
+
+    /// Length of the underlying array.
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::U16(arr) => arr.len(),
+            Self::U32(arr) => arr.len(),
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Iterate over the values widened to `u32`. The compact variant
+    /// emits `u32::MAX` for entries equal to the `u16::MAX` sentinel.
+    pub fn iter(&self) -> WeightArrayIter<'_> {
+        WeightArrayIter {
+            inner: self,
+            i: 0,
+            end: self.len(),
+        }
+    }
+
+    /// Get the storage width — useful for size reporting and tests.
+    #[inline]
+    pub fn width(&self) -> WeightWidth {
+        match self {
+            Self::U16(_) => WeightWidth::U16,
+            Self::U32(_) => WeightWidth::U32,
+        }
+    }
+
+    /// Upgrade to an owned `Vec<u32>` for mutation. Used by callers
+    /// that need to penalize or zero specific entries (e.g. exclude /
+    /// avoid recustomization). The compact variant is widened in
+    /// place; the wide variant produces a fresh Vec via `to_mut`.
+    ///
+    /// After calling this, the returned `&mut Vec<u32>` is the same
+    /// storage `get`/`iter` will read. Subsequent reads decode
+    /// through the U32 path.
+    pub fn to_mut_vec(&mut self) -> &mut Vec<u32> {
+        if let Self::U16(arr) = self {
+            let widened: Vec<u32> = arr
+                .as_slice()
+                .iter()
+                .map(|&v| if v == u16::MAX { u32::MAX } else { v as u32 })
+                .collect();
+            *self = Self::U32(ArcCow::from_vec(widened));
+        }
+        match self {
+            Self::U32(arr) => match arr {
+                ArcCow::Owned(v) => v,
+                ArcCow::Mmap { .. } => {
+                    // Mmap-backed → copy to owned so we can hand out
+                    // a `&mut Vec`.
+                    let owned: Vec<u32> = arr.as_slice().to_vec();
+                    *arr = ArcCow::from_vec(owned);
+                    if let ArcCow::Owned(v) = arr {
+                        v
+                    } else {
+                        unreachable!("just set to ArcCow::Owned")
+                    }
+                }
+            },
+            Self::U16(_) => unreachable!("just upgraded to U32 above"),
+        }
+    }
+
+    /// Construct from an owned `Vec<u32>` at the U32 width. Used by
+    /// in-memory builders / writers that work in the wide space.
+    #[inline]
+    pub fn from_vec_u32(v: Vec<u32>) -> Self {
+        Self::U32(ArcCow::from_vec(v))
+    }
+
+    /// Construct from an owned `Vec<u16>` at the U16 width.
+    #[inline]
+    pub fn from_vec_u16(v: Vec<u16>) -> Self {
+        Self::U16(ArcCow::from_vec(v))
+    }
+
+    /// Empty array (U32 width).
+    #[inline]
+    pub fn empty() -> Self {
+        Self::U32(ArcCow::from_vec(Vec::new()))
+    }
+}
+
+impl From<Vec<u32>> for WeightArray {
+    #[inline]
+    fn from(v: Vec<u32>) -> Self {
+        Self::U32(ArcCow::from_vec(v))
+    }
+}
+
+/// Iterator over a [`WeightArray`], emitting `u32` values.
+pub struct WeightArrayIter<'a> {
+    inner: &'a WeightArray,
+    i: usize,
+    end: usize,
+}
+
+impl Iterator for WeightArrayIter<'_> {
+    type Item = u32;
+    #[inline]
+    fn next(&mut self) -> Option<u32> {
+        if self.i >= self.end {
+            None
+        } else {
+            let v = self.inner.get(self.i);
+            self.i += 1;
+            Some(v)
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end - self.i;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for WeightArrayIter<'_> {}
 
 /// CCH weights - stores weights and relaxed middle nodes for UP and DOWN edges.
 /// The middle arrays are the post-triangle-relaxation middles — these are the
 /// correct middles for path unpacking (the topology's middles are from contraction
 /// and may be suboptimal).
 ///
-/// Fields are [`ArcCow<u32>`] so they can either own a `Vec<u32>`
-/// (legacy / writer / construction sites) or hold an `Arc<Mmap>`-backed
-/// zero-copy view over a section of a `*.butterfly` container (#296).
-/// All `&self.up` access patterns deref to `&[u32]` regardless of variant.
+/// `up` / `down` are [`WeightArray`] (u16 or u32, per direction).
+/// `up_middle` / `down_middle` stay [`ArcCow<u32>`] — middle node ids
+/// can address `n_nodes` which on a planet-scale CCH exceeds 65 535.
+/// All reads go through `WeightArray::get` which widens transparently.
 #[derive(Debug, Clone)]
 pub struct CchWeights {
-    pub up: ArcCow<u32>,
-    pub down: ArcCow<u32>,
+    pub up: WeightArray,
+    pub down: WeightArray,
     /// Relaxed middle nodes for UP shortcuts (empty if not available — use topo middles)
     pub up_middle: ArcCow<u32>,
     /// Relaxed middle nodes for DOWN shortcuts (empty if not available — use topo middles)
@@ -131,35 +341,48 @@ impl CchWeightsFile {
         );
 
         let header = &mmap[byte_offset..byte_offset + HEADER_LEN];
-        let (n_up, n_down) = parse_header(header)?;
+        let CchWeightsHeader {
+            n_up,
+            n_down,
+            up_width,
+            down_width,
+        } = parse_header(header)?;
 
-        // Layout: header(32) | up(4*n_up) | down(4*n_down) |
-        //         [v2: up_middle(4*n_up) | down_middle(4*n_down)] |
-        //         footer(16)
-        let up_bytes = 4usize
+        // Layout v3 (with optional middle arrays):
+        //   header(32) | up(width_up·n_up) | down(width_down·n_down)
+        //              | [v2/v3 middles: up_middle(4·n_up) | down_middle(4·n_down)]
+        //              | footer(16)
+        let up_bytes = up_width
+            .bytes_per_entry()
             .checked_mul(n_up)
             .ok_or_else(|| anyhow::anyhow!("cch.weights up byte len overflow for n_up={n_up}"))?;
-        let down_bytes = 4usize.checked_mul(n_down).ok_or_else(|| {
-            anyhow::anyhow!("cch.weights down byte len overflow for n_down={n_down}")
-        })?;
-        let body_v1 = up_bytes
+        let down_bytes = down_width
+            .bytes_per_entry()
+            .checked_mul(n_down)
+            .ok_or_else(|| anyhow::anyhow!("cch.weights down byte len overflow for n_down={n_down}"))?;
+        let body_no_middle = up_bytes
             .checked_add(down_bytes)
             .ok_or_else(|| anyhow::anyhow!("cch.weights body size overflow"))?;
-        let expected_v1_len = HEADER_LEN
-            .checked_add(body_v1)
+        // Middle arrays (when present) stay at u32 — see CchWeights doc.
+        let middle_bytes = 4usize
+            .checked_mul(n_up)
+            .and_then(|u| u.checked_add(4usize.checked_mul(n_down)?))
+            .ok_or_else(|| anyhow::anyhow!("cch.weights middle size overflow"))?;
+        let expected_no_middle_len = HEADER_LEN
+            .checked_add(body_no_middle)
             .and_then(|n| n.checked_add(FOOTER_LEN))
             .ok_or_else(|| anyhow::anyhow!("cch.weights section size overflow"))?;
-        let expected_v2_len = expected_v1_len
-            .checked_add(body_v1)
-            .ok_or_else(|| anyhow::anyhow!("cch.weights v2 section size overflow"))?;
-        let is_v2 = match byte_len {
-            n if n == expected_v1_len => false,
-            n if n == expected_v2_len => true,
+        let expected_with_middle_len = expected_no_middle_len
+            .checked_add(middle_bytes)
+            .ok_or_else(|| anyhow::anyhow!("cch.weights w/ middle size overflow"))?;
+        let has_middles = match byte_len {
+            n if n == expected_no_middle_len => false,
+            n if n == expected_with_middle_len => true,
             n => anyhow::bail!(
-                "Invalid cch.weights size: got {}, expected {} (v1) or {} (v2)",
+                "Invalid cch.weights size: got {}, expected {} (no middles) or {} (with middles)",
                 n,
-                expected_v1_len,
-                expected_v2_len
+                expected_no_middle_len,
+                expected_with_middle_len
             ),
         };
 
@@ -167,20 +390,32 @@ impl CchWeightsFile {
         let up_off = byte_offset + HEADER_LEN;
         let down_off = up_off + up_bytes;
 
-        let up = ArcCow::<u32>::from_mmap(Arc::clone(&mmap), up_off, n_up)?;
-        let down = ArcCow::<u32>::from_mmap(Arc::clone(&mmap), down_off, n_down)?;
+        let up = match up_width {
+            WeightWidth::U16 => {
+                WeightArray::U16(ArcCow::<u16>::from_mmap(Arc::clone(&mmap), up_off, n_up)?)
+            }
+            WeightWidth::U32 => {
+                WeightArray::U32(ArcCow::<u32>::from_mmap(Arc::clone(&mmap), up_off, n_up)?)
+            }
+        };
+        let down = match down_width {
+            WeightWidth::U16 => {
+                WeightArray::U16(ArcCow::<u16>::from_mmap(Arc::clone(&mmap), down_off, n_down)?)
+            }
+            WeightWidth::U32 => {
+                WeightArray::U32(ArcCow::<u32>::from_mmap(Arc::clone(&mmap), down_off, n_down)?)
+            }
+        };
 
-        let (up_middle, down_middle) = if is_v2 {
+        let (up_middle, down_middle) = if has_middles {
             let upm_off = down_off + down_bytes;
-            let dnm_off = upm_off + up_bytes;
+            let dnm_off = upm_off + 4 * n_up;
             let upm = ArcCow::<u32>::from_mmap(Arc::clone(&mmap), upm_off, n_up)?;
             // Final clone consumes the local `mmap` binding.
             let dnm = ArcCow::<u32>::from_mmap(mmap, dnm_off, n_down)?;
             (upm, dnm)
         } else {
-            // Empty arrays — no need to drag the mmap along; empty
-            // `Vec<u32>` doesn't allocate.
-            let _ = mmap; // suppress unused-binding warning on v1
+            let _ = mmap;
             (ArcCow::from_vec(Vec::new()), ArcCow::from_vec(Vec::new()))
         };
 
@@ -199,42 +434,55 @@ impl CchWeightsFile {
             "cch.weights too short for header+footer: {} bytes",
             bytes.len()
         );
-        // Container guarantees 8-byte section alignment, but `bytemuck::cast_slice`
-        // panics on misalignment. Validate explicitly so a misuse from tests/tools
-        // returns a typed error instead of aborting the process.
         anyhow::ensure!(
             (bytes.as_ptr() as usize).is_multiple_of(4),
             "cch.weights section must start 4-byte aligned (got addr 0x{:x})",
             bytes.as_ptr() as usize
         );
         let header = &bytes[..HEADER_LEN];
-        let (n_up, n_down) = parse_header(header)?;
+        let CchWeightsHeader {
+            n_up,
+            n_down,
+            up_width,
+            down_width,
+        } = parse_header(header)?;
 
-        // ----- Layout: header(32) | up(4*n_up) | down(4*n_down) |
-        //               [v2: up_middle(4*n_up) | down_middle(4*n_down)] |
-        //               footer(16)
-        let expected_v1_len = HEADER_LEN + 4 * (n_up + n_down) + FOOTER_LEN;
-        let expected_v2_len = expected_v1_len + 4 * (n_up + n_down);
-        let is_v2 = match bytes.len() {
-            n if n == expected_v1_len => false,
-            n if n == expected_v2_len => true,
+        // v3 layout (with optional middles, per-direction body width):
+        //   header(32) | up(width_up·n_up) | down(width_down·n_down)
+        //              | [up_middle(4·n_up) | down_middle(4·n_down)]
+        //              | footer(16)
+        let up_bytes = up_width.bytes_per_entry() * n_up;
+        let down_bytes = down_width.bytes_per_entry() * n_down;
+        let no_middle_len = HEADER_LEN + up_bytes + down_bytes + FOOTER_LEN;
+        let with_middle_len = no_middle_len + 4 * (n_up + n_down);
+        let has_middles = match bytes.len() {
+            n if n == no_middle_len => false,
+            n if n == with_middle_len => true,
             n => anyhow::bail!(
-                "Invalid cch.weights size: got {}, expected {} (v1) or {} (v2)",
+                "Invalid cch.weights size: got {}, expected {} (no middles) or {} (with middles)",
                 n,
-                expected_v1_len,
-                expected_v2_len
+                no_middle_len,
+                with_middle_len
             ),
         };
 
         let up_off = HEADER_LEN;
-        let up_end = up_off + 4 * n_up;
+        let up_end = up_off + up_bytes;
         let down_off = up_end;
-        let down_end = down_off + 4 * n_down;
+        let down_end = down_off + down_bytes;
 
-        let up_slice: &[u32] = bytemuck::cast_slice(&bytes[up_off..up_end]);
-        let down_slice: &[u32] = bytemuck::cast_slice(&bytes[down_off..down_end]);
+        let up_body = &bytes[up_off..up_end];
+        let down_body = &bytes[down_off..down_end];
+        let up_vec: Vec<u32> = match up_width {
+            WeightWidth::U16 => decode_u16_to_u32_vec(up_body),
+            WeightWidth::U32 => bytemuck::cast_slice::<u8, u32>(up_body).to_vec(),
+        };
+        let down_vec: Vec<u32> = match down_width {
+            WeightWidth::U16 => decode_u16_to_u32_vec(down_body),
+            WeightWidth::U32 => bytemuck::cast_slice::<u8, u32>(down_body).to_vec(),
+        };
 
-        let (up_middle, down_middle, body_end) = if is_v2 {
+        let (up_middle, down_middle, body_end) = if has_middles {
             let upm_off = down_end;
             let upm_end = upm_off + 4 * n_up;
             let dnm_off = upm_end;
@@ -246,7 +494,6 @@ impl CchWeightsFile {
             (Vec::new(), Vec::new(), down_end)
         };
 
-        // ----- CRC: covers everything before the 16-byte footer -----
         if verify {
             let body = &bytes[..body_end];
             let computed_crc = {
@@ -264,13 +511,11 @@ impl CchWeightsFile {
             );
         }
 
-        // Legacy `'static` zero-copy path now copies into `Vec<u32>` —
-        // production load goes through [`Self::read_from_mmap_unverified`].
-        // The few remaining test fixtures that leak buffers don't care
-        // about the extra Vec; they're tiny by construction.
+        // Test-fixture path now also widens u16→u32 if needed; production
+        // load goes through `read_from_mmap_unverified`.
         Ok(CchWeights {
-            up: ArcCow::from_vec(up_slice.to_vec()),
-            down: ArcCow::from_vec(down_slice.to_vec()),
+            up: WeightArray::from_vec_u32(up_vec),
+            down: WeightArray::from_vec_u32(down_vec),
             up_middle: ArcCow::from_vec(up_middle),
             down_middle: ArcCow::from_vec(down_middle),
         })
@@ -279,64 +524,48 @@ impl CchWeightsFile {
     fn read_from_reader<R: Read>(mut reader: R, file_len: usize) -> Result<CchWeights> {
         let mut crc_digest = crc::Digest::new();
 
-        // Read header (32 bytes)
-        // magic(4) + reserved(4) + n_up(8) + n_down(8) + reserved(8) = 32
         let mut header = [0u8; HEADER_LEN];
         reader.read_exact(&mut header)?;
         crc_digest.update(&header);
+        let CchWeightsHeader {
+            n_up,
+            n_down,
+            up_width,
+            down_width,
+        } = parse_header(&header)?;
 
-        let magic = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
-        if magic != MAGIC {
-            anyhow::bail!(
-                "Invalid magic: expected 0x{:08X}, got 0x{:08X}",
-                MAGIC,
-                magic
-            );
-        }
+        // Read up weights at width.
+        let up_byte_count = up_width.bytes_per_entry() * n_up;
+        let mut up_body = vec![0u8; up_byte_count];
+        reader.read_exact(&mut up_body)?;
+        crc_digest.update(&up_body);
+        let up_vec: Vec<u32> = match up_width {
+            WeightWidth::U16 => decode_u16_to_u32_vec(&up_body),
+            WeightWidth::U32 => up_body
+                .chunks_exact(4)
+                .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+                .collect(),
+        };
 
-        let version = u16::from_le_bytes([header[4], header[5]]);
-        anyhow::ensure!(
-            version == VERSION,
-            "Unsupported cch.weights version {} (expected {}). \
-             v1 stored deciseconds/millimeters; re-run step 8 to regenerate as v2 (seconds/meters, #297).",
-            version,
-            VERSION,
-        );
+        // Read down weights at width.
+        let down_byte_count = down_width.bytes_per_entry() * n_down;
+        let mut down_body = vec![0u8; down_byte_count];
+        reader.read_exact(&mut down_body)?;
+        crc_digest.update(&down_body);
+        let down_vec: Vec<u32> = match down_width {
+            WeightWidth::U16 => decode_u16_to_u32_vec(&down_body),
+            WeightWidth::U32 => down_body
+                .chunks_exact(4)
+                .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+                .collect(),
+        };
 
-        let n_up = u64::from_le_bytes([
-            header[8], header[9], header[10], header[11], header[12], header[13], header[14],
-            header[15],
-        ]) as usize;
-        let n_down = u64::from_le_bytes([
-            header[16], header[17], header[18], header[19], header[20], header[21], header[22],
-            header[23],
-        ]) as usize;
-
-        // Read up weights
-        let mut up = Vec::with_capacity(n_up);
-        for _ in 0..n_up {
-            let mut buf = [0u8; 4];
-            reader.read_exact(&mut buf)?;
-            crc_digest.update(&buf);
-            up.push(u32::from_le_bytes(buf));
-        }
-
-        // Read down weights
-        let mut down = Vec::with_capacity(n_down);
-        for _ in 0..n_down {
-            let mut buf = [0u8; 4];
-            reader.read_exact(&mut buf)?;
-            crc_digest.update(&buf);
-            down.push(u32::from_le_bytes(buf));
-        }
-
-        let expected_v1_len = HEADER_LEN + 4 * (n_up + n_down) + FOOTER_LEN;
-        let expected_v2_len = expected_v1_len + 4 * (n_up + n_down);
+        let no_middle_len = HEADER_LEN + up_byte_count + down_byte_count + FOOTER_LEN;
+        let with_middle_len = no_middle_len + 4 * (n_up + n_down);
 
         let (up_middle, down_middle): (Vec<u32>, Vec<u32>) = match file_len {
-            len if len == expected_v1_len => (Vec::new(), Vec::new()),
-            len if len == expected_v2_len => {
-                // Read relaxed middle arrays (v2: after weights, before CRC)
+            len if len == no_middle_len => (Vec::new(), Vec::new()),
+            len if len == with_middle_len => {
                 let mut up_middle = Vec::with_capacity(n_up);
                 for _ in 0..n_up {
                     let mut buf = [0u8; 4];
@@ -354,14 +583,13 @@ impl CchWeightsFile {
                 (up_middle, down_middle)
             }
             len => anyhow::bail!(
-                "Invalid cch.weights size: got {}, expected {} (v1) or {} (v2)",
+                "Invalid cch.weights size: got {}, expected {} (no middles) or {} (with middles)",
                 len,
-                expected_v1_len,
-                expected_v2_len
+                no_middle_len,
+                with_middle_len
             ),
         };
 
-        // Verify CRC64
         let computed_crc = crc_digest.finalize();
         let mut footer = [0u8; FOOTER_LEN];
         reader.read_exact(&mut footer)?;
@@ -374,17 +602,46 @@ impl CchWeightsFile {
         );
 
         Ok(CchWeights {
-            up: ArcCow::from_vec(up),
-            down: ArcCow::from_vec(down),
+            up: WeightArray::from_vec_u32(up_vec),
+            down: WeightArray::from_vec_u32(down_vec),
             up_middle: ArcCow::from_vec(up_middle),
             down_middle: ArcCow::from_vec(down_middle),
         })
     }
 }
 
-/// Parse the 32-byte CCH weights header and return `(n_up, n_down)`.
+/// Decode a u16-compact body into a `Vec<u32>`, mapping the
+/// `u16::MAX` sentinel back to `u32::MAX`.
+#[inline]
+fn decode_u16_to_u32_vec(bytes: &[u8]) -> Vec<u32> {
+    bytes
+        .chunks_exact(2)
+        .map(|c| {
+            let v = u16::from_le_bytes(c.try_into().unwrap());
+            if v == u16::MAX { u32::MAX } else { v as u32 }
+        })
+        .collect()
+}
+
+/// Parsed cch.weights header.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CchWeightsHeader {
+    pub n_up: usize,
+    pub n_down: usize,
+    pub up_width: WeightWidth,
+    pub down_width: WeightWidth,
+}
+
+/// Parse the 32-byte CCH weights header.
+///
+/// v3 (#306 PR 2): header byte 7 carries `width_flags`:
+///   bit 0 → up body is u16  (else u32)
+///   bit 1 → down body is u16 (else u32)
+///
+/// v2 readers wrote 0 in byte 7, so a v2-as-v3 read sees
+/// `up_width = down_width = U32` — exactly the v2 semantic.
 /// Shared by the owned, zero-copy, and mmap-backed readers.
-fn parse_header(header: &[u8]) -> Result<(usize, usize)> {
+fn parse_header(header: &[u8]) -> Result<CchWeightsHeader> {
     anyhow::ensure!(
         header.len() >= HEADER_LEN,
         "cch.weights header too short: {} bytes",
@@ -397,17 +654,33 @@ fn parse_header(header: &[u8]) -> Result<(usize, usize)> {
         MAGIC,
         magic
     );
-    // #297: enforce v2 (seconds/meters). v1 (deciseconds/millimeters)
-    // is rejected — re-run step 8 to regenerate.
     let version = u16::from_le_bytes(header[4..6].try_into().unwrap());
     anyhow::ensure!(
-        version == VERSION,
-        "Unsupported cch.weights version {} (expected {}). \
-         v1 stored deciseconds/millimeters; re-run step 8 to regenerate as v2 (seconds/meters, #297).",
+        version == VERSION || version == VERSION_V2,
+        "Unsupported cch.weights version {} (expected {} or {}). \
+         v1 stored deciseconds/millimeters; re-run step 8 to regenerate \
+         as v2/v3 (seconds/meters, #297/#306).",
         version,
         VERSION,
+        VERSION_V2,
     );
+    let width_flags = if version == VERSION { header[7] } else { 0 };
+    let up_width = if width_flags & UP_COMPACT_FLAG != 0 {
+        WeightWidth::U16
+    } else {
+        WeightWidth::U32
+    };
+    let down_width = if width_flags & DOWN_COMPACT_FLAG != 0 {
+        WeightWidth::U16
+    } else {
+        WeightWidth::U32
+    };
     let n_up = u64::from_le_bytes(header[8..16].try_into().unwrap()) as usize;
     let n_down = u64::from_le_bytes(header[16..24].try_into().unwrap()) as usize;
-    Ok((n_up, n_down))
+    Ok(CchWeightsHeader {
+        n_up,
+        n_down,
+        up_width,
+        down_width,
+    })
 }

--- a/route/src/formats/mod.rs
+++ b/route/src/formats/mod.rs
@@ -59,7 +59,7 @@ pub mod cch_weights;
 
 pub use bitset::BitsetField;
 pub use cch_topo::{CchTopo, CchTopoFile, Shortcut};
-pub use cch_weights::{CchWeights, CchWeightsFile};
+pub use cch_weights::{CchWeights, CchWeightsFile, WeightArray, WeightWidth};
 pub use ebg_csr::{EbgCsr, EbgCsrFile};
 pub use ebg_nodes::{EbgNode, EbgNodes, EbgNodesFile};
 pub use ebg_turn_table::{TurnEntry, TurnKind, TurnTable, TurnTableFile};

--- a/route/src/matrix/batched_phast.rs
+++ b/route/src/matrix/batched_phast.rs
@@ -171,7 +171,7 @@ impl BatchedPhastEngine {
 
                 for i in up_start..up_end {
                     let v = self.topo.up_targets[i];
-                    let w = self.weights.up[i];
+                    let w = self.weights.up.get(i);
 
                     if w == u32::MAX {
                         continue;
@@ -226,7 +226,7 @@ impl BatchedPhastEngine {
             for i in down_start..down_end {
                 // v is the target's rank (rank-aligned CCH)
                 let v = self.topo.down_targets[i] as usize;
-                let w = self.weights.down[i];
+                let w = self.weights.down.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -331,7 +331,7 @@ impl BatchedPhastEngine {
 
                 for i in up_start..up_end {
                     let v = self.topo.up_targets[i];
-                    let w = self.weights.up[i];
+                    let w = self.weights.up.get(i);
 
                     if w == u32::MAX {
                         continue;
@@ -401,7 +401,7 @@ impl BatchedPhastEngine {
             // Relax DOWN edges for active lanes only
             for i in down_start..down_end {
                 let v = self.topo.down_targets[i] as usize;
-                let w = self.weights.down[i];
+                let w = self.weights.down.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -508,7 +508,7 @@ impl BatchedPhastEngine {
 
                 for i in up_start..up_end {
                     let v = self.topo.up_targets[i];
-                    let w = self.weights.up[i];
+                    let w = self.weights.up.get(i);
 
                     if w == u32::MAX {
                         continue;
@@ -563,7 +563,7 @@ impl BatchedPhastEngine {
 
             for i in down_start..down_end {
                 let v = self.topo.down_targets[i] as usize;
-                let w = self.weights.down[i];
+                let w = self.weights.down.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -835,7 +835,7 @@ impl BatchedPhastEngine {
 
                 for i in up_start..up_end {
                     let v = self.topo.up_targets[i];
-                    let w = self.weights.up[i];
+                    let w = self.weights.up.get(i);
 
                     if w == u32::MAX {
                         continue;
@@ -884,7 +884,7 @@ impl BatchedPhastEngine {
 
             for i in down_start..down_end {
                 let v = self.topo.down_targets[i] as usize;
-                let w = self.weights.down[i];
+                let w = self.weights.down.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -1010,7 +1010,7 @@ impl BatchedPhastEngine {
 
                 for i in up_start..up_end {
                     let v = self.topo.up_targets[i];
-                    let w = self.weights.up[i];
+                    let w = self.weights.up.get(i);
 
                     if w == u32::MAX {
                         continue;
@@ -1096,7 +1096,7 @@ impl BatchedPhastEngine {
 
                 for i in down_start..down_end {
                     let v = self.topo.down_targets[i] as usize;
-                    let w = self.weights.down[i];
+                    let w = self.weights.down.get(i);
 
                     if w == u32::MAX {
                         continue;
@@ -1164,7 +1164,7 @@ impl BatchedPhastEngine {
                     // Relax DOWN edges for active lanes only
                     for i in down_start..down_end {
                         let v = self.topo.down_targets[i] as usize;
-                        let w = self.weights.down[i];
+                        let w = self.weights.down.get(i);
 
                         if w == u32::MAX {
                             continue;

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -94,7 +94,7 @@ impl UpAdjFlat {
             let start = topo.up_offsets[source] as usize;
             let end = topo.up_offsets[source + 1] as usize;
             for i in start..end {
-                if weights.up[i] != u32::MAX {
+                if weights.up.get(i) != u32::MAX {
                     *count += 1;
                 }
             }
@@ -127,7 +127,7 @@ impl UpAdjFlat {
             let end = topo.up_offsets[source + 1] as usize;
 
             for i in start..end {
-                let w = weights.up[i];
+                let w = weights.up.get(i);
                 if w == u32::MAX {
                     continue;
                 }
@@ -180,7 +180,7 @@ impl DownAdjFlat {
             let start = topo.down_offsets[source] as usize;
             let end = topo.down_offsets[source + 1] as usize;
             for i in start..end {
-                if weights.down[i] != u32::MAX {
+                if weights.down.get(i) != u32::MAX {
                     *count += 1;
                 }
             }
@@ -203,7 +203,7 @@ impl DownAdjFlat {
             let start = topo.down_offsets[source] as usize;
             let end = topo.down_offsets[source + 1] as usize;
             for i in start..end {
-                let w = weights.down[i];
+                let w = weights.down.get(i);
                 if w == u32::MAX {
                     continue;
                 }
@@ -250,7 +250,7 @@ impl DownReverseAdjFlat {
             let start = topo.down_offsets[source] as usize;
             let end = topo.down_offsets[source + 1] as usize;
             for i in start..end {
-                if weights.down[i] != u32::MAX {
+                if weights.down.get(i) != u32::MAX {
                     let target = topo.down_targets[i] as usize;
                     counts[target] += 1;
                 }
@@ -280,7 +280,7 @@ impl DownReverseAdjFlat {
             let start = topo.down_offsets[source] as usize;
             let end = topo.down_offsets[source + 1] as usize;
             for i in start..end {
-                let w = weights.down[i];
+                let w = weights.down.get(i);
                 if w == u32::MAX {
                     continue;
                 }
@@ -1904,10 +1904,13 @@ fn forward_fill_buckets_flat(
     }
 }
 
-/// Forward search from source using UP edges, collecting bucket items
+/// Forward search from source using UP edges, collecting bucket items.
+/// Takes `&WeightArray` so the caller's `cch_weights.up` (which may be
+/// `U16` or `U32` per #306 PR 2) passes through transparently — the
+/// hot path stays one widening read per edge.
 fn forward_fill_buckets_opt(
     topo: &CchTopo,
-    weights_up: &[u32],
+    weights_up: &crate::formats::WeightArray,
     source_idx: u32,
     source: u32,
     state: &mut SearchState,
@@ -1923,14 +1926,11 @@ fn forward_fill_buckets_opt(
         let start = topo.up_offsets[u as usize] as usize;
         let end = topo.up_offsets[u as usize + 1] as usize;
 
-        for (&v, &w) in topo.up_targets[start..end]
-            .iter()
-            .zip(&weights_up[start..end])
-        {
+        for (slot, &v) in topo.up_targets[start..end].iter().enumerate() {
+            let w = weights_up.get(start + slot);
             if w == u32::MAX {
                 continue;
             }
-
             let new_dist = d.saturating_add(w);
             state.relax(v, new_dist);
         }
@@ -2694,7 +2694,7 @@ mod step_a_tests {
         for (slot, &topo_idx) in flat.topo_edge_idx.iter().enumerate() {
             let i = topo_idx as usize;
             assert_eq!(flat.targets[slot], topo.up_targets[i]);
-            assert_eq!(flat.weights[slot], w.up[i]);
+            assert_eq!(flat.weights[slot], w.up.get(i));
         }
     }
 
@@ -2723,7 +2723,7 @@ mod step_a_tests {
             let s_off = topo.down_offsets[source] as usize;
             let s_end = topo.down_offsets[source + 1] as usize;
             for i in s_off..s_end {
-                let w_topo = w.down[i];
+                let w_topo = w.down.get(i);
                 if w_topo == u32::MAX {
                     continue;
                 }
@@ -2750,7 +2750,7 @@ mod step_a_tests {
 
         for (slot, &topo_idx) in flat.topo_edge_idx.iter().enumerate() {
             let i = topo_idx as usize;
-            assert_eq!(flat.weights[slot], w.down[i]);
+            assert_eq!(flat.weights[slot], w.down.get(i));
         }
     }
 

--- a/route/src/range/mod.rs
+++ b/route/src/range/mod.rs
@@ -169,7 +169,7 @@ impl RangeEngine {
 
             for i in up_start..up_end {
                 let v = self.topo.up_targets[i];
-                let w = self.weights.up[i];
+                let w = self.weights.up.get(i);
 
                 if w == u32::MAX {
                     continue; // Skip infinite weight edges
@@ -196,7 +196,7 @@ impl RangeEngine {
 
             for i in down_start..down_end {
                 let v = self.topo.down_targets[i];
-                let w = self.weights.down[i];
+                let w = self.weights.down.get(i);
 
                 if w == u32::MAX {
                     continue; // Skip infinite weight edges
@@ -233,7 +233,7 @@ impl RangeEngine {
 
                 for i in up_start..up_end {
                     let v = self.topo.up_targets[i];
-                    let w = self.weights.up[i];
+                    let w = self.weights.up.get(i);
                     if w != u32::MAX {
                         let d_v = d_u.saturating_add(w);
                         // Check if this edge crosses the threshold
@@ -255,7 +255,7 @@ impl RangeEngine {
 
                 for i in down_start..down_end {
                     let v = self.topo.down_targets[i];
-                    let w = self.weights.down[i];
+                    let w = self.weights.down.get(i);
                     if w != u32::MAX {
                         let d_v = d_u.saturating_add(w);
                         if d_v > threshold_ms {

--- a/route/src/range/phast.rs
+++ b/route/src/range/phast.rs
@@ -186,7 +186,7 @@ impl PhastEngine {
 
             for i in up_start..up_end {
                 let v = self.topo.up_targets[i];
-                let w = self.weights.up[i];
+                let w = self.weights.up.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -233,7 +233,7 @@ impl PhastEngine {
             for i in down_start..down_end {
                 // v is the target's rank (rank-aligned CCH)
                 let v = self.topo.down_targets[i] as usize;
-                let w = self.weights.down[i];
+                let w = self.weights.down.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -325,7 +325,7 @@ impl PhastEngine {
 
             for i in up_start..up_end {
                 let v = self.topo.up_targets[i];
-                let w = self.weights.up[i];
+                let w = self.weights.up.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -376,7 +376,7 @@ impl PhastEngine {
 
                 for i in down_start..down_end {
                     let v = self.topo.down_targets[i] as usize;
-                    let w = self.weights.down[i];
+                    let w = self.weights.down.get(i);
 
                     if w == u32::MAX {
                         continue;
@@ -418,7 +418,7 @@ impl PhastEngine {
 
                     for i in down_start..down_end {
                         let v = self.topo.down_targets[i] as usize;
-                        let w = self.weights.down[i];
+                        let w = self.weights.down.get(i);
 
                         if w == u32::MAX {
                             continue;
@@ -503,7 +503,7 @@ impl PhastEngine {
 
             for i in up_start..up_end {
                 let v = self.topo.up_targets[i];
-                let w = self.weights.up[i];
+                let w = self.weights.up.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -561,7 +561,7 @@ impl PhastEngine {
             for i in down_start..down_end {
                 // v is the target's rank (rank-aligned CCH)
                 let v = self.topo.down_targets[i] as usize;
-                let w = self.weights.down[i];
+                let w = self.weights.down.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -629,7 +629,7 @@ impl PhastEngine {
 
             for i in up_start..up_end {
                 let v = self.topo.up_targets[i];
-                let w = self.weights.up[i];
+                let w = self.weights.up.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -667,7 +667,7 @@ impl PhastEngine {
             for i in down_start..down_end {
                 // v is the target's rank (rank-aligned CCH)
                 let v = self.topo.down_targets[i] as usize;
-                let w = self.weights.down[i];
+                let w = self.weights.down.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -762,7 +762,7 @@ impl PhastEngine {
 
             for i in up_start..up_end {
                 let v = self.topo.up_targets[i];
-                let w = self.weights.up[i];
+                let w = self.weights.up.get(i);
 
                 if w == u32::MAX {
                     continue;
@@ -826,7 +826,7 @@ impl PhastEngine {
 
                 for i in down_start..down_end {
                     let v = self.topo.down_targets[i] as usize;
-                    let w = self.weights.down[i];
+                    let w = self.weights.down.get(i);
 
                     if w == u32::MAX {
                         continue;
@@ -1128,7 +1128,7 @@ impl PhastEngine {
 
             for i in up_start..up_end {
                 let v = self.topo.up_targets[i];
-                let w = self.weights.up[i];
+                let w = self.weights.up.get(i);
                 if w != u32::MAX {
                     let d_v = dist[v as usize];
                     if d_v > threshold {
@@ -1149,7 +1149,7 @@ impl PhastEngine {
 
             for i in down_start..down_end {
                 let v = self.topo.down_targets[i];
-                let w = self.weights.down[i];
+                let w = self.weights.down.get(i);
                 if w != u32::MAX {
                     let d_v = dist[v as usize];
                     if d_v > threshold {

--- a/route/src/server/consistency_test.rs
+++ b/route/src/server/consistency_test.rs
@@ -631,7 +631,7 @@ fn test_ghent_liege_unpacked_hops_exist_in_filtered_ebg() {
             rank_path[i + 1],
             edge_idx
         );
-        unpacked_dist_s += weights[edge_idx] as u64;
+        unpacked_dist_s += weights.get(edge_idx) as u64;
     }
 
     eprintln!(
@@ -663,7 +663,7 @@ fn test_ghent_liege_unpacked_hops_exist_in_filtered_ebg() {
             let edge_idx = (start..end)
                 .find(|&idx| targets[idx] == dst)
                 .expect("missing edge while summing path");
-            total += weights[edge_idx] as u64;
+            total += weights.get(edge_idx) as u64;
         }
         total
     };
@@ -672,7 +672,7 @@ fn test_ghent_liege_unpacked_hops_exist_in_filtered_ebg() {
     for (step, &(_node, edge_idx_u32)) in result.forward_parent.iter().enumerate() {
         let edge_idx = edge_idx_u32 as usize;
         let target = mode_data.cch_topo.up_targets[edge_idx];
-        let edge_weight = mode_data.cch_weights.up[edge_idx];
+        let edge_weight = mode_data.cch_weights.up.get(edge_idx);
         let expanded = unpack_path(
             &mode_data.cch_topo,
             &mode_data.cch_weights,
@@ -699,7 +699,7 @@ fn test_ghent_liege_unpacked_hops_exist_in_filtered_ebg() {
     for (step, &(node, edge_idx_u32)) in result.backward_parent.iter().rev().enumerate() {
         let edge_idx = edge_idx_u32 as usize;
         let target = mode_data.cch_topo.down_targets[edge_idx];
-        let edge_weight = mode_data.cch_weights.down[edge_idx];
+        let edge_weight = mode_data.cch_weights.down.get(edge_idx);
         let expanded = unpack_path(
             &mode_data.cch_topo,
             &mode_data.cch_weights,
@@ -746,15 +746,15 @@ fn test_alternative_routes_differ() {
     for &(_node, edge_idx) in &primary.forward_parent {
         let idx = edge_idx as usize;
         if idx < penalized.up.len() {
-            let new_val = penalized.up[idx].saturating_mul(3);
-            penalized.up.to_mut()[idx] = new_val;
+            let new_val = penalized.up.get(idx).saturating_mul(3);
+            penalized.up.to_mut_vec()[idx] = new_val;
         }
     }
     for &(_node, edge_idx) in &primary.backward_parent {
         let idx = edge_idx as usize;
         if idx < penalized.down.len() {
-            let new_val = penalized.down[idx].saturating_mul(3);
-            penalized.down.to_mut()[idx] = new_val;
+            let new_val = penalized.down.get(idx).saturating_mul(3);
+            penalized.down.to_mut_vec()[idx] = new_val;
         }
     }
 
@@ -1355,15 +1355,15 @@ fn test_alternative_routes_all_modes() {
             for &(_node, edge_idx) in &primary.forward_parent {
                 let idx = edge_idx as usize;
                 if idx < penalized.up.len() {
-                    let new_val = penalized.up[idx].saturating_mul(3);
-                    penalized.up.to_mut()[idx] = new_val;
+                    let new_val = penalized.up.get(idx).saturating_mul(3);
+                    penalized.up.to_mut_vec()[idx] = new_val;
                 }
             }
             for &(_node, edge_idx) in &primary.backward_parent {
                 let idx = edge_idx as usize;
                 if idx < penalized.down.len() {
-                    let new_val = penalized.down[idx].saturating_mul(3);
-                    penalized.down.to_mut()[idx] = new_val;
+                    let new_val = penalized.down.get(idx).saturating_mul(3);
+                    penalized.down.to_mut_vec()[idx] = new_val;
                 }
             }
 

--- a/route/src/server/exclude.rs
+++ b/route/src/server/exclude.rs
@@ -416,8 +416,8 @@ pub fn recustomize_weights_incremental(
     filtered_to_original: &[u32],
 ) -> CchWeights {
     let start = std::time::Instant::now();
-    let mut up_weights = base_weights.up.to_vec();
-    let mut down_weights = base_weights.down.to_vec();
+    let mut up_weights = base_weights.up.iter().collect::<Vec<u32>>();
+    let mut down_weights = base_weights.down.iter().collect::<Vec<u32>>();
     let mut up_middle = if base_weights.up_middle.len() == topo.up_targets.len() {
         base_weights.up_middle.to_vec()
     } else {
@@ -641,8 +641,8 @@ fn recompute_edge_weight(
         u32::MAX
     } else {
         match edge.dir {
-            EdgeDir::Up => base_weights.up[edge.idx],
-            EdgeDir::Down => base_weights.down[edge.idx],
+            EdgeDir::Up => base_weights.up.get(edge.idx),
+            EdgeDir::Down => base_weights.down.get(edge.idx),
         }
     };
     let mut best_middle = match edge.dir {

--- a/route/src/server/query.rs
+++ b/route/src/server/query.rs
@@ -259,7 +259,7 @@ fn reconstruct_path_versioned(
 /// that build per-call weight arrays. After #152 it reuses the SAME
 /// `UpAdjFlat`/`DownReverseAdjFlat` topology that the hot path uses —
 /// the flats already carry `topo_edge_idx`, so we look up custom
-/// weights via `weights.up[topo_edge_idx]` / `weights.down[topo_edge_idx]`
+/// weights via `weights.up.get(topo_edge_idx)` / `weights.down.get(topo_edge_idx)`
 /// and ignore the flat's embedded weights. This eliminates the
 /// duplicate `DownReverseAdj` Vec-of-Vec topology that #149 left
 /// stranded on the heap (~320 MB on Belgium across 4 modes).
@@ -336,7 +336,7 @@ impl<'a> CchQuery<'a> {
                 let end = up_adj_flat.offsets[u as usize + 1] as usize;
                 for slot in start..end {
                     let parent_idx = up_adj_flat.topo_edge_idx[slot];
-                    let w = weights.up[parent_idx as usize];
+                    let w = weights.up.get(parent_idx as usize);
                     if w == u32::MAX {
                         continue;
                     }
@@ -371,7 +371,7 @@ impl<'a> CchQuery<'a> {
                 let end = down_rev_flat.offsets[u as usize + 1] as usize;
                 for slot in start..end {
                     let parent_idx = down_rev_flat.topo_edge_idx[slot];
-                    let w = weights.down[parent_idx as usize];
+                    let w = weights.down.get(parent_idx as usize);
                     if w == u32::MAX {
                         continue;
                     }

--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -928,15 +928,15 @@ pub async fn route_handler(
         for &(_node, edge_idx) in &result.forward_parent {
             let idx = edge_idx as usize;
             if idx < penalized_weights.up.len() {
-                let new_val = penalized_weights.up[idx].saturating_mul(3);
-                penalized_weights.up.to_mut()[idx] = new_val;
+                let new_val = penalized_weights.up.get(idx).saturating_mul(3);
+                penalized_weights.up.to_mut_vec()[idx] = new_val;
             }
         }
         for &(_node, edge_idx) in &result.backward_parent {
             let idx = edge_idx as usize;
             if idx < penalized_weights.down.len() {
-                let new_val = penalized_weights.down[idx].saturating_mul(3);
-                penalized_weights.down.to_mut()[idx] = new_val;
+                let new_val = penalized_weights.down.get(idx).saturating_mul(3);
+                penalized_weights.down.to_mut_vec()[idx] = new_val;
             }
         }
 
@@ -971,15 +971,15 @@ pub async fn route_handler(
                 for &(_node, edge_idx) in &alt_result.forward_parent {
                     let idx = edge_idx as usize;
                     if idx < penalized_weights.up.len() {
-                        let new_val = penalized_weights.up[idx].saturating_mul(3);
-                        penalized_weights.up.to_mut()[idx] = new_val;
+                        let new_val = penalized_weights.up.get(idx).saturating_mul(3);
+                        penalized_weights.up.to_mut_vec()[idx] = new_val;
                     }
                 }
                 for &(_node, edge_idx) in &alt_result.backward_parent {
                     let idx = edge_idx as usize;
                     if idx < penalized_weights.down.len() {
-                        let new_val = penalized_weights.down[idx].saturating_mul(3);
-                        penalized_weights.down.to_mut()[idx] = new_val;
+                        let new_val = penalized_weights.down.get(idx).saturating_mul(3);
+                        penalized_weights.down.to_mut_vec()[idx] = new_val;
                     }
                 }
 

--- a/route/src/validate/cch_correctness.rs
+++ b/route/src/validate/cch_correctness.rs
@@ -413,7 +413,7 @@ fn build_down_reverse(
         let end = topo.down_offsets[u + 1] as usize;
         for i in start..end {
             let v = topo.down_targets[i] as usize;
-            let w = weights.down[i];
+            let w = weights.down.get(i);
             let idx = offsets[v] as usize + pos[v] as usize;
             sources[idx] = u as u32;
             rev_weights[idx] = w;
@@ -439,11 +439,11 @@ fn find_routable_nodes(
         // Check if has at least one finite outgoing edge (UP or DOWN)
         let up_start = topo.up_offsets[u] as usize;
         let up_end = topo.up_offsets[u + 1] as usize;
-        let has_up = (up_start..up_end).any(|i| weights.up[i] != u32::MAX);
+        let has_up = (up_start..up_end).any(|i| weights.up.get(i) != u32::MAX);
 
         let down_start = topo.down_offsets[u] as usize;
         let down_end = topo.down_offsets[u + 1] as usize;
-        let has_down = (down_start..down_end).any(|i| weights.down[i] != u32::MAX);
+        let has_down = (down_start..down_end).any(|i| weights.down.get(i) != u32::MAX);
 
         if has_up || has_down {
             routable.push(u as u32);
@@ -469,7 +469,7 @@ fn random_walk_neighbor(
         let up_start = topo.up_offsets[current as usize] as usize;
         let up_end = topo.up_offsets[current as usize + 1] as usize;
         for i in up_start..up_end {
-            if weights.up[i] != u32::MAX {
+            if weights.up.get(i) != u32::MAX {
                 neighbors.push(topo.up_targets[i]);
             }
         }
@@ -477,7 +477,7 @@ fn random_walk_neighbor(
         let down_start = topo.down_offsets[current as usize] as usize;
         let down_end = topo.down_offsets[current as usize + 1] as usize;
         for i in down_start..down_end {
-            if weights.down[i] != u32::MAX {
+            if weights.down.get(i) != u32::MAX {
                 neighbors.push(topo.down_targets[i]);
             }
         }
@@ -539,7 +539,7 @@ fn bidi_cch_query(
                 let end = topo.up_offsets[u_idx + 1] as usize;
                 for i in start..end {
                     let v = topo.up_targets[i];
-                    let w = weights.up[i];
+                    let w = weights.up.get(i);
                     if w == u32::MAX {
                         continue;
                     }
@@ -646,7 +646,7 @@ fn cch_dijkstra_query(
         let up_end = topo.up_offsets[u_idx + 1] as usize;
         for i in up_start..up_end {
             let v = topo.up_targets[i];
-            let w = weights.up[i];
+            let w = weights.up.get(i);
             if w == u32::MAX {
                 continue;
             }
@@ -671,7 +671,7 @@ fn cch_dijkstra_query(
         let down_end = topo.down_offsets[u_idx + 1] as usize;
         for i in down_start..down_end {
             let v = topo.down_targets[i];
-            let w = weights.down[i];
+            let w = weights.down.get(i);
             if w == u32::MAX {
                 continue;
             }
@@ -911,7 +911,7 @@ fn generate_regression_cases(
         let up_start = topo.up_offsets[u] as usize;
         let up_end = topo.up_offsets[u + 1] as usize;
         for i in up_start..up_end {
-            if weights.up[i] != u32::MAX && adjacent_count < 10 {
+            if weights.up.get(i) != u32::MAX && adjacent_count < 10 {
                 cases.push(RegressionCase {
                     name: "adjacent_up",
                     src: u as u32,
@@ -932,7 +932,7 @@ fn generate_regression_cases(
         let down_start = topo.down_offsets[u] as usize;
         let down_end = topo.down_offsets[u + 1] as usize;
         for i in down_start..down_end {
-            if weights.down[i] != u32::MAX && down_count < 10 {
+            if weights.down.get(i) != u32::MAX && down_count < 10 {
                 cases.push(RegressionCase {
                     name: "adjacent_down",
                     src: u as u32,
@@ -993,8 +993,8 @@ fn generate_regression_cases(
         let down_end = topo.down_offsets[u + 1] as usize;
 
         // Check if node has no finite edges
-        let has_finite_up = (up_start..up_end).any(|i| weights.up[i] != u32::MAX);
-        let has_finite_down = (down_start..down_end).any(|i| weights.down[i] != u32::MAX);
+        let has_finite_up = (up_start..up_end).any(|i| weights.up.get(i) != u32::MAX);
+        let has_finite_down = (down_start..down_end).any(|i| weights.down.get(i) != u32::MAX);
 
         if !has_finite_up && !has_finite_down {
             // This node is isolated - route to another node should fail
@@ -1031,7 +1031,7 @@ fn generate_regression_cases(
         let up_end = topo.up_offsets[u + 1] as usize;
 
         for i in up_start..up_end {
-            if weights.up[i] == u32::MAX {
+            if weights.up.get(i) == u32::MAX {
                 continue;
             }
             let v = topo.up_targets[i] as usize;
@@ -1040,7 +1040,7 @@ fn generate_regression_cases(
             let v_up_end = topo.up_offsets[v + 1] as usize;
 
             for j in v_up_start..v_up_end {
-                if weights.up[j] != u32::MAX && two_hop_count < 10 {
+                if weights.up.get(j) != u32::MAX && two_hop_count < 10 {
                     cases.push(RegressionCase {
                         name: "two_hop",
                         src: u as u32,
@@ -1070,7 +1070,7 @@ fn find_chain_start(
         let up_end = topo.up_offsets[u + 1] as usize;
 
         let finite_count = (up_start..up_end)
-            .filter(|&i| weights.up[i] != u32::MAX)
+            .filter(|&i| weights.up.get(i) != u32::MAX)
             .count();
 
         if finite_count == 1 {
@@ -1097,7 +1097,7 @@ fn follow_chain(
         // Find first finite neighbor
         let mut next = None;
         for i in up_start..up_end {
-            if weights.up[i] != u32::MAX {
+            if weights.up.get(i) != u32::MAX {
                 next = Some(topo.up_targets[i]);
                 break;
             }

--- a/route/src/validate/invariants.rs
+++ b/route/src/validate/invariants.rs
@@ -144,13 +144,13 @@ fn check_non_negative_weights(weights: &crate::formats::CchWeights, result: &mut
     let mut near_max_up = 0usize;
     let mut near_max_down = 0usize;
 
-    for &w in weights.up.iter() {
+    for w in weights.up.iter() {
         if w >= near_max_threshold && w != u32::MAX {
             near_max_up += 1;
         }
     }
 
-    for &w in weights.down.iter() {
+    for w in weights.down.iter() {
         if w >= near_max_threshold && w != u32::MAX {
             near_max_down += 1;
         }
@@ -178,7 +178,7 @@ fn check_weight_domain(weights: &crate::formats::CchWeights, result: &mut Invari
     let mut excessive_up = 0usize;
     let mut excessive_down = 0usize;
 
-    for &w in weights.up.iter() {
+    for w in weights.up.iter() {
         if w == u32::MAX {
             inf_up += 1;
         } else {
@@ -192,7 +192,7 @@ fn check_weight_domain(weights: &crate::formats::CchWeights, result: &mut Invari
         }
     }
 
-    for &w in weights.down.iter() {
+    for w in weights.down.iter() {
         if w == u32::MAX {
             inf_down += 1;
         } else {
@@ -256,8 +256,8 @@ fn check_inf_consistency(
         let down_start = topo.down_offsets[u] as usize;
         let down_end = topo.down_offsets[u + 1] as usize;
 
-        let has_finite_up = (up_start..up_end).any(|i| weights.up[i] != u32::MAX);
-        let has_finite_down = (down_start..down_end).any(|i| weights.down[i] != u32::MAX);
+        let has_finite_up = (up_start..up_end).any(|i| weights.up.get(i) != u32::MAX);
+        let has_finite_down = (down_start..down_end).any(|i| weights.down.get(i) != u32::MAX);
 
         if !has_finite_up && !has_finite_down && (up_end > up_start || down_end > down_start) {
             isolated_nodes += 1;
@@ -428,16 +428,14 @@ fn check_overflow_potential(
     let max_finite_up = weights
         .up
         .iter()
-        .filter(|&&w| w != u32::MAX)
+        .filter(|&w| w != u32::MAX)
         .max()
-        .copied()
         .unwrap_or(0);
     let max_finite_down = weights
         .down
         .iter()
-        .filter(|&&w| w != u32::MAX)
+        .filter(|&w| w != u32::MAX)
         .max()
-        .copied()
         .unwrap_or(0);
     let max_weight = max_finite_up.max(max_finite_down);
 
@@ -484,7 +482,7 @@ fn check_tie_breaking_readiness(
         // Collect finite weights and targets
         let mut edges: Vec<(u32, u32)> = Vec::new();
         for i in up_start..up_end {
-            let w = weights.up[i];
+            let w = weights.up.get(i);
             if w != u32::MAX {
                 edges.push((w, topo.up_targets[i]));
             }


### PR DESCRIPTION
## Summary

Lands the **u16 codec for cch.weights** (#306 plan PR 2). The on-disk file gets a new format v3 with a per-direction body-width flag; step 8 picks the smallest losslessly-fitting width per direction; the runtime widens transparently via a new `WeightArray` smart-accessor.

This is the second of four PRs in the #306 codec plan:

| PR | Scope | Status |
|---|---|---|
| 1 | Drop semantic precision (ds→s, mm→m) | landed via #323 |
| **2** | **u16 codec for time weights** | **this PR** |
| 3 | u24 codec for distance weights + foot u16+overflow | next |
| 4 | Flat-adjacency propagation (runtime RSS win) | after 3 |

## Format v3

Header (32 B, unchanged size) carries `width_flags` at byte 7:

| bit | meaning |
|---|---|
| 0 | up body is u16 (else u32) |
| 1 | down body is u16 (else u32) |

Body:

```
up_body     width_up · n_up   (u16 or u32)
down_body   width_down · n_down
up_middle   4 · n_up   (always u32 — middle node ids can exceed u16)
down_middle 4 · n_down
```

v2 readers see `width_flags == 0` and get the v2 semantic (u32/u32). v1 is still rejected — re-run step 8.

## Smart accessor

`CchWeights.up` / `.down` switch from `ArcCow<u32>` to:

```rust
pub enum WeightArray {
    U16(ArcCow<u16>),
    U32(ArcCow<u32>),
}
```

The mmap path stays zero-copy: U16 variant holds an `ArcCow<u16>` backed by the container mmap. After `madvise(DONTNEED)` at boot, the kernel can evict the section pages just like the v2 case — **steady-state RSS is identical** to v2, the disk savings + boot-time peak RSS shrink immediately.

Accessors:
```rust
fn get(&self, i: usize) -> u32           // widens U16, MAX-sentinel maps
fn len(&self) -> usize
fn iter(&self) -> WeightArrayIter        // owned u32 items
fn to_mut_vec(&mut self) -> &mut Vec<u32>  // upgrade for mutation
```

## ~50 consumer sites migrated

Mechanical `.up[i]` → `.up.get(i)` across:
- `server/{query,route,exclude,consistency_test}.rs`
- `range/{mod,phast}.rs`
- `matrix/{bucket_ch,batched_phast}.rs`
- `validate/{invariants,cch_correctness}.rs`
- `bench/{main,weight_profile}.rs`

`forward_fill_buckets_opt` now takes `&WeightArray` directly (one branch per edge read on the matrix hot loop; U32 path has zero overhead, U16 only adds a sentinel check).

## Belgium results

Per-mode profile, confirmed against v2 step-8 outputs:

| mode | direction | max | u16 overflow | chosen width |
|---|---|---|---|---|
| car | up | 23 881 | 0% | **u16** |
| car | down | 21 939 | 0% | **u16** |
| bike | up | 50 600 | 0% | **u16** |
| bike | down | 48 779 | 0% | **u16** |
| foot | up | 181 794 | 1.67% | u32 |
| foot | down | 195 310 | 1.71% | u32 |

**Disk** (Belgium car):
- v2 cch.w.car.u32 = 289 893 576 B
- v3 cch.w.car.u32 = 217 420 194 B  **(−25%)** — weights halved; middles stay u32 until PR 3 adds u24.

**Smoke** (Belgium car, /route Brussels→Antwerp):
- duration_s = 3 082.0 (byte-identical to v2)
- distance_m = 25 938.0 (byte-identical)
- 116 steps, 104 named (identical to v2 path)

## What this does NOT yet ship

- **Foot weights**: still u32 (1.67% u16-overflow rate). PR 3 lands u24+overflow-table.
- **Middle arrays**: still u32. PR 3 lands u24 for middles (node ids fit ≤ 16 M on planet-scale CCH).
- **Flat propagation**: `UpAdjFlat` / `DownReverseAdjFlat` still embed u32 weights. PR 4 is the actual runtime-RSS-reduction step — those flats can't be madvise'd because they're on the hot path.

## Test plan

- [x] `cargo test --workspace --lib`: 548 pass, 0 fail
- [x] Re-ran step 8 on Belgium car: 1m25s, produced 217 MiB v3 file
- [x] Verified header bytes: magic CCHW + version 03 + flags 0b11 (both u16)
- [x] Server boots from v3 container; `/route` byte-identical to v2 baseline
- [ ] Re-run step 8 for bike + foot (in progress as I write this)
- [ ] Run `bucket-m2m` bench post-rebuild to confirm no latency regression

Closes #306 PR 2.