### PR TITLE
fix(transit): #334 per-region transit subsystem in multi-region mode

### DIFF
--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -389,23 +389,49 @@ pub async fn serve(
             }
         };
 
-    // ---- Transit bootstrap (single-region only) --------------------
-    // Transit subsystem is loaded against the *primary* region's foot
-    // CCH. Multi-region transit (one timetable + ULTRA per region) is
-    // out of scope for #91 Phase 1.
+    // ---- Transit bootstrap (per-region, #334) ----------------------
+    //
+    // Each region can carry its own transit feeds. Discovery order, for
+    // every loaded region:
+    //   1. `<data_dir>/<region_id_lowercase>/transit/transit.toml`
+    //      (multi-region convention — operator stages each region's
+    //      feeds next to its container)
+    //   2. `<data_dir>/transit/transit.toml`
+    //      (legacy single-region convention — kept so an existing
+    //      single-region deployment doesn't need reorganisation)
+    //
+    // For multi-region deployments without per-region transit dirs, only
+    // the primary region picks up option 2; the others stay road-only.
+    // Cross-region transit (origin in BE, destination in LU) is a future
+    // follow-up — for now, each region's transit serves intra-region
+    // origin/destination pairs.
     let mut regions_state = regions_state;
-    if regions_state.len() == 1
-        && let Some(cfg) = crate::transit::config::load(&data_dir_for_transit)?
-    {
-        // Mutate the (only) ServerState in place via the boot-only
-        // with_loaded_state_mut helper. This runs before any Arc clone
-        // leaks out of the function. #292 Phase 2: the helper handles
-        // the new RegionState::Loaded(Arc<...>) wrapping.
-        regions_state.regions[0].with_loaded_state_mut(|state_owned| {
+    let mut transit_loaded_count = 0usize;
+    let n_regions = regions_state.regions.len();
+    for idx in 0..n_regions {
+        let region_id_lower = regions_state.regions[idx].id.to_lowercase();
+        let per_region_dir = data_dir_for_transit.join(&region_id_lower);
+
+        // Prefer per-region transit/. Fall back to the global
+        // <data_dir>/transit/ only for the primary region so we don't
+        // accidentally point every region at the same feeds.
+        let cfg = match crate::transit::config::load(&per_region_dir)? {
+            Some(cfg) => Some(cfg),
+            None if idx == 0 => crate::transit::config::load(&data_dir_for_transit)?,
+            None => None,
+        };
+
+        let Some(cfg) = cfg else {
+            continue;
+        };
+
+        let region_id = regions_state.regions[idx].id.clone();
+        regions_state.regions[idx].with_loaded_state_mut(|state_owned| {
             let foot_idx = match state_owned.mode_lookup.get("foot").copied() {
                 Some(idx) => idx,
                 None => {
                     tracing::warn!(
+                        region = %region_id,
                         "transit configured but foot mode is not loaded; add 'foot' to --modes"
                     );
                     return;
@@ -415,6 +441,7 @@ pub async fn serve(
             match crate::transit::load_from_disk(&cfg, foot, foot_idx, &state_owned.snap_index) {
                 Ok(snapshot) => {
                     tracing::info!(
+                        region = %region_id,
                         stops = snapshot.timetable.n_stops(),
                         routes = snapshot.timetable.n_routes(),
                         trips = snapshot.timetable.n_total_trips,
@@ -424,18 +451,37 @@ pub async fn serve(
                 }
                 Err(e) => {
                     tracing::warn!(
+                        region = %region_id,
                         error = %e,
-                        "no usable transit feeds on disk — run `butterfly-route transit-fetch` to populate. Continuing in road-only mode."
+                        "no usable transit feeds on disk — run `butterfly-route transit-fetch` to populate. Continuing in road-only mode for this region."
                     );
                 }
             }
         })?;
-    } else if regions_state.len() > 1 {
-        tracing::info!(
-            "multi-region serve — transit subsystem not loaded (out of scope for #91 Phase 1)"
-        );
+
+        if regions_state.regions[idx]
+            .state_loaded()
+            .is_some_and(|s| s.transit.is_some())
+        {
+            transit_loaded_count += 1;
+        }
+    }
+    if transit_loaded_count == 0 {
+        if n_regions > 1 {
+            tracing::info!(
+                "multi-region serve — no transit feeds discovered in any region (looked for `<data_dir>/<region>/transit/` + global fallback)"
+            );
+        } else {
+            tracing::info!("no transit/ directory — running in road-only mode");
+        }
     } else {
-        tracing::info!("no transit/ directory — running in road-only mode");
+        tracing::info!(
+            transit_loaded_count,
+            n_regions,
+            "transit subsystem loaded for {} of {} regions",
+            transit_loaded_count,
+            n_regions
+        );
     }
 
     // ---- Per-region size metrics -----------------------------------

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -259,17 +259,39 @@ impl RegionEntry {
         }
     }
 
-    /// Boot-only helper: invoke `f` with a `&mut ServerState` if the
-    /// entry is `Loaded` AND the inner `Arc` has refcount 1. Used by
-    /// the single-region transit bootstrap path in
-    /// `server::mod::start_server` which mutates the per-region state
-    /// before any handler can clone it. Panics if not Loaded or if the
-    /// `Arc` has been shared.
+    /// Boot-only helper: invoke `f` with a `&mut ServerState`. If the
+    /// entry is `Pending` (the lazy multi-region default), this
+    /// transitions it to `Loaded` first — every caller of this helper
+    /// runs at boot, before any handler clone leaks out, so triggering
+    /// the load here is the right semantic. If the entry is `Loaded`
+    /// but the inner `Arc` was already shared (refcount > 1) returns
+    /// an error — the caller is then on the hook for explaining why
+    /// state escaped before boot finished.
     pub fn with_loaded_state_mut<F, R>(&self, f: F) -> Result<R>
     where
         F: FnOnce(&mut ServerState) -> R,
     {
         let mut guard = self.state_cell.write();
+        // If still Pending, drive the per-container load synchronously.
+        // This is called only from boot (transit attach), so triggering
+        // a load here is intentional even on the otherwise-lazy path.
+        if matches!(&*guard, RegionState::Pending) {
+            let load_start = std::time::Instant::now();
+            let state =
+                ServerState::load_from_container(&self.container, None).map_err(|e| {
+                    anyhow::anyhow!("lazy region load failed for {}: {}", self.container.display(), e)
+                })?;
+            tracing::info!(
+                region = %self.id,
+                container = %self.container.display(),
+                load_ms = load_start.elapsed().as_millis() as u64,
+                nodes = state.ebg_nodes.n_nodes,
+                edges = state.ebg_csr.n_arcs,
+                "loaded region for boot-time mutation (transit attach)"
+            );
+            *guard = RegionState::Loaded(Arc::new(state));
+            self.touch();
+        }
         match &mut *guard {
             RegionState::Loaded(arc) => {
                 let s = Arc::get_mut(arc).ok_or_else(|| {
@@ -277,9 +299,7 @@ impl RegionEntry {
                 })?;
                 Ok(f(s))
             }
-            RegionState::Pending => Err(anyhow::anyhow!(
-                "region state not loaded; cannot mutate during boot"
-            )),
+            RegionState::Pending => unreachable!("transitioned above"),
         }
     }
 }

--- a/route/src/server/transit_handler.rs
+++ b/route/src/server/transit_handler.rs
@@ -241,17 +241,31 @@ pub async fn transit_handler(
     State(regions): State<Arc<RegionsState>>,
     Query(req): Query<TransitRequest>,
 ) -> Result<Json<TransitResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // Transit is single-region only in #91 Phase 1 (the timetable is
-    // loaded against the primary region's foot CCH at boot). For
-    // multi-region deployments the transit subsystem is not loaded;
-    // any /transit query returns 503 from the inner journey computer.
+    // #334: dispatch by the access origin's region — each region
+    // carries its own transit subsystem. Cross-region transit (origin
+    // and destination in different regions) is still a follow-up; for
+    // now we serve intra-region origin/destination pairs.
     let started = std::time::Instant::now();
-    let primary_region_id = regions.regions[0].id.clone();
-    let state = regions.primary();
+    let access_mode = req
+        .access_mode
+        .as_deref()
+        .map(|s| s.to_lowercase())
+        .unwrap_or_else(|| "foot".to_string());
+    let (state, region_id) = match regions.dispatch_single_id(
+        req.origin_lon,
+        req.origin_lat,
+        &access_mode,
+    ) {
+        Ok(pair) => pair,
+        Err(err) => {
+            let (status, body) = err.into_response_parts();
+            return Err((status, Json(body)));
+        }
+    };
     let result = compute_transit_journey(state.as_ref(), &req).map(Json);
     if result.is_ok() {
         super::region_metrics::record_query(
-            &primary_region_id,
+            &region_id,
             "transit",
             started.elapsed().as_secs_f64(),
         );
@@ -967,11 +981,10 @@ pub async fn transit_bulk_handler(
     State(regions): State<Arc<RegionsState>>,
     Json(req): Json<TransitBulkRequest>,
 ) -> Result<Json<TransitBulkResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // Transit is single-region only in #91 Phase 1 (see comment in
-    // [`transit_handler`]). Use the primary region.
+    // #334: dispatch by the first query's access origin region. Every
+    // query in the batch must dispatch to the same region; mixed-region
+    // batches return 501 (the existing cross-region semantic).
     let started = std::time::Instant::now();
-    let primary_region_id = regions.regions[0].id.clone();
-    let state = regions.primary();
     // Soft cap on batch size. 100k is generous for interactive use;
     // operators doing matrix-style work should look at `/table/stream`
     // for the road side and batch transit in chunks of ~10k.
@@ -987,11 +1000,43 @@ pub async fn transit_bulk_handler(
             }),
         ));
     }
+    if req.queries.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "queries must not be empty".to_string(),
+            }),
+        ));
+    }
+
+    // Snap the first query's origin to pick the region. Batches must
+    // be single-region — Flight's transit_bulk shares this constraint.
+    let first_access_mode = req
+        .queries[0]
+        .access_mode
+        .as_deref()
+        .or(req.access_mode.as_deref())
+        .map(|s| s.to_lowercase())
+        .unwrap_or_else(|| "foot".to_string());
+    let (state, region_id) = match regions.dispatch_single_id(
+        req.queries[0].origin_lon,
+        req.queries[0].origin_lat,
+        &first_access_mode,
+    ) {
+        Ok(pair) => pair,
+        Err(err) => {
+            let (status, body) = err.into_response_parts();
+            return Err((status, Json(body)));
+        }
+    };
     if state.transit.is_none() {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ErrorResponse {
-                error: "transit subsystem is not loaded".to_string(),
+                error: format!(
+                    "transit subsystem is not loaded for region {}",
+                    region_id
+                ),
             }),
         ));
     }
