### PR TITLE
fix(pipeline): #332 step4 mode-index divergence — discover global ordering from step2 dir

### DIFF
--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -1330,19 +1330,57 @@ impl Cli {
                         .join("node_signals.bin")
                 });
 
-                // Build dynamic EbgModeConfig list
+                // #332: mode indices MUST come from the global alphabetical
+                // ordering over every mode the step2 directory holds, NOT
+                // from the (sub)set passed via --way-attrs. step5-weights
+                // discovers modes the same way (`Mode::discover_from_dir`),
+                // so step4 and step5 stay aligned even when step4 only
+                // processes a subset. Without this, the per-arc mode_mask
+                // bits written by step4 don't match the bits step5 looks
+                // up, and the subset modes end with `n_filtered_arcs == 0`.
+                let step2_dir = wa_parsed
+                    .first()
+                    .and_then(|(_, _, p)| p.parent())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Cannot determine step2 directory from way-attrs paths")
+                    })?;
+                let all_modes = Mode::discover_from_dir(step2_dir);
+                anyhow::ensure!(
+                    !all_modes.is_empty(),
+                    "No modes found in {}. Expected way_attrs.*.bin files.",
+                    step2_dir.display()
+                );
+
+                // Build dynamic EbgModeConfig list — keep ONLY the modes
+                // the operator passed via --way-attrs, but assign the
+                // global index from `all_modes`.
                 let modes: Vec<crate::ebg::EbgModeConfig> = wa_parsed
                     .iter()
                     .zip(tr_parsed.iter())
