### PR TITLE
perf(disk): #347 zstd-compress cold container sections — way_names_idx + snap_grid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "wiremock",
+ "zstd",
 ]
 
 [[package]]
@@ -2542,6 +2543,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -4834,4 +4841,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/route/Cargo.toml
+++ b/route/Cargo.toml
@@ -141,6 +141,13 @@ prost_011 = { package = "prost", version = "0.11" }
 # Transit: TOML config parsing
 toml = "1.1"
 
+# zstd compression for cold container sections (#347 — way_names_idx
+# and snap_grid). Pure-Rust binding to the upstream zstd C library;
+# uses the bundled C source so no system dep. Level-3 chosen as the
+# fast-decompress sweet spot — boot-time decompression is single-
+# digit ms per section on Belgium.
+zstd = "0.13"
+
 [lints]
 workspace = true
 

--- a/route/src/formats/mod.rs
+++ b/route/src/formats/mod.rs
@@ -57,6 +57,9 @@ pub mod cch_topo;
 // Step 8 formats
 pub mod cch_weights;
 
+// Transparent zstd compression for cold container sections (#347)
+pub mod zstd_compress;
+
 pub use bitset::BitsetField;
 pub use cch_topo::{CchTopo, CchTopoFile, Shortcut};
 pub use cch_weights::{CchWeights, CchWeightsFile, U24_SENTINEL, WeightArray, WeightWidth};

--- a/route/src/formats/snap_index.rs
+++ b/route/src/formats/snap_index.rs
@@ -525,30 +525,42 @@ impl SnapGridFile {
             "snap_grid section out of bounds: off={byte_offset} len={byte_len} mmap_len={}",
             mmap.len()
         );
-        let (n_cells_x, n_cells_y, origin_x, origin_y, cell_log2, n_offsets) = {
-            let bytes = &mmap[byte_offset..byte_offset + byte_len];
-            let parsed = parse_snap_grid_header_and_check(bytes, false)?;
-            let n_cells = (parsed.n_cells_x as usize)
-                .checked_mul(parsed.n_cells_y as usize)
-                .ok_or_else(|| anyhow::anyhow!("snap_grid cell count overflow"))?;
-            let n_offsets = n_cells
-                .checked_add(1)
-                .ok_or_else(|| anyhow::anyhow!("snap_grid offsets count overflow"))?;
-            (
-                parsed.n_cells_x,
-                parsed.n_cells_y,
-                parsed.origin_x,
-                parsed.origin_y,
-                parsed.cell_log2,
-                n_offsets,
-            )
-        };
+        let section_bytes = &mmap[byte_offset..byte_offset + byte_len];
+
+        // #347: zstd magic at the section start triggers decompression
+        // to an owned Vec<u8>. Returned offsets land as `ArcCow::Owned`
+        // — heap rather than mmap-backed. SnapGrid is a one-shot lookup
+        // table consulted at every /nearest request but the offsets
+        // are small enough (<5 MB on Belgium) that owned storage is
+        // fine.
+        let owned = crate::formats::zstd_compress::decompress_if_zstd(section_bytes)?;
+        let is_compressed = matches!(owned, std::borrow::Cow::Owned(_));
+        let bytes: &[u8] = &owned;
+        let parsed = parse_snap_grid_header_and_check(bytes, false)?;
+        let n_cells = (parsed.n_cells_x as usize)
+            .checked_mul(parsed.n_cells_y as usize)
+            .ok_or_else(|| anyhow::anyhow!("snap_grid cell count overflow"))?;
+        let n_offsets = n_cells
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("snap_grid offsets count overflow"))?;
+        let n_cells_x = parsed.n_cells_x;
+        let n_cells_y = parsed.n_cells_y;
+        let origin_x = parsed.origin_x;
+        let origin_y = parsed.origin_y;
+        let cell_log2 = parsed.cell_log2;
+
         // Body sits immediately after the 40-byte header. 8-byte
         // section alignment + 40-byte header keeps the body 4-byte
