### PR TITLE
fix(reviews): #328 post-merge — 4 Copilot inline comments addressed

### DIFF
--- a/route/src/customization.rs
+++ b/route/src/customization.rs
@@ -1141,8 +1141,9 @@ fn write_weights_body<W: std::io::Write>(
 }
 
 /// Emit 0-3 zero bytes so the next array begins on a 4-byte boundary.
-/// u32 bodies are already 4-aligned; only u16 needs 2 bytes of pad
-/// when `n` is odd.
+/// u32 bodies are already 4-aligned; u16 needs 0-2 bytes of pad when
+/// `n` is odd; u24 needs 0-3 bytes of pad to round `n * 3` up to the
+/// next multiple of 4. CRC covers the padding.
 fn write_padding<W: std::io::Write>(
     writer: &mut W,
     crc_digest: &mut crate::formats::crc::Digest,

--- a/route/src/formats/cch_weights.rs
+++ b/route/src/formats/cch_weights.rs
@@ -227,7 +227,7 @@ impl WeightArray {
     /// same storage `get` / `iter` reads from.
     pub fn to_mut_vec(&mut self) -> &mut Vec<u32> {
         match self {
-            Self::U16(_) | Self::U24 { .. } => {
+            Self::U16(_) | Self::U24(_) => {
                 let widened: Vec<u32> = (0..self.len()).map(|i| self.get(i)).collect();
                 *self = Self::U32(ArcCow::from_vec(widened));
             }
@@ -408,14 +408,14 @@ impl CchWeightsFile {
             down_width,
         } = parse_header(header)?;
 
-        // Layout v3 (with optional middle arrays):
-        //   header(32) | up(width_up·n_up [+0-2 pad]) | down(width_down·n_down [+0-2 pad])
-        //              | [v3 middles: up_middle(4·n_up) | down_middle(4·n_down)]
+        // Layout v4 (with optional middle arrays):
+        //   header(32) | up(width_up·n_up [+0-3 pad]) | down(width_down·n_down [+0-3 pad])
+        //              | [middles: up_middle(4·n_up) | down_middle(4·n_down)]
         //              | footer(16)
         //
-        // u16 bodies are padded up to a 4-byte boundary so the
-        // following arrays (the other direction's body and the u32
-        // middles) stay aligned for `bytemuck::cast_slice` /
+        // u16 bodies pad 0-2 bytes; u24 bodies pad 0-3 bytes. The pad
+        // keeps the following arrays (the other direction's body and
+        // the u32 middles) 4-byte aligned for `bytemuck::cast_slice` /
         // `ArcCow::<u32>::from_mmap`.
         let up_bytes = up_width.padded_body_bytes(n_up);
         let down_bytes = down_width.padded_body_bytes(n_down);
@@ -492,11 +492,11 @@ impl CchWeightsFile {
             down_width,
         } = parse_header(header)?;
 
-        // v3 layout (with optional middles, per-direction body width):
-        //   header(32) | up(width_up·n_up [+0-2 pad]) | down(width_down·n_down [+0-2 pad])
+        // v4 layout (with optional middles, per-direction body width):
+        //   header(32) | up(width_up·n_up [+0-3 pad]) | down(width_down·n_down [+0-3 pad])
         //              | [up_middle(4·n_up) | down_middle(4·n_down)]
         //              | footer(16)
-        // u16 bodies pad up to 4-byte boundary — see `padded_body_bytes`.
+        // u16/u24 bodies pad up to 4-byte boundary — see `padded_body_bytes`.
         let up_bytes = up_width.padded_body_bytes(n_up);
         let down_bytes = down_width.padded_body_bytes(n_down);
         let no_middle_len = HEADER_LEN + up_bytes + down_bytes + FOOTER_LEN;
@@ -735,12 +735,13 @@ pub(crate) struct CchWeightsHeader {
 
 /// Parse the 32-byte CCH weights header.
 ///
-/// v3 (#306 PR 2): header byte 7 carries `width_flags`:
-///   bit 0 → up body is u16  (else u32)
-///   bit 1 → down body is u16 (else u32)
+/// v4 (#306 PR 3): header byte 7 carries a 2-bit per-direction width
+/// code:
+///   bits 0..2: up_width   { 00=u32, 01=u16, 10=u24, 11=reserved }
+///   bits 2..4: down_width { same encoding }
+///   bits 4..8: reserved
 ///
-/// v2 readers wrote 0 in byte 7, so a v2-as-v3 read sees
-/// `up_width = down_width = U32` — exactly the v2 semantic.
+/// Anything other than v4 is rejected — re-run step 8 to regenerate.
 /// Shared by the owned, zero-copy, and mmap-backed readers.
 fn parse_header(header: &[u8]) -> Result<CchWeightsHeader> {
     anyhow::ensure!(


### PR DESCRIPTION
## Summary

PR #328 merged cleanly but Copilot's review landed ~60 s after the squash with 4 inline findings. Addressing them now.

### 4 fixes

| Site | Issue | Fix |
|---|---|---|
| cch_weights.rs:230 | `to_mut_vec` used `Self::U24 { .. }` struct-pattern syntax on a tuple variant | switched to idiomatic `Self::U24(_)` (matches the file's other tuple-pattern matches) |
| cch_weights.rs:412 | Mmap reader's layout comment still said "Layout v3 / u16 bodies pad 0-2 bytes" | rewrote to mention v4 + u24 + 0-3 byte padding |
| cch_weights.rs:495 | Bytes (zero-copy) reader had the same stale v3 comment | same fix |
| cch_weights.rs:738 | `parse_header` doc described the v2/v3 single-bit `width_flags` layout | rewrote to spell out the v4 2-bit code: `00=u32, 01=u16, 10=u24, 11=reserved` |
| customization.rs:1144 | `write_padding` doc said only u16 needs pad | u24 also needs 0-3 bytes; updated |

The first one was a real correctness clarification (Rust accepts the wildcard pattern on a tuple variant but the idiomatic form is `(_)`). The other 4 were doc-stale-with-code that would have misled future readers.

## Test plan

- [x] `cargo build --workspace --release`: clean
- [x] `cargo test --workspace --lib`: **559 pass**, 0 fail