-                    .map(
-                        |((name, idx, wa_path), (_, _, tr_path))| crate::ebg::EbgModeConfig {
+                    .map(|((name, _local_idx, wa_path), (_, _, tr_path))| {
+                        let global_idx = all_modes
+                            .iter()
+                            .find(|(n, _)| n == name)
+                            .map(|(_, idx)| *idx)
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "Mode '{}' not found in step2 directory {} (discovered: {:?})",
+                                    name,
+                                    step2_dir.display(),
+                                    all_modes
+                                        .iter()
+                                        .map(|(n, _)| n.as_str())
+                                        .collect::<Vec<_>>()
+                                )
+                            })?;
+                        Ok(crate::ebg::EbgModeConfig {
                             mode_name: name.clone(),
-                            mode_index: *idx,
+                            mode_index: global_idx,
                             way_attrs_path: wa_path.clone(),
                             turn_rules_path: tr_path.clone(),
-                        },
-                    )
-                    .collect();
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
 
                 let config = EbgConfig {
                     nbg_csr_path: nbg_csr.clone(),

--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -1311,6 +1311,18 @@ impl Cli {
                 let wa_parsed = parse_mode_path_pairs(&way_attrs, "way-attrs")?;
                 let tr_parsed = parse_mode_path_pairs(&turn_rules, "turn-rules")?;
 
+                // Fail loudly when no modes were passed at all — otherwise
+                // step2_dir discovery below would error with the misleading
+                // "cannot determine step2 directory" message.
+                anyhow::ensure!(
+                    !wa_parsed.is_empty(),
+                    "step4-ebg requires at least one --way-attrs MODE=PATH"
+                );
+                anyhow::ensure!(
+                    !tr_parsed.is_empty(),
+                    "step4-ebg requires at least one --turn-rules MODE=PATH"
+                );
+
                 // Validate that way_attrs and turn_rules have the same set of modes
                 let wa_modes: Vec<&str> = wa_parsed.iter().map(|(n, _, _)| n.as_str()).collect();
                 let tr_modes: Vec<&str> = tr_parsed.iter().map(|(n, _, _)| n.as_str()).collect();
@@ -1338,17 +1350,57 @@ impl Cli {
                 // processes a subset. Without this, the per-arc mode_mask
                 // bits written by step4 don't match the bits step5 looks
                 // up, and the subset modes end with `n_filtered_arcs == 0`.
-                let step2_dir = wa_parsed
-                    .first()
-                    .and_then(|(_, _, p)| p.parent())
+                //
+                // PR #333 review: all paths MUST live under the same step2
+                // directory — discovering modes from only the first path's
+                // parent while the others point elsewhere would silently
+                // produce wrong global indices.
+                let step2_dir = wa_parsed[0]
+                    .2
+                    .parent()
                     .ok_or_else(|| {
                         anyhow::anyhow!("Cannot determine step2 directory from way-attrs paths")
                     })?;
+                for ((name, _, wa_path), (_, _, tr_path)) in wa_parsed.iter().zip(tr_parsed.iter())
+                {
+                    let wa_parent = wa_path.parent().unwrap_or(Path::new(""));
+                    anyhow::ensure!(
+                        wa_parent == step2_dir,
+                        "--way-attrs for '{}' is in {} but step4-ebg expects every \
+                         way_attrs/turn_rules under the same step2 directory (first \
+                         path's parent: {})",
+                        name,
+                        wa_parent.display(),
+                        step2_dir.display()
+                    );
+                    let tr_parent = tr_path.parent().unwrap_or(Path::new(""));
+                    anyhow::ensure!(
+                        tr_parent == step2_dir,
+                        "--turn-rules for '{}' is in {} but step4-ebg expects every \
+                         way_attrs/turn_rules under the same step2 directory (first \
+                         path's parent: {})",
+                        name,
+                        tr_parent.display(),
+                        step2_dir.display()
+                    );
+                }
+
                 let all_modes = Mode::discover_from_dir(step2_dir);
                 anyhow::ensure!(
                     !all_modes.is_empty(),
                     "No modes found in {}. Expected way_attrs.*.bin files.",
                     step2_dir.display()
+                );
+                // Bit masks in turn_table.mode_mask are u8; mode_index ≥ 8
+                // would overflow. Defensive check in case the directory has
+                // stale way_attrs files from an older multi-mode run.
+                anyhow::ensure!(
+                    all_modes.len() <= crate::profile_abi::MAX_MODES,
+                    "Found {} modes in {} but MAX_MODES is {}. Remove stale \
+                     way_attrs.*.bin files before re-running step4-ebg.",
+                    all_modes.len(),
+                    step2_dir.display(),
+                    crate::profile_abi::MAX_MODES
                 );
 
                 // Build dynamic EbgModeConfig list — keep ONLY the modes

--- a/route/src/customization.rs
+++ b/route/src/customization.rs
@@ -1141,9 +1141,9 @@ fn write_weights_body<W: std::io::Write>(
 }
 
 /// Emit 0-3 zero bytes so the next array begins on a 4-byte boundary.
-/// u32 bodies are already 4-aligned; u16 needs 0-2 bytes of pad when
-/// `n` is odd; u24 needs 0-3 bytes of pad to round `n * 3` up to the
-/// next multiple of 4. CRC covers the padding.
+/// u32 bodies are already 4-aligned; u16 needs exactly 2 bytes of pad
+/// when `n` is odd (else 0); u24 needs 0, 1, 2, or 3 bytes of pad to
+/// round `n * 3` up to the next multiple of 4. CRC covers the padding.
 fn write_padding<W: std::io::Write>(
     writer: &mut W,
     crc_digest: &mut crate::formats::crc::Digest,

--- a/route/src/formats/cch_weights.rs
+++ b/route/src/formats/cch_weights.rs
@@ -255,6 +255,15 @@ impl WeightArray {
         Self::U32(ArcCow::from_vec(v))
     }
 
+    /// Wrap an existing `ArcCow<u32>` at the U32 width. Use this for
+    /// mmap-backed flats so the underlying mapping is preserved
+    /// (zero-copy) and call sites don't reach for the enum variant
+    /// directly.
+    #[inline]
+    pub fn from_arccow_u32(arc: ArcCow<u32>) -> Self {
+        Self::U32(arc)
+    }
+
     /// Construct from an owned `Vec<u16>` at the U16 width.
     #[inline]
     pub fn from_vec_u16(v: Vec<u16>) -> Self {
@@ -413,10 +422,11 @@ impl CchWeightsFile {
         //              | [middles: up_middle(4·n_up) | down_middle(4·n_down)]
         //              | footer(16)
         //
-        // u16 bodies pad 0-2 bytes; u24 bodies pad 0-3 bytes. The pad
-        // keeps the following arrays (the other direction's body and
-        // the u32 middles) 4-byte aligned for `bytemuck::cast_slice` /
-        // `ArcCow::<u32>::from_mmap`.
+        // u16 bodies pad 0 or 2 bytes (exactly 2 when `n_up`/`n_down`
+        // is odd, else 0); u24 bodies pad 0, 1, 2, or 3 bytes to round
+        // `n * 3` up to a 4-byte boundary. The pad keeps the following
+        // arrays (the other direction's body and the u32 middles)
+        // 4-byte aligned for `bytemuck::cast_slice` / `ArcCow::<u32>::from_mmap`.
         let up_bytes = up_width.padded_body_bytes(n_up);
         let down_bytes = down_width.padded_body_bytes(n_down);
         let body_no_middle = up_bytes

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -699,7 +699,9 @@ impl UpAdjFlatFile {
         let offsets =
             ArcCow::<u64>::from_mmap(std::sync::Arc::clone(&mmap), offsets_abs, n_nodes + 1)?;
         let targets = ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), targets_abs, n_edges)?;
-        let weights = crate::formats::WeightArray::U32(ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), weights_abs, n_edges)?);
+        let weights = crate::formats::WeightArray::from_arccow_u32(
+            ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), weights_abs, n_edges)?,
+        );
         let topo_edge_idx = if has_topo_idx {
             ArcCow::<u32>::from_mmap(mmap, topo_abs, n_edges)?
         } else {
@@ -809,7 +811,9 @@ impl DownAdjFlatFile {
         let offsets =
             ArcCow::<u64>::from_mmap(std::sync::Arc::clone(&mmap), offsets_abs, n_nodes + 1)?;
         let targets = ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), targets_abs, n_edges)?;
-        let weights = crate::formats::WeightArray::U32(ArcCow::<u32>::from_mmap(mmap, weights_abs, n_edges)?);
+        let weights = crate::formats::WeightArray::from_arccow_u32(
+            ArcCow::<u32>::from_mmap(mmap, weights_abs, n_edges)?,
+        );
         Ok(DownAdjFlat {
             offsets,
             targets,
@@ -925,7 +929,9 @@ impl DownReverseAdjFlatFile {
         let offsets =
             ArcCow::<u64>::from_mmap(std::sync::Arc::clone(&mmap), offsets_abs, n_nodes + 1)?;
         let sources = ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), sources_abs, n_edges)?;
-        let weights = crate::formats::WeightArray::U32(ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), weights_abs, n_edges)?);
+        let weights = crate::formats::WeightArray::from_arccow_u32(
+            ArcCow::<u32>::from_mmap(std::sync::Arc::clone(&mmap), weights_abs, n_edges)?,
+        );
         let topo_edge_idx = if has_topo_idx {
             ArcCow::<u32>::from_mmap(mmap, topo_abs, n_edges)?
         } else {


### PR DESCRIPTION
## Summary

step4-ebg was assigning per-arc `mode_mask` bits from a **local** sort of the CLI args (`parse_mode_path_pairs`), while step5-weights reads them back using the **global** ordering it discovers from the step2 directory (`Mode::discover_from_dir`). When step4 was invoked with a subset of the modes the step2 dir actually holds, the two index spaces silently diverged → step5's per-arc mode-mask check looked at a bit step4 never set → every arc was rejected → `n_filtered_arcs = 0` for the misaligned modes.

step4 now derives the mode index the same way step5 does, then processes only the modes the operator passed via `--way-attrs`. CLI surface unchanged.

## Fixes #332

## Smoke

Reproduced on Luxembourg this evening. Full pipeline run with `--way-attrs car=... bike=... foot=...` against an 8-mode step2 directory (bike/bus/car/foot/motorcycle/scooter/truck/wheelchair):

| mode | n_filtered_nodes | n_filtered_arcs (before fix) | n_filtered_arcs (this PR) |
|---|---|---|---|
| car  | 227 511 | 534 704     | **338 245** (correct) |
| bike | 455 007 | 1 167 234    | **853 722** (correct) |
| foot | 469 304 | **0** (broken) | **1 341 341** (correct) |

All 3 modes now produce v4 `cch.w.*.u32` files of expected sizes and pass step7 + step8.

## Why Belgium wasn't affected

The Belgium step4 currently on disk was invoked with a mode set that happens to align with `Mode::discover_from_dir` over the current `data/belgium/step2/` contents, so the dormant bug never surfaced. No Belgium rebuild required.

## Test plan

- [x] Workspace release build clean
- [x] LU full pipeline runs to step8 with subset modes (`car/bike/foot` of 8 step2 modes)
- [x] step7 no longer bails with "Filtered EBG has no original_arc_idx"
- [x] step5 filtered EBG arc counts non-zero for all 3 modes
- [ ] Follow-up: add a regression test that runs step4 with a deliberate subset and asserts non-zero arcs across modes (filed under #332 as acceptance gate; deferred to a separate PR so this one ships immediately to unblock #330)