### PR TITLE
fix(reviews): #326 + #329 followup — from_arccow_u32 + padding doc precision

### DIFF
--- a/route/src/customization.rs
+++ b/route/src/customization.rs
@@ -1141,9 +1141,9 @@ fn write_weights_body<W: std::io::Write>(
 }
 
 /// Emit 0-3 zero bytes so the next array begins on a 4-byte boundary.
-/// u32 bodies are already 4-aligned; u16 needs 0-2 bytes of pad when
-/// `n` is odd; u24 needs 0-3 bytes of pad to round `n * 3` up to the
-/// next multiple of 4. CRC covers the padding.
+/// u32 bodies are already 4-aligned; u16 needs exactly 2 bytes of pad
+/// when `n` is odd (else 0); u24 needs 0, 1, 2, or 3 bytes of pad to
+/// round `n * 3` up to the next multiple of 4. CRC covers the padding.
 fn write_padding<W: std::io::Write>(
     writer: &mut W,
     crc_digest: &mut crate::formats::crc::Digest,

--- a/route/src/formats/cch_weights.rs
+++ b/route/src/formats/cch_weights.rs
@@ -255,6 +255,15 @@ impl WeightArray {
         Self::U32(ArcCow::from_vec(v))
     }
 
+    /// Wrap an existing `ArcCow<u32>` at the U32 width. Use this for
+    /// mmap-backed flats so the underlying mapping is preserved
+    /// (zero-copy) and call sites don't reach for the enum variant
+    /// directly.
+    #[inline]
+    pub fn from_arccow_u32(arc: ArcCow<u32>) -> Self {
+        Self::U32(arc)
+    }
+
     /// Construct from an owned `Vec<u16>` at the U16 width.
     #[inline]
     pub fn from_vec_u16(v: Vec<u16>) -> Self {
@@ -413,10 +422,11 @@ impl CchWeightsFile {
         //              | [middles: up_middle(4·n_up) | down_middle(4·n_down)]
         //              | footer(16)
         //
-        // u16 bodies pad 0-2 bytes; u24 bodies pad 0-3 bytes. The pad
-        // keeps the following arrays (the other direction's body and
-        // the u32 middles) 4-byte aligned for `bytemuck::cast_slice` /
-        // `ArcCow::<u32>::from_mmap`.
+        // u16 bodies pad 0 or 2 bytes (exactly 2 when `n_up`/`n_down`
+        // is odd, else 0); u24 bodies pad 0, 1, 2, or 3 bytes to round
+        // `n * 3` up to a 4-byte boundary. The pad keeps the following
+        // arrays (the other direction's body and the u32 middles)
+        // 4-byte aligned for `bytemuck::cast_slice` / `ArcCow::<u32>::from_mmap`.
         let up_bytes = up_width.padded_body_bytes(n_up);
         let down_bytes = down_width.padded_body_bytes(n_down);
         let body_no_middle = up_bytes

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -699,7 +699,9 @@ impl UpAdjFlatFile {
         let offsets =
             ArcCow::<u64>::from_mmap(std::sync::Arc::clone(&mmap), offsets_abs, n_nodes + 1)?;
         let targets = ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), targets_abs, n_edges)?;
-        let weights = crate::formats::WeightArray::U32(ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), weights_abs, n_edges)?);
+        let weights = crate::formats::WeightArray::from_arccow_u32(
+            ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), weights_abs, n_edges)?,
+        );
         let topo_edge_idx = if has_topo_idx {
             ArcCow::<u32>::from_mmap(mmap, topo_abs, n_edges)?
         } else {
@@ -809,7 +811,9 @@ impl DownAdjFlatFile {
         let offsets =
             ArcCow::<u64>::from_mmap(std::sync::Arc::clone(&mmap), offsets_abs, n_nodes + 1)?;
         let targets = ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), targets_abs, n_edges)?;
-        let weights = crate::formats::WeightArray::U32(ArcCow::<u32>::from_mmap(mmap, weights_abs, n_edges)?);
+        let weights = crate::formats::WeightArray::from_arccow_u32(
+            ArcCow::<u32>::from_mmap(mmap, weights_abs, n_edges)?,
+        );
         Ok(DownAdjFlat {
             offsets,
             targets,
@@ -925,7 +929,9 @@ impl DownReverseAdjFlatFile {
         let offsets =
             ArcCow::<u64>::from_mmap(std::sync::Arc::clone(&mmap), offsets_abs, n_nodes + 1)?;
         let sources = ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), sources_abs, n_edges)?;
-        let weights = crate::formats::WeightArray::U32(ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), weights_abs, n_edges)?);
+        let weights = crate::formats::WeightArray::from_arccow_u32(
+            ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), weights_abs, n_edges)?,
+        );
         let topo_edge_idx = if has_topo_idx {
             ArcCow::<u32>::from_mmap(mmap, topo_abs, n_edges)?
         } else {


### PR DESCRIPTION
## Summary

- **PR #326 review** — 3 mmap-backed call sites in `matrix/bucket_ch.rs` (lines 702/812/928 on the original PR) constructed `WeightArray::U32(...)` directly. Copilot flagged the encapsulation. Added `WeightArray::from_arccow_u32(ArcCow<u32>)` so the call sites use a constructor (matching `from_vec_u32`/`from_vec_u16`/`from_u24_bytes`) while keeping the zero-copy mmap path (`from_vec_u32` would force `Vec<u32>`, defeating mmap).
- **PR #329 review** — 2 docstrings (`cch_weights.rs:418`, `customization.rs:1146`) said u16 pads "0-2 bytes", which implies a 1-byte pad is possible. Reworded to "exactly 0 or 2 bytes (2 iff `n` is odd)". u24 wording stays "0, 1, 2, or 3" — every value really is possible for u24.

## Smoke
- `cargo test -p butterfly-route --lib formats::cch_weights` — 11/11 pass
- `cargo test -p butterfly-route --lib matrix::` — 32/32 pass
- `cargo build --workspace --release` — clean
- `butterfly-route serve --data-dir data/belgium` — boots in 26s, routes Brussels→Antwerp for car/bike/foot return well-formed JSON

## Files
- `route/src/formats/cch_weights.rs` — new `from_arccow_u32` + corrected padding comment in `read_from_mmap_unverified`
- `route/src/customization.rs` — corrected `write_padding` doc
- `route/src/matrix/bucket_ch.rs` — 3 mmap constructor sites now use `WeightArray::from_arccow_u32`

## Test plan
- [x] cch_weights unit tests
- [x] matrix unit tests
- [x] release build clean
- [x] data-dir server boot + 3-mode route smoke