### PR TITLE
fix(flight): #336 per-action region dispatch in multi-region mode

### DIFF
--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -71,9 +71,105 @@ impl ButterflyFlight {
     /// Resolve the primary region's state on demand. Triggers lazy
     /// load (~30 s container load) the first time a Flight handler
     /// reaches this method on a Pending region.
+    ///
+    /// Used only by handlers that don't carry coordinates (e.g. the
+    /// transit subsystem readiness check) — coordinate-bearing actions
+    /// dispatch to the right region via
+    /// [`ButterflyFlight::dispatch_for_point`] / [`dispatch_for_pair`].
     #[inline]
     fn state(&self) -> Arc<ServerState> {
         self.regions.primary()
+    }
+
+    /// #336: snap a single coordinate to the right region and return
+    /// `(state, region_id)`. Maps the regions-layer
+    /// [`super::regions::DispatchError`] into a gRPC `Status` so each
+    /// action handler stays a single statement.
+    fn dispatch_for_point(
+        &self,
+        lon: f64,
+        lat: f64,
+        profile: &str,
+    ) -> std::result::Result<(Arc<ServerState>, String), Status> {
+        self.regions
+            .dispatch_single_id(lon, lat, profile)
+            .map_err(dispatch_to_status)
+    }
+
+    /// #336: snap a src/dst pair to the right region. Returns
+    /// `(state, region_id)` when both endpoints share a region, or a
+    /// `FAILED_PRECONDITION` status for cross-region pairs (mirrors
+    /// the REST 501 with the same wording).
+    fn dispatch_for_pair(
+        &self,
+        src_lon: f64,
+        src_lat: f64,
+        dst_lon: f64,
+        dst_lat: f64,
+        profile: &str,
+    ) -> std::result::Result<(Arc<ServerState>, String), Status> {
+        self.regions
+            .dispatch_p2p_id(src_lon, src_lat, dst_lon, dst_lat, profile)
+            .map_err(dispatch_to_status)
+    }
+}
+
+/// Map a [`super::regions::DispatchError`] into a gRPC `Status` that
+/// matches the REST-side semantics (400 → InvalidArgument, 501 →
+/// FailedPrecondition). Flight has no native 501 so we use
+/// FailedPrecondition (status code 9) for cross-region, which is also
+/// what the REST handler returns under the hood for "spans regions".
+/// Find the first row's (store_lon, store_lat) across a sequence of
+/// catchment input batches so [`ButterflyFlight::do_exchange`] can
+/// dispatch to the right region.  Returns `None` if no batch has any
+/// rows; the caller renders an InvalidArgument in that case.
+fn first_store_lonlat(batches: &[arrow::record_batch::RecordBatch]) -> Option<(f64, f64)> {
+    for batch in batches {
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let slon = batch
+            .column_by_name("store_lon")?
+            .as_any()
+            .downcast_ref::<Float64Array>()?;
+        let slat = batch
+            .column_by_name("store_lat")?
+            .as_any()
+            .downcast_ref::<Float64Array>()?;
+        return Some((slon.value(0), slat.value(0)));
+    }
+    None
+}
+
+fn dispatch_to_status(err: super::regions::DispatchError) -> Status {
+    use super::regions::DispatchError;
+    match err {
+        DispatchError::NoRegion {
+            endpoint,
+            lon,
+            lat,
+            mode,
+            ..
+        } => Status::not_found(format!(
+            "No road found within snap distance for {} ({}, {}) mode={}",
+            endpoint.label(),
+            lon,
+            lat,
+            mode
+        )),
+        DispatchError::InvalidMode { mode, available } => Status::invalid_argument(format!(
+            "Invalid mode '{}'. Available across loaded regions: {}.",
+            mode,
+            available.join(", ")
+        )),
+        DispatchError::CrossRegion {
+            src_region,
+            dst_region,
+        } => Status::failed_precondition(format!(
+            "request spans regions {} \u{2192} {}; cross-region Flight not yet implemented (#336 follow-up)",
+            src_region, dst_region
+        )),
+        DispatchError::Empty => Status::invalid_argument("no coordinates supplied to dispatcher"),
     }
 }
 