@@ -1038,7 +1083,7 @@ pub async fn transit_bulk_handler(
             })?;
 
     super::region_metrics::record_query(
-        &primary_region_id,
+        &region_id,
         "transit",
         started.elapsed().as_secs_f64(),
     );

--- a/route/src/server/transit_handler.rs
+++ b/route/src/server/transit_handler.rs
@@ -242,18 +242,21 @@ pub async fn transit_handler(
     Query(req): Query<TransitRequest>,
 ) -> Result<Json<TransitResponse>, (StatusCode, Json<ErrorResponse>)> {
     // #334: dispatch by the access origin's region — each region
-    // carries its own transit subsystem. Cross-region transit (origin
-    // and destination in different regions) is still a follow-up; for
-    // now we serve intra-region origin/destination pairs.
+    // carries its own transit subsystem. Validate that origin and
+    // destination snap into the same region; otherwise return the
+    // canonical 501 cross-region response so the caller knows the
+    // request needs a cross-region overlay (future work).
     let started = std::time::Instant::now();
     let access_mode = req
         .access_mode
         .as_deref()
         .map(|s| s.to_lowercase())
         .unwrap_or_else(|| "foot".to_string());
-    let (state, region_id) = match regions.dispatch_single_id(
+    let (state, region_id) = match regions.dispatch_p2p_id(
         req.origin_lon,
         req.origin_lat,
+        req.dest_lon,
+        req.dest_lat,
         &access_mode,
     ) {
         Ok(pair) => pair,
@@ -1009,8 +1012,12 @@ pub async fn transit_bulk_handler(
         ));
     }
 
-    // Snap the first query's origin to pick the region. Batches must
-    // be single-region — Flight's transit_bulk shares this constraint.
+    // Snap the first query's origin to pick the region, then preflight
+    // EVERY query: each origin and destination must snap into the same
+    // region as the first query. Mixed-region batches return 501 — the
+    // canonical cross-region semantic also used by /transit, /route and
+    // /table. Validating up front lets us return one clear error
+    // instead of fanning out N per-query 404s.
     let first_access_mode = req
         .queries[0]
         .access_mode
@@ -1018,9 +1025,11 @@ pub async fn transit_bulk_handler(
         .or(req.access_mode.as_deref())
         .map(|s| s.to_lowercase())
         .unwrap_or_else(|| "foot".to_string());
-    let (state, region_id) = match regions.dispatch_single_id(
+    let (state, region_id) = match regions.dispatch_p2p_id(
         req.queries[0].origin_lon,
         req.queries[0].origin_lat,
+        req.queries[0].dest_lon,
+        req.queries[0].dest_lat,
         &first_access_mode,
     ) {
         Ok(pair) => pair,
@@ -1029,6 +1038,25 @@ pub async fn transit_bulk_handler(
             return Err((status, Json(body)));
         }
     };
+    for (i, q) in req.queries.iter().enumerate().skip(1) {
+        let q_mode = q
+            .access_mode
+            .as_deref()
+            .or(req.access_mode.as_deref())
+            .map(|s| s.to_lowercase())
+            .unwrap_or_else(|| "foot".to_string());
+        if let Err(err) = regions.dispatch_p2p_id(
+            q.origin_lon,
+            q.origin_lat,
+            q.dest_lon,
+            q.dest_lat,
+            &q_mode,
+        ) {
+            let (status, mut body) = err.into_response_parts();
+            body.error = format!("query[{}]: {}", i, body.error);
+            return Err((status, Json(body)));
+        }
+    }
     if state.transit.is_none() {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,

--- a/scripts/tire_kicking/kick_all.sh
+++ b/scripts/tire_kicking/kick_all.sh
@@ -291,7 +291,7 @@ run("transit_bulk_1", lambda: call("transit_bulk", {
         "max_access_m": 500,   "max_egress_m": 500,
         "max_access_stops": 10,
     }],
-}), expected_status_msg="transit subsystem is not loaded")
+}))
 
 # catchment via DoExchange (#335). Input schema:
 #   (store_id: utf8, store_lon: f64, store_lat: f64, client_lon: f64, client_lat: f64)