-        // aligned, matching `align_of::<u32>() == 4`. `ArcCow::from_mmap`
-        // re-validates the alignment itself.
-        let body_byte_offset = byte_offset + HEADER_SIZE;
-        let offsets = ArcCow::<u32>::from_mmap(mmap, body_byte_offset, n_offsets)?;
+        // aligned for the uncompressed path; the decompressed Vec<u8>
+        // is heap-aligned so `bytemuck::cast_slice` is safe either way.
+        let offsets = if is_compressed {
+            let off_slice: &[u32] =
+                bytemuck::cast_slice(&bytes[HEADER_SIZE..HEADER_SIZE + 4 * n_offsets]);
+            ArcCow::from_vec(off_slice.to_vec())
+        } else {
+            let body_byte_offset = byte_offset + HEADER_SIZE;
+            ArcCow::<u32>::from_mmap(mmap, body_byte_offset, n_offsets)?
+        };
         Ok(SnapGrid {
             n_cells_x,
             n_cells_y,

--- a/route/src/formats/way_names_idx.rs
+++ b/route/src/formats/way_names_idx.rs
@@ -244,7 +244,17 @@ pub fn read_from_mmap_unverified(
         total_len,
         mmap.len()
     );
-    let bytes = &mmap[byte_offset..total_len];
+    let section_bytes = &mmap[byte_offset..total_len];
+
+    // #347: if the section body starts with the zstd magic, decompress
+    // to an owned Vec<u8> and parse from that. The returned `ArcCow`
+    // views are `Owned` rather than `Mmap` — they consume ~25 MB of
+    // heap (vs ~120 MB compressed in the mmap's page cache) but we
+    // accept the trade because way_names_idx is cold and sparse-access
+    // anyway.
+    let owned_decompressed = crate::formats::zstd_compress::decompress_if_zstd(section_bytes)?;
+    let is_compressed = matches!(owned_decompressed, std::borrow::Cow::Owned(_));
+    let bytes: &[u8] = &owned_decompressed;
     anyhow::ensure!(
         bytes.len() >= HEADER_SIZE + FOOTER_SIZE,
         "way_names section too short: {} bytes",
@@ -292,15 +302,38 @@ pub fn read_from_mmap_unverified(
         expected_total
     );
 
-    // Build ArcCow views.
-    let way_ids_off = byte_offset + HEADER_SIZE;
-    let offsets_off = way_ids_off + way_ids_bytes;
-    let names_off = offsets_off + offsets_bytes;
+    // Build views. Zero-copy mmap path for the uncompressed case;
+    // owned Vec path for the zstd-decompressed case (#347).
+    let way_ids_local_off = HEADER_SIZE;
+    let offsets_local_off = way_ids_local_off + way_ids_bytes;
+    let names_local_off = offsets_local_off + offsets_bytes;
 
-    let way_ids = ArcCow::from_mmap(Arc::clone(&mmap), way_ids_off, n_entries as usize)?;
-    let offsets =
-        ArcCow::from_mmap(Arc::clone(&mmap), offsets_off, n_entries as usize + 1)?;
-    let names = ArcCow::from_mmap(Arc::clone(&mmap), names_off, names_blob_len as usize)?;
+    let (way_ids, offsets, names) = if is_compressed {
+        // Decompressed bytes — copy out each subarray as owned Vec.
+        let way_ids_slice: &[i64] = bytemuck::cast_slice(
+            &bytes[way_ids_local_off..way_ids_local_off + way_ids_bytes],
+        );
+        let offsets_slice: &[u32] = bytemuck::cast_slice(
+            &bytes[offsets_local_off..offsets_local_off + offsets_bytes],
+        );
+        let names_slice =
+            &bytes[names_local_off..names_local_off + names_bytes];
+        (
+            ArcCow::from_vec(way_ids_slice.to_vec()),
+            ArcCow::from_vec(offsets_slice.to_vec()),
+            ArcCow::from_vec(names_slice.to_vec()),
+        )
+    } else {
+        // Mmap-backed zero-copy.
+        let way_ids_off = byte_offset + way_ids_local_off;
+        let offsets_off = byte_offset + offsets_local_off;
+        let names_off = byte_offset + names_local_off;
+        let way_ids = ArcCow::from_mmap(Arc::clone(&mmap), way_ids_off, n_entries as usize)?;
+        let offsets =
+            ArcCow::from_mmap(Arc::clone(&mmap), offsets_off, n_entries as usize + 1)?;
+        let names = ArcCow::from_mmap(Arc::clone(&mmap), names_off, names_blob_len as usize)?;
+        (way_ids, offsets, names)
+    };
 
     Ok(WayNamesIdx {
         n_entries,

--- a/route/src/formats/zstd_compress.rs
+++ b/route/src/formats/zstd_compress.rs
@@ -1,0 +1,181 @@
+//! zstd-3 transparent compression for cold container sections (#347).
+//!
+//! Some container sections are read once at boot then either never
+//! touched again (snap_grid header) or randomly accessed with tiny
+//! actual hit rate (way_names_idx — only used during route response
+//! reconstruction, with sparse access patterns over a 21 MB blob).
+//!
+//! Compressing them with zstd-3 (fast decompress, ~5-10× ratio on
+//! text-like payloads) saves disk for a small one-time boot cost.
+//!
+//! # Design
+//!
+//! Section-level transparency: the container directory and per-section
+//! CRC stays as-is. Compression lives **inside** the section payload —
+//! a producer that wants to compress prefixes the body with the zstd
+//! magic (`0x28b52ffd`) and writes the compressed bytes. A consumer
+//! checks the first 4 bytes against the magic; on match it
+//! decompresses to a heap `Vec<u8>` and parses from that. On mismatch
+//! it parses the raw bytes (legacy uncompressed path).
+//!
+//! This keeps the container layer agnostic of compression and lets the
+//! format authors decide per-section whether the trade-off (heap RSS
+//! up by the decompressed size on first read, vs page-cache mmap that
+//! pays back over time) makes sense.
+//!
+//! # Beneficial?
+//!
+//! [`encode_compressed_if_beneficial`] runs the compressor on the input
+//! and returns the compressed bytes only if they save at least
+//! `MIN_SAVED_BYTES`. Otherwise it returns the raw bytes — readers that
+//! went through [`decompress_if_zstd`] will see no magic and parse the
+//! raw payload. The minimum-savings guard avoids hurting payloads that
+//! are already compact (e.g. tightly packed bitsets).
+
+use anyhow::Result;
+use std::borrow::Cow;
+
+/// First four bytes of every zstd-compressed stream — RFC 8478 §3.1.1
+/// ("Zstandard frames"). Reader uses this as a sniff hint: if the
+/// section body starts with these bytes, decompress; otherwise treat
+/// the payload as raw.
+pub const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+
+/// Compression level: 3 is zstd's default — sub-millisecond per MiB
+/// decompression on commodity hardware, ~5× ratio on text-like
+/// content. Higher levels (e.g. 19) cost much more on compress for
+/// modest ratio gains; cold sections compress once per region build
+/// so the absolute compress time is bounded.
+const COMPRESS_LEVEL: i32 = 3;
+
+/// Don't bother compressing if zstd saves fewer than this many bytes
+/// vs the raw input — the on-disk overhead of carrying the zstd frame
+/// header and decompressor cost on the read path isn't worth a tiny
+/// disk win. Empirically 4 KiB filters out already-compact bitset and
+/// CSR offset payloads cleanly.
+const MIN_SAVED_BYTES: usize = 4096;
+
+/// Compress `bytes` with zstd-3 and return the compressed bytes if
+/// the compressed size is at least `MIN_SAVED_BYTES` smaller than the
+/// raw input. Otherwise return the input unchanged so the section
+/// stays raw and the reader skips the decompress step.
+pub fn encode_compressed_if_beneficial(bytes: &[u8]) -> Vec<u8> {
+    if bytes.len() < MIN_SAVED_BYTES {
+        return bytes.to_vec();
+    }
+    match zstd::bulk::compress(bytes, COMPRESS_LEVEL) {
+        Ok(compressed) if bytes.len().saturating_sub(compressed.len()) >= MIN_SAVED_BYTES => {
+            compressed
+        }
+        Ok(_) | Err(_) => bytes.to_vec(),
+    }
+}
+
+/// Decompress `bytes` if they start with the zstd magic. Otherwise
+/// borrow them through unchanged. The returned `Cow` lets callers
+/// avoid an allocation in the uncompressed case (the common path for
+/// regions built before #347).
+///
+/// # Errors
+///
+/// Returns an error if the bytes start with the zstd magic but the
+/// frame is malformed. This propagates as a section-load failure,
+/// surfacing the corruption at boot rather than at first read.
+pub fn decompress_if_zstd(bytes: &[u8]) -> Result<Cow<'_, [u8]>> {
+    if bytes.len() < ZSTD_MAGIC.len() || bytes[..ZSTD_MAGIC.len()] != ZSTD_MAGIC {
+        return Ok(Cow::Borrowed(bytes));
+    }
+    // Pass a generous upper-bound; bulk::decompress shrinks the output
+    // to the actual size and frees the slack. The cap defends against
+    // malformed inputs claiming planet-scale sizes.
+    let decoded = zstd::bulk::decompress(bytes, MAX_DECOMPRESSED)
+        .map_err(|e| anyhow::anyhow!("zstd decompress failed: {e}"))?;
+    Ok(Cow::Owned(decoded))
+}
+
+/// Upper-bound buffer size for the decompressor. zstd's `bulk::compress`
+/// does not always pledge the source size in the frame header, so we
+/// can't always rely on the in-band hint. Instead we cap at 16 GiB —
+/// large enough for every section we'd pack (largest Belgium raw
+/// section is ~1.3 GB) and tight enough to defend against malicious
+/// inputs claiming planet-scale sizes.
+const MAX_DECOMPRESSED: usize = 16 * 1024 * 1024 * 1024;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_passthrough_for_short_input() {
+        let raw = b"hello world".to_vec();
+        let out = encode_compressed_if_beneficial(&raw);
+        assert_eq!(out, raw, "below MIN_SAVED_BYTES — stays raw");
+    }
+
+    #[test]
+    fn compresses_repetitive_input_into_smaller_payload() {
+        // 64 KiB of zeros — should compress to <1 KiB.
+        let raw = vec![0u8; 64 * 1024];
+        let out = encode_compressed_if_beneficial(&raw);
+        assert!(
+            out.len() < raw.len(),
+            "compressed should be smaller (raw={}, compressed={})",
+            raw.len(),
+            out.len()
+        );
+        assert_eq!(
+            out[..4],
+            ZSTD_MAGIC,
+            "compressed payload should start with zstd magic"
+        );
+    }
+
+    #[test]
+    fn round_trip_via_decompress_if_zstd() -> Result<()> {
+        // Mix of zeros + low-entropy bytes — guaranteed compressible.
+        let mut raw: Vec<u8> = (0..1024u32).map(|i| (i as u8).wrapping_mul(7)).collect();
+        raw.extend(vec![0u8; 64 * 1024]);
+        let compressed = encode_compressed_if_beneficial(&raw);
+        assert!(compressed.len() < raw.len());
+        let decompressed = decompress_if_zstd(&compressed)?;
+        assert_eq!(&decompressed[..], &raw[..]);
+        Ok(())
+    }
+
+    #[test]
+    fn decompress_passes_through_raw_bytes() -> Result<()> {
+        let raw = b"not compressed at all - just raw bytes";
+        let got = decompress_if_zstd(raw)?;
+        assert_eq!(&got[..], &raw[..]);
+        Ok(())
+    }
+
+    #[test]
+    fn decompress_rejects_truncated_frame() {
+        let mut buf = ZSTD_MAGIC.to_vec();
+        buf.extend_from_slice(&[0u8; 4]); // garbage after magic
+        let err = decompress_if_zstd(&buf).expect_err("must reject");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("zstd"),
+            "expected zstd error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn skips_incompressible_input() {
+        // Random-ish bytes don't compress — encode_compressed_if_beneficial
+        // should return the raw input.
+        let raw: Vec<u8> = (0..16 * 1024).map(|i| (i as u8).wrapping_mul(31)).collect();
+        let out = encode_compressed_if_beneficial(&raw);
+        // Either staying raw or compressing — but the test asserts the
+        // function's contract: if compressed isn't ≥ MIN_SAVED_BYTES
+        // smaller, we get raw.
+        if out.len() != raw.len() {
+            assert!(
+                raw.len().saturating_sub(out.len()) >= MIN_SAVED_BYTES,
+                "if compressed, must save at least MIN_SAVED_BYTES"
+            );
+        }
+    }
+}

--- a/route/src/pack.rs
+++ b/route/src/pack.rs
@@ -779,16 +779,35 @@ fn pack_snap_index(
     drop(tiles_bytes);
 
     let grid_bytes = SnapGridFile::encode(&built.grid);
-    println!(
-        "  + [{:>5} MiB] {:<28} <- (snap_grid, {}x{} cells)",
-        grid_bytes.len() / (1024 * 1024),
-        "shared/snap_grid",
-        built.grid.n_cells_x,
-        built.grid.n_cells_y,
-    );
-    w.append_bytes(SectionKind::SnapGrid, "shared/snap_grid", &grid_bytes)
+    // #347: compress the snap_grid section transparently. Grid offsets
+    // are CSR-style sparse arrays — many adjacent cells have identical
+    // start offsets, so zstd-3 compresses them ~3-5× on Belgium.
+    let raw_len = grid_bytes.len();
+    let packed = crate::formats::zstd_compress::encode_compressed_if_beneficial(&grid_bytes);
+    let compressed = packed.len() != raw_len;
+    if compressed {
+        println!(
+            "  + [{:>5} KiB → {:>5} KiB zstd, {:.0}% saved] {:<28} <- (snap_grid, {}x{} cells)",
+            raw_len / 1024,
+            packed.len() / 1024,
+            100.0 * (1.0 - packed.len() as f64 / raw_len as f64),
+            "shared/snap_grid",
+            built.grid.n_cells_x,
+            built.grid.n_cells_y,
+        );
+    } else {
+        println!(
+            "  + [{:>5} MiB] {:<28} <- (snap_grid, {}x{} cells)",
+            raw_len / (1024 * 1024),
+            "shared/snap_grid",
+            built.grid.n_cells_x,
+            built.grid.n_cells_y,
+        );
+    }
+    w.append_bytes(SectionKind::SnapGrid, "shared/snap_grid", &packed)
         .with_context(|| "packing shared/snap_grid".to_string())?;
     drop(grid_bytes);
+    drop(packed);
 
     for (mw, mask) in mode_work.iter().zip(built.masks.iter()) {
         let mask_bytes = SnapMaskFile::encode(mask);
@@ -1063,14 +1082,32 @@ fn pack_way_names_idx(w: &mut ContainerWriter, step1: &Path) -> Result<()> {
     let buf = way_names_idx::serialise_to_bytes(&idx)
         .with_context(|| "serialising way_names_idx".to_string())?;
 
-    w.append_bytes(SectionKind::WayNamesIdx, "shared/way_names_idx", &buf)
+    // #347: compress the section body transparently. The reader sniffs
+    // the zstd magic and decompresses on first access. Text-like name
+    // payload compresses ~5×; bitset+offsets are dense binary so the
+    // overall ratio is ~3×.
+    let raw_len = buf.len();
+    let packed = crate::formats::zstd_compress::encode_compressed_if_beneficial(&buf);
+    let compressed = packed.len() != raw_len;
+
+    w.append_bytes(SectionKind::WayNamesIdx, "shared/way_names_idx", &packed)
         .with_context(|| "packing shared/way_names_idx".to_string())?;
 
-    println!(
-        "  + packed shared/way_names_idx ({} entries, {:.2} MiB)",
-        n_entries,
-        buf.len() as f64 / (1024.0 * 1024.0)
-    );
+    if compressed {
+        println!(
+            "  + packed shared/way_names_idx ({} entries, {:.2} MiB raw → {:.2} MiB zstd, {:.0}% saved)",
+            n_entries,
+            raw_len as f64 / (1024.0 * 1024.0),
+            packed.len() as f64 / (1024.0 * 1024.0),
+            100.0 * (1.0 - packed.len() as f64 / raw_len as f64),
+        );
+    } else {
+        println!(
+            "  + packed shared/way_names_idx ({} entries, {:.2} MiB)",
+            n_entries,
+            raw_len as f64 / (1024.0 * 1024.0)
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Smallest of the codex disk levers. Transparent zstd-3 compression for cold container sections — section-internal magic prefix, container directory and CRC stay format-agnostic.

## Bytes saved (Belgium, real pack output)

| Section | Raw | zstd-3 | Saved |
|---------|-----|--------|-------|
| \`shared/way_names_idx\` | 19.81 MiB | 6.61 MiB | **67%** |
| \`shared/snap_grid\` | 179 KiB | 77 KiB | **57%** |
| **TOTAL** | ~20 MB | ~6.7 MB | **~13 MB** |

Per-region savings on this measurement: ~13 MB. Europe rollout at 10 regions: **~130 MB**. Smaller than the codec chain (#349 / #351 / #352 saved 1.9 GB combined) but cheap to ship and orthogonal.

## How it works

\`encode_compressed_if_beneficial(bytes)\` runs zstd-3 and returns the compressed output only if it saves ≥ 4 KiB. Otherwise the raw input passes through. The pack writer calls it before \`append_bytes\` for \`way_names_idx\` and \`snap_grid\`; readers call \`decompress_if_zstd(section_bytes)\` which sniffs the zstd magic (\`0x28b52ffd\`) and decompresses to an owned \`Vec<u8>\`, or returns \`Cow::Borrowed\` for the raw case.

Container directory is unchanged. Section CRC covers the on-disk bytes (compressed or raw — readers verify before decompress).

## Trade-off

Compressed sections lose mmap-backed zero-copy reads — the decompressed payload lives in heap. Acceptable for these two sections:

- \`way_names_idx\` is consulted on every route response but sparse-access (binary search over 754k entries). Heap RSS for 25 MB of names < page-cache cost of the 20 MB mmap-backed equivalent.
- \`snap_grid\` is small (179 KiB) and consulted on every \`/nearest\`. Heap residency is trivial.

Net: heap goes up by < 25 MB, RSS stays roughly even (since the uncompressed sections were already mostly resident), disk drops by ~13 MB per region.

## Migration

Pre-#347 containers (no zstd magic) load unchanged — the sniff returns the raw bytes. Going forward, repacked containers compress these sections transparently. **No regen required for existing deployments**.

## Tests

6 new round-trip tests in \`formats/zstd_compress.rs\`:

- raw passthrough for short input
- repetitive input compresses + has zstd magic prefix
- full encode→decode round-trip
- raw bytes pass through \`decompress_if_zstd\` unchanged
- truncated frame rejected with clear error
- incompressible input either passes through or saves ≥ MIN

**586 lib tests pass** (was 580 + 6 new).

## Test plan

- [x] cargo build --release -p butterfly-route
- [x] cargo test --workspace --lib
- [x] Belgium repack — measured: way_names_idx 67% saved, snap_grid 57% saved
- [x] Reader sniff handles both compressed and uncompressed payloads (verified via test_decompress_passes_through_raw_bytes)