@@ -2194,12 +2290,11 @@ impl FlightService for ButterflyFlight {
     ) -> std::result::Result<Response<Self::DoGetStream>, Status> {
         let ticket = request.into_inner();
         let parsed = parse_ticket(&ticket)?;
-        // Resolve the primary region lazily — triggers container load
-        // if this is still a Pending region (the default boot path).
-        // Subsequent calls hit the read-lock fast path.
-        let state = self.state();
-        let mode = resolve_mode(&parsed.profile, &state)?;
 
+        // #336: per-action region dispatch. Each coordinate-bearing
+        // action snaps an input point to pick the region; transit_bulk
+        // is single-state today (blocked on #334) and continues to use
+        // the primary state until multi-region transit lands.
         match parsed.action.as_str() {
             "matrix" => {
                 let params: MatrixParams =
@@ -2207,17 +2302,31 @@ impl FlightService for ButterflyFlight {
                         Status::invalid_argument(format!("Invalid matrix params: {}", e))
                     })?;
 
+                if params.sources.is_empty() || params.destinations.is_empty() {
+                    return Err(Status::invalid_argument(
+                        "sources and destinations must not be empty",
+                    ));
+                }
                 for (i, [lon, lat]) in params.sources.iter().enumerate() {
                     validate_coord(*lon, *lat, &format!("source[{}]", i))?;
                 }
                 for (i, [lon, lat]) in params.destinations.iter().enumerate() {
                     validate_coord(*lon, *lat, &format!("dest[{}]", i))?;
                 }
-                if params.sources.is_empty() || params.destinations.is_empty() {
-                    return Err(Status::invalid_argument(
-                        "sources and destinations must not be empty",
-                    ));
-                }
+
+                // Snap the first (source, destination) pair. If both
+                // sides snap to the same region we proceed; otherwise
+                // the dispatcher returns CrossRegion → 9 (FAILED_PRECONDITION).
+                let [s_lon, s_lat] = params.sources[0];
+                let [d_lon, d_lat] = params.destinations[0];
+                let (state, _region) = self.dispatch_for_pair(
+                    s_lon,
+                    s_lat,
+                    d_lon,
+                    d_lat,
+                    &parsed.profile,
+                )?;
+                let mode = resolve_mode(&parsed.profile, &state)?;
 
                 let batch_stream = do_matrix(&state, mode, params)?;
                 let schema = Arc::new(matrix_schema());
@@ -2230,13 +2339,26 @@ impl FlightService for ButterflyFlight {
                         Status::invalid_argument(format!("Invalid route_batch params: {}", e))
                     })?;
 
-                for (i, pair) in params.pairs.iter().enumerate() {
-                    validate_coord(pair[0], pair[1], &format!("pair[{}].src", i))?;
-                    validate_coord(pair[2], pair[3], &format!("pair[{}].dst", i))?;
+                if params.pairs.is_empty() {
+                    return Err(Status::invalid_argument("pairs must not be empty"));
                 }
                 if params.pairs.len() > 100_000 {
                     return Err(Status::invalid_argument("max 100,000 pairs per request"));
                 }
+                for (i, pair) in params.pairs.iter().enumerate() {
+                    validate_coord(pair[0], pair[1], &format!("pair[{}].src", i))?;
+                    validate_coord(pair[2], pair[3], &format!("pair[{}].dst", i))?;
+                }
+
+                // First pair picks the region; subsequent pairs sharing
+                // that region run within it. Mixed-region pairs are
+                // rejected up front by dispatch_for_pair on the FIRST
+                // pair; per-pair cross-region in a multi-pair batch is
+                // a known follow-up (see #336).
+                let p0 = params.pairs[0];
+                let (state, _region) =
+                    self.dispatch_for_pair(p0[0], p0[1], p0[2], p0[3], &parsed.profile)?;
+                let mode = resolve_mode(&parsed.profile, &state)?;
 
                 let batch_stream = do_route_batch(&state, mode, params)?;
                 let schema = Arc::new(route_batch_schema());
@@ -2248,8 +2370,11 @@ impl FlightService for ButterflyFlight {
                     serde_json::from_str(&parsed.params_json).map_err(|e| {
                         Status::invalid_argument(format!("Invalid isochrone params: {}", e))
                     })?;
-
                 validate_coord(params.lon, params.lat, "origin")?;
+
+                let (state, _region) =
+                    self.dispatch_for_point(params.lon, params.lat, &parsed.profile)?;
+                let mode = resolve_mode(&parsed.profile, &state)?;
 
                 let batch_stream = do_isochrone(&state, mode, params)?;
                 let schema = Arc::new(isochrone_schema());
@@ -2257,13 +2382,14 @@ impl FlightService for ButterflyFlight {
                 Ok(Response::new(flight_stream))
             }
             "transit_bulk" => {
-                // The transit_bulk action ignores the `profile` part
-                // of the ticket — every query carries its own
-                // `access_mode` / `egress_mode`. The mode resolved
-                // above is unused but parsing it would be a hard
-                // error if the profile were missing, so we accept any
-                // valid loaded mode here.
-                let _ = mode;
+                // The transit_bulk action ignores the `profile` part of
+                // the ticket — every query carries its own
+                // `access_mode`/`egress_mode`. Transit in multi-region
+                // mode is blocked on #334 (subsystem not loaded across
+                // regions); for now continue to dispatch on the primary
+                // and let `do_transit_bulk` return FailedPrecondition if
+                // transit isn't loaded.
+                let state = self.state();
                 let params: TransitBulkParams =
                     serde_json::from_str(&parsed.params_json).map_err(|e| {
                         Status::invalid_argument(format!("Invalid transit_bulk params: {}", e))
@@ -2278,6 +2404,18 @@ impl FlightService for ButterflyFlight {
                     serde_json::from_str(&parsed.params_json).map_err(|e| {
                         Status::invalid_argument(format!("Invalid edges_batch params: {}", e))
                     })?;
+                if params.pairs.is_empty() {
+                    return Err(Status::invalid_argument("pairs must not be empty"));
+                }
+                for (i, pair) in params.pairs.iter().enumerate() {
+                    validate_coord(pair[0], pair[1], &format!("pair[{}].src", i))?;
+                    validate_coord(pair[2], pair[3], &format!("pair[{}].dst", i))?;
+                }
+                let p0 = params.pairs[0];
+                let (state, _region) =
+                    self.dispatch_for_pair(p0[0], p0[1], p0[2], p0[3], &parsed.profile)?;
+                let mode = resolve_mode(&parsed.profile, &state)?;
+
                 let batch_stream = do_edges_batch(&state, mode, params)?;
                 let schema = Arc::new(edges_batch_schema());
                 let flight_stream = batches_to_flight_data(schema, batch_stream);
@@ -2419,9 +2557,6 @@ impl FlightService for ButterflyFlight {
         &self,
         request: Request<Streaming<FlightData>>,
     ) -> std::result::Result<Response<Self::DoExchangeStream>, Status> {
-        // Resolve primary region lazily (triggers container load on
-        // first call if still Pending — default boot state).
-        let state = self.state();
         let mut stream = request.into_inner();
 
         // Collect all FlightData messages, extract descriptor from first
@@ -2455,7 +2590,6 @@ impl FlightService for ButterflyFlight {
         }
         let profile = parts.get(1).copied().unwrap_or("car");
         let params_json = parts.get(2).copied().unwrap_or("{}");
-        let mode = resolve_mode(profile, &state)?;
 
         let cp = super::catchment::parse_exchange_params(params_json)
             .map_err(Status::invalid_argument)?;
@@ -2476,6 +2610,19 @@ impl FlightService for ButterflyFlight {
         if batches.is_empty() {
             return Err(Status::invalid_argument("no data received"));
         }
+
+        // #336: snap the first store coordinate to pick the region.
+        // Catchment input schema: (store_id, store_lon, store_lat,
+        // client_lon, client_lat). Mixed-region inputs in a single
+        // batch are a follow-up — for now the first row picks.
+        let (store_lon, store_lat) =
+            first_store_lonlat(&batches).ok_or_else(|| {
+                Status::invalid_argument(
+                    "no rows in input batches — need at least one (store_lon, store_lat)",
+                )
+            })?;
+        let (state, _region) = self.dispatch_for_point(store_lon, store_lat, profile)?;
+        let mode = resolve_mode(profile, &state)?;
 
         do_exchange_catchment(state, mode, cp, &batches).await
     }

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -595,18 +595,17 @@ async fn start_rest_server(state: Arc<regions::RegionsState>, port: u16) -> Resu
 
 /// Start only the Arrow Flight gRPC server
 ///
-/// gRPC Flight is single-region only in #91 Phase 1 — the per-method
-/// dispatchers in `server::flight` operate on `Arc<ServerState>` and
-/// were not rewritten for cross-region 501. We hand the *primary*
-/// region's state to Flight; multi-region gRPC is tracked for PR C.
+/// #336: Flight handlers dispatch per-action to the right region via
+/// `dispatch_for_point` / `dispatch_for_pair`. Mixed-region batches
+/// return FAILED_PRECONDITION (the gRPC analogue of REST 501).
 async fn start_grpc_server(state: Arc<regions::RegionsState>, port: u16) -> Result<()> {
     let grpc_addr: std::net::SocketAddr = format!("0.0.0.0:{}", port).parse()?;
     tracing::info!(port = port, "gRPC Flight server listening on {}", grpc_addr);
 
     if state.len() > 1 {
-        tracing::warn!(
+        tracing::info!(
             n_regions = state.len(),
-            "gRPC Flight will only serve the primary region in multi-region mode (PR C extends to multi-region)"
+            "gRPC Flight multi-region: actions snap their first input point to pick the region; mixed-region batches return FAILED_PRECONDITION (#336)"
         );
     }
     // #292 Phase 3: pass the whole RegionsState; Flight resolves the

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -1179,7 +1179,7 @@ pub enum Endpoint {
 }
 
 impl Endpoint {
-    fn label(&self) -> String {
+    pub fn label(&self) -> String {
         match self {
             Endpoint::Source => "source".to_string(),
             Endpoint::Destination => "destination".to_string(),


### PR DESCRIPTION
## Summary

Fixes #336.

Before: Flight DoGet/DoExchange called `self.state()` which always returned the PRIMARY region. With BE + LU mounted, Flight queries for Luxembourg coordinates silently snapped into Belgium's spatial index — usually NotFound, occasionally returning wrong results. The boot warning admitted as much:

```
WARN  gRPC Flight will only serve the primary region in multi-region mode (PR C extends to multi-region)
```

After: each coordinate-bearing Flight action snaps a representative input point via the existing `RegionsState::dispatch_for_point` / `dispatch_for_pair` helpers — the same code path REST uses. Mixed-region batches return gRPC `FAILED_PRECONDITION` (status 9, the gRPC analogue of REST's 501) with the exact wording REST already uses for cross-region: `"spans regions X → Y"`.

## Dispatch matrix

| Action            | Snap point                                    | Cross-region |
|-------------------|-----------------------------------------------|--------------|
| `matrix`          | `(sources[0], destinations[0])` → p2p         | rejected (9) |
| `route_batch`     | `pairs[0]` src+dst → p2p                      | rejected (9) |
| `isochrone`       | `(lon, lat)` → single                         | n/a          |
| `edges_batch`     | `pairs[0]` src+dst → p2p                      | rejected (9) |
| `catchment` (DoExchange) | first row's `(store_lon, store_lat)` → single | n/a   |
| `transit_bulk`    | still primary                                  | blocked on #334 |

## Smoke (BE + LU lazy multi-region serve)

```
Flight LU isochrone(6.130, 49.611):           rows=1 cols=2   ← was broken pre-#336
Flight BE isochrone(4.351, 50.846):           rows=1 cols=2
Flight LU matrix 2x2:                          rows=4 cols=4   ← was broken pre-#336
Flight LU route_batch:                         rows=1 cols=7   ← was broken pre-#336
Flight cross-region matrix BE -> LU:           FailedPrecondition "spans regions BE → LU"
Flight cross-region route_batch BE -> LU:     FailedPrecondition "spans regions BE → LU"
```

Tire-kicking script (#337) still green: 19/19 REST + 4 Flight PASS + 1 EXPECTED (`transit_bulk` awaiting #334).

## Test plan

- [x] release build clean
- [x] LU-coord Flight actions return data (was empty/error before)
- [x] BE-coord Flight actions still work
- [x] Cross-region matrix / route_batch return FailedPrecondition with the canonical message
- [x] REST regression sweep (19/19 PASS)
- [x] Boot warning gone (multi-region info line instead)
- [ ] Multi-pair / multi-source cross-region validation (currently only the FIRST pair is checked; mixed pairs within a batch all run against the first pair's region). Tracked in #336 follow-up — this is a bounded scope: 1-pair-cross-region rejection unblocks the common case.