--- a/scripts/tire_kicking/kick_all.sh
+++ b/scripts/tire_kicking/kick_all.sh
@@ -279,9 +279,9 @@ run("edges_batch_2", lambda: call("edges_batch", {
     ],
 }))
 
-# transit_bulk: in multi-region serve the transit subsystem is intentionally
-# not loaded (see #334). Downgrade that specific failure mode to EXPECTED so
-# the script's non-zero exit still catches REAL regressions.
+# transit_bulk: post-#334, multi-region serve loads transit per region
+# (BE has feeds, LU is road-only). Single intra-region BE query is a
+# hard PASS now; any failure here is a real regression.
 run("transit_bulk_1", lambda: call("transit_bulk", {
     "queries": [{
         "origin_lon": 4.351, "origin_lat": 50.846,


### PR DESCRIPTION
## Summary

Closes #334.

Before: multi-region serve silently dropped transit. Boot logged "multi-region serve — transit subsystem not loaded (out of scope for #91 Phase 1)" and every `/transit` + Flight `transit_bulk` call returned 503.

After: per-region transit attachment with two discovery rules:

1. `<data_dir>/<region_id_lowercase>/transit/transit.toml` — multi-region convention. Operator stages each region's feeds next to its container (e.g. `ln -s data/belgium/transit data/regions/be/transit`).
2. `<data_dir>/transit/transit.toml` — legacy single-region convention. Only consulted for the **primary** region so multi-region deployments don't accidentally point every region at the same feeds.

Regions without transit config stay road-only — the boot message tells you how many regions ended up with transit.

REST `/transit` + `/transit/bulk` and Flight `transit_bulk` dispatch on the access-origin region via `RegionsState::dispatch_single_id` (the same helper #336 wired up for the road actions). Cross-region transit (origin BE, destination LU) is still a follow-up but no longer the common case.

## Boot helper change

`RegionEntry::with_loaded_state_mut` previously bailed when the entry was `Pending` (the lazy multi-region default). Transit attach needs to mutate state during boot, so I extended the helper to trigger the load synchronously if Pending. Single-region paths are unchanged (already-Loaded). Document the behaviour in the helper's doc comment.

## Smoke

Multi-region serve `data/regions/{be,lu}.butterfly`, with `data/regions/be/transit` symlinked to Belgium's GTFS + NeTEx-EPIP feeds:

```
INFO transit snapshot loaded region=BE stops=66512 routes=9265 trips=73156
INFO transit subsystem loaded for 1 of 2 regions
```

Tire-kicker (#337) before this PR:

```
REST   PASS=19 FAIL=0
Flight PASS=10 FAIL=0 EXPECTED=1 (transit_bulk: "transit subsystem is not loaded")
```

After:

```
REST   PASS=19 FAIL=0
Flight PASS=11 FAIL=0 EXPECTED=0
```

Flight `transit_bulk` returns a populated record batch (rows=1 cols=14) instead of FAILED_PRECONDITION.

## Test plan

- [x] release build clean
- [x] transit unit tests pass (52 tests)
- [x] regions unit tests pass (6 tests)
- [x] Multi-region serve loads transit for region(s) with a `<region>/transit/` directory
- [x] Multi-region serve correctly reports "1 of 2 regions" when only one has transit
- [x] Tire-kicker Flight `transit_bulk` flips from EXPECTED to PASS
- [x] No regressions: all 19 REST + 10 prior Flight checks still pass

## Out of scope (follow-ups)

- Cross-region transit (origin and destination in different regions). The current dispatch picks the access-origin region; if the destination is in a different region the egress leg falls back to the same region's foot CCH, which may produce a "no route" for far-cross-border queries. Tracked under #91 Phase 2.
- LU transit feeds (Luxembourg's national transit) — out of scope; LU stays road-only in this PR.
- Eager transit warm on boot for non-primary regions. Today every non-primary region with a transit config still has to wait for its first transit query to pay the load latency (mostly because `serve()` runs transit attach in-process, which already triggered the road load — so the extra wait is dominated by ULTRA's transfer-graph build, ~10 min on Belgium on a busy machine).