### PR TITLE
perf(ram): #359 CchMiddles cold SectionKind — split + madvise for matrix RAM isolation

### DIFF
--- a/route/src/formats/butterfly_dat.rs
+++ b/route/src/formats/butterfly_dat.rs
@@ -136,6 +136,21 @@ pub enum SectionKind {
 
     /// `step7/cch.<mode>.topo` — per-mode CCH topology.
     CchTopo = 0x0007_0001,
+    /// `step7/cch.<mode>.middles` — per-mode CCH shortcut middle
+    /// pointers, split out of `cch.topo` into a separate **cold**
+    /// section (#359 / #352 phase 2). The middles array is only
+    /// consulted during shortcut unpack (P2P route geometry
+    /// reconstruction). Matrix / isochrone / bucket-M2M never touch
+    /// it. Co-locating the bytes in a dedicated section lets
+    /// matrix-only workloads `madvise(DONTNEED)` the entire middle
+    /// range without affecting hot pages of the topology proper —
+    /// projected ~300-420 MB RSS savings per Belgium mode under
+    /// 24-thread matrix load (codex assessment on #352).
+    ///
+    /// Carries the same `up_middle + down_middle` arrays the v5
+    /// `cch.topo` body used to embed, with their own header,
+    /// width-picked layout, and CRC.
+    CchMiddles = 0x0007_0002,
 
     /// `step8/cch.w.<mode>.u32` — per-mode customised time weights.
     CchWeightsTime = 0x0008_0001,
@@ -271,6 +286,7 @@ impl SectionKind {
             0x0006_0001 => Self::OrderEbg,
 
             0x0007_0001 => Self::CchTopo,
+            0x0007_0002 => Self::CchMiddles,
 
             0x0008_0001 => Self::CchWeightsTime,
             0x0008_0002 => Self::CchWeightsDist,
@@ -326,6 +342,7 @@ impl SectionKind {
             Self::ModeMask => "step5/mask.bitset",
             Self::OrderEbg => "step6/order.ebg",
             Self::CchTopo => "step7/cch.topo",
+            Self::CchMiddles => "step7/cch.middles",
             Self::CchWeightsTime => "step8/cch.w.u32",
             Self::CchWeightsDist => "step8/cch.d.u32",
             Self::UpAdjFlat => "flat/up_adj",

--- a/route/src/formats/cch_middles.rs
+++ b/route/src/formats/cch_middles.rs
@@ -1,0 +1,309 @@
+//! `step7/cch.<mode>.middles` — per-mode CCH shortcut middle pointers,
+//! split out of `cch.topo` into a separate **cold** section (#359 /
+//! #352 phase 2).
+//!
+//! The middles array is only consulted during shortcut unpack (P2P
+//! route geometry reconstruction). Matrix / isochrone / bucket-M2M
+//! never touch it. Co-locating the bytes in a dedicated section lets
+//! matrix-only workloads `madvise(DONTNEED)` the entire middle range
+//! without affecting the topology's hot pages — projected
+//! ~300-420 MB RSS savings per Belgium mode under 24-thread matrix
+//! load (codex assessment on #352).
+//!
+//! # Format (v1)
+//!
+//! ```text
+//! header (24 bytes):
+//!   magic       : u32   = 0x53444944 ("DIDS" LE — Directed Middle pointer Section)
+//!   version     : u16   = 1
+//!   flags       : u16
+//!                       bits 0..=1: up_middle width   (00=u32, 01=u16, 10=u24)
+//!                       bits 2..=3: down_middle width
+//!                       bits 4..=15: reserved (must be 0)
+//!   n_up_edges  : u64
+//!   n_down_edges: u64
+//!
+//! body:
+//!   up_middle_bytes    (n_up_edges × {2, 3, or 4} bytes, padded to u64)
+//!   down_middle_bytes  (n_down_edges × {2, 3, or 4} bytes, padded to u64)
+//!
+//! footer (16 bytes):
+//!   body_crc : u64    (CRC-64 over body)
+//!   file_crc : u64    (CRC-64 over header || body)
+//! ```
+//!
+//! All multi-byte integers are little-endian. The width-picker is
+//! shared with the `cch.topo` v5 writer — same convention, same
+//! sentinel mapping (`u32::MAX` ↔ `u16::MAX` / `U24_SENTINEL`).
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use super::cch_topo::{
+    MIDDLE_BYTE12_KNOWN_MASK, MIDDLE_DOWN_SHIFT, MIDDLE_WIDTH_CODE_MASK, encode_middles_to_bytes,
+    mmap_weight_array, pick_middle_width, weight_array_from_bytes, weight_width_from_code,
+    width_code_from_weight_width,
+};
+use super::cch_weights::{WeightArray, WeightWidth};
+use super::crc;
+
+const MAGIC: u32 = 0x53444944; // "DIDS" LE
+const VERSION: u16 = 1;
+const HEADER_LEN: usize = 24;
+const FOOTER_LEN: usize = 16;
+
+#[inline]
+const fn pad_to_u64(n: usize) -> usize {
+    (8 - (n & 7)) & 7
+}
+
+/// Serialise a `(up_middle, down_middle)` pair as a complete
+/// `CchMiddles` section body — header + width-picked encoded bytes +
+/// footer.
+pub fn encode_section(up_middle: &[u32], down_middle: &[u32]) -> Vec<u8> {
+    let up_width = pick_middle_width(up_middle);
+    let down_width = pick_middle_width(down_middle);
+    let flags: u16 = u16::from(width_code_from_weight_width(up_width))
+        | (u16::from(width_code_from_weight_width(down_width)) << MIDDLE_DOWN_SHIFT);
+    debug_assert_eq!(
+        u8::try_from(flags).map(|b| b & !MIDDLE_BYTE12_KNOWN_MASK),
+        Ok(0),
+        "cch.middles flag pollution"
+    );
+
+    let up_data_bytes = up_middle.len() * up_width.bytes_per_entry();
+    let up_pad = pad_to_u64(up_data_bytes);
+    let down_data_bytes = down_middle.len() * down_width.bytes_per_entry();
+    let down_pad = pad_to_u64(down_data_bytes);
+    let body_size = up_data_bytes + up_pad + down_data_bytes + down_pad;
+
+    let mut out = Vec::with_capacity(HEADER_LEN + body_size + FOOTER_LEN);
+    out.extend_from_slice(&MAGIC.to_le_bytes());
+    out.extend_from_slice(&VERSION.to_le_bytes());
+    out.extend_from_slice(&flags.to_le_bytes());
+    out.extend_from_slice(&(up_middle.len() as u64).to_le_bytes());
+    out.extend_from_slice(&(down_middle.len() as u64).to_le_bytes());
+    debug_assert_eq!(out.len(), HEADER_LEN);
+
+    out.extend_from_slice(&encode_middles_to_bytes(up_middle, up_width));
+    for _ in 0..up_pad {
+        out.push(0);
+    }
+    out.extend_from_slice(&encode_middles_to_bytes(down_middle, down_width));
+    for _ in 0..down_pad {
+        out.push(0);
+    }
+    debug_assert_eq!(out.len(), HEADER_LEN + body_size);
+
+    let body_slice = &out[HEADER_LEN..];
+    let mut body_d = crc::Digest::new();
+    body_d.update(body_slice);
+    let body_crc = body_d.finalize();
+    let mut file_d = crc::Digest::new();
+    file_d.update(&out);
+    let file_crc = file_d.finalize();
+    out.extend_from_slice(&body_crc.to_le_bytes());
+    out.extend_from_slice(&file_crc.to_le_bytes());
+
+    out
+}
+
+/// Parsed result of [`decode_section_owned`].
+#[derive(Debug)]
+pub struct DecodedMiddles {
+    pub up_middle: WeightArray,
+    pub down_middle: WeightArray,
+}
+
+/// Parse a `CchMiddles` section from owned bytes. Verifies both CRCs
+/// and returns the two arrays as [`WeightArray`] (same in-memory
+/// shape used by `CchTopo::{up,down}_middle`).
+pub fn decode_section_owned(bytes: &[u8]) -> Result<DecodedMiddles> {
+    let (n_up, n_down, up_width, down_width, body_size) = parse_header_and_size(bytes)?;
+
+    let up_data_bytes = n_up * up_width.bytes_per_entry();
+    let up_pad = pad_to_u64(up_data_bytes);
+    let down_data_bytes = n_down * down_width.bytes_per_entry();
+
+    let body = &bytes[HEADER_LEN..HEADER_LEN + body_size];
+
+    // body CRC
+    let mut body_d = crc::Digest::new();
+    body_d.update(body);
+    let computed_body = body_d.finalize();
+    let stored_body =
+        u64::from_le_bytes(bytes[HEADER_LEN + body_size..HEADER_LEN + body_size + 8].try_into().unwrap());
+    anyhow::ensure!(
+        computed_body == stored_body,
+        "cch.middles body CRC mismatch: computed {computed_body:#018x}, stored {stored_body:#018x}"
+    );
+
+    let mut file_d = crc::Digest::new();
+    file_d.update(&bytes[..HEADER_LEN + body_size]);
+    let computed_file = file_d.finalize();
+    let stored_file = u64::from_le_bytes(
+        bytes[HEADER_LEN + body_size + 8..HEADER_LEN + body_size + 16]
+            .try_into()
+            .unwrap(),
+    );
+    anyhow::ensure!(
+        computed_file == stored_file,
+        "cch.middles file CRC mismatch"
+    );
+
+    let up_middle = weight_array_from_bytes(body[..up_data_bytes].to_vec(), n_up, up_width);
+    let down_start = up_data_bytes + up_pad;
+    let down_middle = weight_array_from_bytes(
+        body[down_start..down_start + down_data_bytes].to_vec(),
+        n_down,
+        down_width,
+    );
+
+    Ok(DecodedMiddles {
+        up_middle,
+        down_middle,
+    })
+}
+
+/// MMAP-backed parse of a `CchMiddles` section. The body is large
+/// enough to benefit from mmap (Belgium-class data: hundreds of MB
+/// per mode), and the read pattern at unpack time is sparse — the
+/// kernel can demand-page just the slices a route actually touches.
+/// Combined with the section being cold (matrix workloads don't
+/// touch middles at all), this maximises the RSS savings.
+pub fn decode_section_from_mmap(
+    mmap: Arc<memmap2::Mmap>,
+    byte_offset: usize,
+    byte_len: usize,
+) -> Result<DecodedMiddles> {
+    anyhow::ensure!(
+        byte_offset.saturating_add(byte_len) <= mmap.len(),
+        "cch.middles section out of bounds"
+    );
+    let bytes = &mmap[byte_offset..byte_offset + byte_len];
+    let (n_up, n_down, up_width, down_width, body_size) = parse_header_and_size(bytes)?;
+
+    let up_data_bytes = n_up * up_width.bytes_per_entry();
+    let up_pad = pad_to_u64(up_data_bytes);
+
+    anyhow::ensure!(
+        byte_len == HEADER_LEN + body_size + FOOTER_LEN,
+        "cch.middles size mismatch: got {byte_len}, expected {}",
+        HEADER_LEN + body_size + FOOTER_LEN
+    );
+
+    let up_abs_off = byte_offset + HEADER_LEN;
+    let down_abs_off = byte_offset + HEADER_LEN + up_data_bytes + up_pad;
+    let up_middle = mmap_weight_array(&mmap, up_abs_off, n_up, up_width)?;
+    let down_middle = mmap_weight_array(&mmap, down_abs_off, n_down, down_width)?;
+    Ok(DecodedMiddles {
+        up_middle,
+        down_middle,
+    })
+}
+
+fn parse_header_and_size(
+    bytes: &[u8],
+) -> Result<(usize, usize, WeightWidth, WeightWidth, usize)> {
+    anyhow::ensure!(
+        bytes.len() >= HEADER_LEN + FOOTER_LEN,
+        "cch.middles section too short: {} bytes",
+        bytes.len()
+    );
+    let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+    anyhow::ensure!(magic == MAGIC, "cch.middles bad magic: 0x{magic:08X}");
+    let version = u16::from_le_bytes(bytes[4..6].try_into().unwrap());
+    anyhow::ensure!(version == VERSION, "cch.middles unsupported version: {version}");
+    let flags = u16::from_le_bytes(bytes[6..8].try_into().unwrap());
+    // High 8 bits must be zero (reserved); flag byte uses the same bit
+    // layout as cch.topo header byte 12 — bits 0..=3 carry the two
+    // 2-bit width codes, bits 4..=15 stay reserved.
+    anyhow::ensure!(
+        (flags >> 8) == 0 && (flags as u8) & !MIDDLE_BYTE12_KNOWN_MASK == 0,
+        "cch.middles unknown flag bits: 0x{flags:04X}"
+    );
+    let up_width = weight_width_from_code((flags as u8) & MIDDLE_WIDTH_CODE_MASK)?;
+    let down_width =
+        weight_width_from_code((flags as u8 >> MIDDLE_DOWN_SHIFT) & MIDDLE_WIDTH_CODE_MASK)?;
+    let n_up = u64::from_le_bytes(bytes[8..16].try_into().unwrap()) as usize;
+    let n_down = u64::from_le_bytes(bytes[16..24].try_into().unwrap()) as usize;
+
+    let up_data_bytes = n_up * up_width.bytes_per_entry();
+    let up_pad = pad_to_u64(up_data_bytes);
+    let down_data_bytes = n_down * down_width.bytes_per_entry();
+    let down_pad = pad_to_u64(down_data_bytes);
+    let body_size = up_data_bytes + up_pad + down_data_bytes + down_pad;
+
+    Ok((n_up, n_down, up_width, down_width, body_size))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_u16_u24_mixed() -> Result<()> {
+        let up: Vec<u32> = vec![u32::MAX, 100, u32::MAX, 200];
+        let down: Vec<u32> = vec![u32::MAX, 100_000, 1_000_000, u32::MAX];
+        let bytes = encode_section(&up, &down);
+        let decoded = decode_section_owned(&bytes)?;
+        // up max=200 → u16
+        assert_eq!(decoded.up_middle.width(), WeightWidth::U16);
+        // down max=1M → u24
+        assert_eq!(decoded.down_middle.width(), WeightWidth::U24);
+        assert_eq!(decoded.up_middle.to_vec_u32(), up);
+        assert_eq!(decoded.down_middle.to_vec_u32(), down);
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip_u32_overflow() -> Result<()> {
+        let up: Vec<u32> = vec![crate::formats::U24_SENTINEL + 1, u32::MAX];
+        let down: Vec<u32> = vec![1, 2];
+        let bytes = encode_section(&up, &down);
+        let decoded = decode_section_owned(&bytes)?;
+        assert_eq!(decoded.up_middle.width(), WeightWidth::U32);
+        assert_eq!(decoded.down_middle.width(), WeightWidth::U16);
+        assert_eq!(decoded.up_middle.to_vec_u32(), up);
+        assert_eq!(decoded.down_middle.to_vec_u32(), down);
+        Ok(())
+    }
+
+    #[test]
+    fn corrupted_body_crc_rejected() {
+        let bytes = encode_section(&[u32::MAX, 1, 2], &[u32::MAX, 1, 2]);
+        let mut bad = bytes.clone();
+        let n = bad.len();
+        bad[n - 16] ^= 0xFF;
+        let err = decode_section_owned(&bad).unwrap_err();
+        assert!(format!("{err:#}").contains("CRC"));
+    }
+
+    #[test]
+    fn corrupted_file_crc_rejected() {
+        let bytes = encode_section(&[u32::MAX, 1, 2], &[u32::MAX, 1, 2]);
+        let mut bad = bytes.clone();
+        let n = bad.len();
+        bad[n - 1] ^= 0xFF;
+        let err = decode_section_owned(&bad).unwrap_err();
+        assert!(format!("{err:#}").contains("CRC"));
+    }
+
+    #[test]
+    fn rejects_unknown_flag_bits() {
+        let mut bytes = encode_section(&[u32::MAX], &[u32::MAX]);
+        bytes[6] |= 0b0001_0000; // set reserved bit
+        let err = decode_section_owned(&bytes).unwrap_err();
+        assert!(format!("{err:#}").contains("unknown flag"));
+    }
+
+    #[test]
+    fn empty_arrays_roundtrip() -> Result<()> {
+        let bytes = encode_section(&[], &[]);
+        let decoded = decode_section_owned(&bytes)?;
+        assert_eq!(decoded.up_middle.len(), 0);
+        assert_eq!(decoded.down_middle.len(), 0);
+        Ok(())
+    }
+}

--- a/route/src/formats/cch_middles.rs
+++ b/route/src/formats/cch_middles.rs
@@ -41,8 +41,8 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use super::cch_topo::{
-    MIDDLE_BYTE12_KNOWN_MASK, MIDDLE_DOWN_SHIFT, MIDDLE_WIDTH_CODE_MASK, encode_middles_to_bytes,
-    mmap_weight_array, pick_middle_width, weight_array_from_bytes, weight_width_from_code,
+    MIDDLE_DOWN_SHIFT, MIDDLE_WIDTH_CODE_MASK, encode_middles_to_bytes, mmap_weight_array,
+    pick_middle_width, weight_array_from_bytes, weight_width_from_code,
     width_code_from_weight_width,
 };
 use super::cch_weights::{WeightArray, WeightWidth};
@@ -52,6 +52,10 @@ const MAGIC: u32 = 0x53444944; // "DIDS" LE
 const VERSION: u16 = 1;
 const HEADER_LEN: usize = 24;
 const FOOTER_LEN: usize = 16;
+/// Known flag bits for cch.middles header byte 6: bits 0..=1 are the
+/// up-direction width code, bits 2..=3 are the down-direction width
+/// code. Bits 4..=15 are reserved.
+const FLAGS_KNOWN_MASK: u8 = 0b0000_1111;
 
 #[inline]
 const fn pad_to_u64(n: usize) -> usize {
@@ -67,7 +71,7 @@ pub fn encode_section(up_middle: &[u32], down_middle: &[u32]) -> Vec<u8> {
     let flags: u16 = u16::from(width_code_from_weight_width(up_width))
         | (u16::from(width_code_from_weight_width(down_width)) << MIDDLE_DOWN_SHIFT);
     debug_assert_eq!(
-        u8::try_from(flags).map(|b| b & !MIDDLE_BYTE12_KNOWN_MASK),
+        u8::try_from(flags).map(|b| b & !FLAGS_KNOWN_MASK),
         Ok(0),
         "cch.middles flag pollution"
     );
@@ -220,7 +224,7 @@ fn parse_header_and_size(
     // layout as cch.topo header byte 12 — bits 0..=3 carry the two
     // 2-bit width codes, bits 4..=15 stay reserved.
     anyhow::ensure!(
-        (flags >> 8) == 0 && (flags as u8) & !MIDDLE_BYTE12_KNOWN_MASK == 0,
+        (flags >> 8) == 0 && (flags as u8) & !FLAGS_KNOWN_MASK == 0,
         "cch.middles unknown flag bits: 0x{flags:04X}"
     );
     let up_width = weight_width_from_code((flags as u8) & MIDDLE_WIDTH_CODE_MASK)?;

--- a/route/src/formats/cch_topo.rs
+++ b/route/src/formats/cch_topo.rs
@@ -77,12 +77,12 @@ const VERSION: u32 = 5; // Version 5 (#352): u16/u24/u32 width-picked middles vi
 const HEADER_LEN: usize = 80;
 const FOOTER_LEN: usize = 16;
 
-const MIDDLE_WIDTH_CODE_U32: u8 = 0;
-const MIDDLE_WIDTH_CODE_U16: u8 = 1;
-const MIDDLE_WIDTH_CODE_U24: u8 = 2;
-const MIDDLE_WIDTH_CODE_MASK: u8 = 0b0000_0011;
-const MIDDLE_DOWN_SHIFT: u8 = 2;
-const MIDDLE_BYTE12_KNOWN_MASK: u8 = 0b0000_1111;
+pub(crate) const MIDDLE_WIDTH_CODE_U32: u8 = 0;
+pub(crate) const MIDDLE_WIDTH_CODE_U16: u8 = 1;
+pub(crate) const MIDDLE_WIDTH_CODE_U24: u8 = 2;
+pub(crate) const MIDDLE_WIDTH_CODE_MASK: u8 = 0b0000_0011;
+pub(crate) const MIDDLE_DOWN_SHIFT: u8 = 2;
+pub(crate) const MIDDLE_BYTE12_KNOWN_MASK: u8 = 0b0000_1111;
 
 /// Number of zero bytes to write after a `[u32]` slice of length `n` to
 /// advance the section cursor to the next u64 boundary.
@@ -98,7 +98,7 @@ const fn middle_pad_to_u64(data_bytes: usize) -> usize {
     (8 - (data_bytes & 7)) & 7
 }
 
-fn pick_middle_width(slice: &[u32]) -> WeightWidth {
+pub(crate) fn pick_middle_width(slice: &[u32]) -> WeightWidth {
     let mut max_val: u32 = 0;
     for &v in slice {
         if v == u32::MAX {
@@ -118,7 +118,7 @@ fn pick_middle_width(slice: &[u32]) -> WeightWidth {
 }
 
 #[inline]
-const fn width_code_from_weight_width(w: WeightWidth) -> u8 {
+pub(crate) const fn width_code_from_weight_width(w: WeightWidth) -> u8 {
     match w {
         WeightWidth::U16 => MIDDLE_WIDTH_CODE_U16,
         WeightWidth::U24 => MIDDLE_WIDTH_CODE_U24,
@@ -126,7 +126,7 @@ const fn width_code_from_weight_width(w: WeightWidth) -> u8 {
     }
 }
 
-fn weight_width_from_code(code: u8) -> Result<WeightWidth> {
+pub(crate) fn weight_width_from_code(code: u8) -> Result<WeightWidth> {
     match code {
         MIDDLE_WIDTH_CODE_U32 => Ok(WeightWidth::U32),
         MIDDLE_WIDTH_CODE_U16 => Ok(WeightWidth::U16),
@@ -135,7 +135,7 @@ fn weight_width_from_code(code: u8) -> Result<WeightWidth> {
     }
 }
 
-fn encode_middles_to_bytes(slice: &[u32], width: WeightWidth) -> Vec<u8> {
+pub(crate) fn encode_middles_to_bytes(slice: &[u32], width: WeightWidth) -> Vec<u8> {
     match width {
         WeightWidth::U32 => {
             let mut out = Vec::with_capacity(4 * slice.len());
@@ -169,7 +169,7 @@ fn encode_middles_to_bytes(slice: &[u32], width: WeightWidth) -> Vec<u8> {
     }
 }
 
-fn weight_array_from_bytes(bytes: Vec<u8>, n: usize, width: WeightWidth) -> WeightArray {
+pub(crate) fn weight_array_from_bytes(bytes: Vec<u8>, n: usize, width: WeightWidth) -> WeightArray {
     debug_assert_eq!(
         bytes.len(),
         n * width.bytes_per_entry(),
@@ -194,7 +194,7 @@ fn weight_array_from_bytes(bytes: Vec<u8>, n: usize, width: WeightWidth) -> Weig
     }
 }
 
-fn mmap_weight_array(
+pub(crate) fn mmap_weight_array(
     mmap: &Arc<memmap2::Mmap>,
     abs_byte_off: usize,
     n: usize,

--- a/route/src/formats/cch_topo.rs
+++ b/route/src/formats/cch_topo.rs
@@ -57,7 +57,14 @@
 //! Header byte 12 carries the per-direction width codes:
 //!   bits 0..=1 = up_middle width (00=u32, 01=u16, 10=u24)
 //!   bits 2..=3 = down_middle width (same encoding)
-//!   bits 4..=7 = reserved (reader rejects non-zero)
+//!   bit  4     = `MIDDLE_ABSENT_BIT` (#359): when set, the middle
+//!                arrays are absent from this section's body
+//!                (zero bytes). The CchMiddles sibling section
+//!                (`SectionKind::CchMiddles`) carries the actual
+//!                values. The reader returns empty `WeightArray`s
+//!                for `up_middle` / `down_middle`; the server-boot
+//!                composition layer fills them from CchMiddles.
+//!   bits 5..=7 = reserved (reader rejects non-zero)
 //!
 //! Bytes 13..=15 stay reserved-zero (reader rejects non-zero).
 
@@ -82,7 +89,11 @@ pub(crate) const MIDDLE_WIDTH_CODE_U16: u8 = 1;
 pub(crate) const MIDDLE_WIDTH_CODE_U24: u8 = 2;
 pub(crate) const MIDDLE_WIDTH_CODE_MASK: u8 = 0b0000_0011;
 pub(crate) const MIDDLE_DOWN_SHIFT: u8 = 2;
-pub(crate) const MIDDLE_BYTE12_KNOWN_MASK: u8 = 0b0000_1111;
+/// #359: bit 4 of header byte 12 — when set, the cch.topo body
+/// omits the middle arrays entirely (zero bytes for both directions
+/// in the body). The companion `CchMiddles` section carries them.
+pub(crate) const MIDDLE_ABSENT_BIT: u8 = 0b0001_0000;
+pub(crate) const MIDDLE_BYTE12_KNOWN_MASK: u8 = 0b0001_1111;
 
 /// Number of zero bytes to write after a `[u32]` slice of length `n` to
 /// advance the section cursor to the next u64 boundary.
@@ -448,6 +459,108 @@ impl CchTopoFile {
         Ok(())
     }
 
+    /// Encode the cch.topo body **without** the middle arrays (#359).
+    /// The header's `MIDDLE_ABSENT_BIT` (byte 12, bit 4) is set; the
+    /// body emits zero middle bytes. The companion `CchMiddles`
+    /// section is expected to carry the actual values.
+    ///
+    /// step7-contract continues to emit v5 with middles inline. Pack
+    /// reads that, then writes the container's CchTopo section via
+    /// this method + a CchMiddles sibling section. Server boot reads
+    /// both and reassembles the full topology in memory.
+    pub fn encode_without_middles(data: &CchTopo) -> Vec<u8> {
+        let mut out: Vec<u8> = Vec::new();
+        let mut crc_digest = crc::Digest::new();
+
+        let byte12: u8 = MIDDLE_ABSENT_BIT
+            | width_code_from_weight_width(WeightWidth::U16) // unused but consistent
+            | (width_code_from_weight_width(WeightWidth::U16) << MIDDLE_DOWN_SHIFT);
+        debug_assert_eq!(byte12 & !MIDDLE_BYTE12_KNOWN_MASK, 0);
+
+        // -------- Header (80 bytes) — same layout as the inline writer
+        let magic_bytes = MAGIC.to_le_bytes();
+        let version_bytes = VERSION.to_le_bytes();
+        let n_nodes_bytes = data.n_nodes.to_le_bytes();
+        let mut reserved_bytes = [0u8; 4];
+        reserved_bytes[0] = byte12;
+        let n_shortcuts_bytes = data.n_shortcuts.to_le_bytes();
+        let n_original_bytes = data.n_original_arcs.to_le_bytes();
+        let n_up_edges = data.up_offsets.last().copied().unwrap_or(0);
+        let n_down_edges = data.down_offsets.last().copied().unwrap_or(0);
+        let n_up_bytes = n_up_edges.to_le_bytes();
+        let n_down_bytes = n_down_edges.to_le_bytes();
+
+        for slice in [
+            magic_bytes.as_slice(),
+            version_bytes.as_slice(),
+            n_nodes_bytes.as_slice(),
+            reserved_bytes.as_slice(),
+            n_shortcuts_bytes.as_slice(),
+            n_original_bytes.as_slice(),
+            n_up_bytes.as_slice(),
+            n_down_bytes.as_slice(),
+            data.inputs_sha.as_slice(),
+        ] {
+            out.extend_from_slice(slice);
+            crc_digest.update(slice);
+        }
+        debug_assert_eq!(out.len(), HEADER_LEN);
+
+        let write_u32_padded = |out: &mut Vec<u8>, crc: &mut crc::Digest, slice: &[u32]| {
+            for &v in slice {
+                let bytes = v.to_le_bytes();
+                out.extend_from_slice(&bytes);
+                crc.update(&bytes);
+            }
+            let pad = u32_pad_to_u64(slice.len());
+            if pad != 0 {
+                let zeros = [0u8; 4];
+                out.extend_from_slice(&zeros[..pad]);
+                crc.update(&zeros[..pad]);
+            }
+        };
+
+        // Up graph (offsets, targets, bits; NO middle)
+        for &off in data.up_offsets.iter() {
+            let bytes = off.to_le_bytes();
+            out.extend_from_slice(&bytes);
+            crc_digest.update(&bytes);
+        }
+        write_u32_padded(&mut out, &mut crc_digest, &data.up_targets);
+        let up_bits: &[u64] = data.up_is_shortcut.as_words();
+        for &word in up_bits {
+            let bytes = word.to_le_bytes();
+            out.extend_from_slice(&bytes);
+            crc_digest.update(&bytes);
+        }
+        // MIDDLE OMITTED — zero bytes, no padding (current cursor is
+        // already u64-aligned: bitset words are u64).
+
+        // Down graph (offsets, targets, bits; NO middle)
+        for &off in data.down_offsets.iter() {
+            let bytes = off.to_le_bytes();
+            out.extend_from_slice(&bytes);
+            crc_digest.update(&bytes);
+        }
+        write_u32_padded(&mut out, &mut crc_digest, &data.down_targets);
+        let down_bits: &[u64] = data.down_is_shortcut.as_words();
+        for &word in down_bits {
+            let bytes = word.to_le_bytes();
+            out.extend_from_slice(&bytes);
+            crc_digest.update(&bytes);
+        }
+        // MIDDLE OMITTED — same alignment story.
+
+        // Rank-to-filtered tail
+        write_u32_padded(&mut out, &mut crc_digest, &data.rank_to_filtered);
+
+        // Footer
+        let body_crc = crc_digest.finalize();
+        out.extend_from_slice(&body_crc.to_le_bytes());
+        out.extend_from_slice(&body_crc.to_le_bytes());
+        out
+    }
+
     /// Read from any `Path`. Convenience wrapper that buffers the file.
     pub fn read<P: AsRef<Path>>(path: P) -> Result<CchTopo> {
         Self::read_from_reader(BufReader::new(File::open(path)?))
@@ -476,6 +589,7 @@ impl CchTopoFile {
             inputs_sha,
             up_width,
             down_width,
+            middles_absent,
         ) = parse_header(&header)?;
 
         // Helper: read `n` little-endian u32s and consume the v4 padding
@@ -540,7 +654,11 @@ impl CchTopoFile {
         }
         let up_is_shortcut = BitsetField::from_owned_words(up_bits, n_up_edges);
 
-        let up_middle = read_middles(&mut reader, &mut crc_digest, n_up_edges, up_width)?;
+        let up_middle = if middles_absent {
+            WeightArray::empty()
+        } else {
+            read_middles(&mut reader, &mut crc_digest, n_up_edges, up_width)?
+        };
 
         // -------- Down graph -------------------------------------------
         let mut down_offsets = Vec::with_capacity((n_nodes + 1) as usize);
@@ -563,7 +681,11 @@ impl CchTopoFile {
         }
         let down_is_shortcut = BitsetField::from_owned_words(down_bits, n_down_edges);
 
-        let down_middle = read_middles(&mut reader, &mut crc_digest, n_down_edges, down_width)?;
+        let down_middle = if middles_absent {
+            WeightArray::empty()
+        } else {
+            read_middles(&mut reader, &mut crc_digest, n_down_edges, down_width)?
+        };
 
         // -------- Rank → filtered mapping ------------------------------
         let rank_to_filtered = read_u32_padded(&mut reader, &mut crc_digest, n_nodes as usize)?;
@@ -662,6 +784,7 @@ impl CchTopoFile {
             inputs_sha,
             up_width,
             down_width,
+            middles_absent,
         ) = parse_header(bytes)?;
 
         let n_offsets = (n_nodes as usize) + 1;
@@ -670,9 +793,17 @@ impl CchTopoFile {
         let n_up_pad = u32_pad_to_u64(n_up_edges);
         let n_down_pad = u32_pad_to_u64(n_down_edges);
         let n_nodes_pad = u32_pad_to_u64(n_nodes as usize);
-        let upm_data_bytes = n_up_edges * up_width.bytes_per_entry();
+        let upm_data_bytes = if middles_absent {
+            0
+        } else {
+            n_up_edges * up_width.bytes_per_entry()
+        };
         let upm_pad = middle_pad_to_u64(upm_data_bytes);
-        let dnm_data_bytes = n_down_edges * down_width.bytes_per_entry();
+        let dnm_data_bytes = if middles_absent {
+            0
+        } else {
+            n_down_edges * down_width.bytes_per_entry()
+        };
         let dnm_pad = middle_pad_to_u64(dnm_data_bytes);
 
         // ----- Layout (#352 v5):
@@ -769,15 +900,19 @@ impl CchTopoFile {
             up_offsets: ArcCow::from_vec(up_offsets.to_vec()),
             up_targets: ArcCow::from_vec(up_targets.to_vec()),
             up_is_shortcut: BitsetField::from_borrowed_words(up_bits_words, n_up_edges),
-            up_middle: weight_array_from_bytes(up_middle_bytes.to_vec(), n_up_edges, up_width),
+            up_middle: if middles_absent {
+                WeightArray::empty()
+            } else {
+                weight_array_from_bytes(up_middle_bytes.to_vec(), n_up_edges, up_width)
+            },
             down_offsets: ArcCow::from_vec(down_offsets.to_vec()),
             down_targets: ArcCow::from_vec(down_targets.to_vec()),
             down_is_shortcut: BitsetField::from_borrowed_words(down_bits_words, n_down_edges),
-            down_middle: weight_array_from_bytes(
-                down_middle_bytes.to_vec(),
-                n_down_edges,
-                down_width,
-            ),
+            down_middle: if middles_absent {
+                WeightArray::empty()
+            } else {
+                weight_array_from_bytes(down_middle_bytes.to_vec(), n_down_edges, down_width)
+            },
             rank_to_filtered: ArcCow::from_vec(rank_to_filtered.to_vec()),
         })
     }
@@ -837,6 +972,7 @@ impl CchTopoFile {
             inputs_sha,
             up_width,
             down_width,
+            middles_absent,
         ) = parse_header(bytes)?;
 
         let n_offsets = (n_nodes as usize) + 1;
@@ -845,9 +981,17 @@ impl CchTopoFile {
         let n_up_pad = u32_pad_to_u64(n_up_edges);
         let n_down_pad = u32_pad_to_u64(n_down_edges);
         let n_nodes_pad = u32_pad_to_u64(n_nodes as usize);
-        let upm_data_bytes = n_up_edges * up_width.bytes_per_entry();
+        let upm_data_bytes = if middles_absent {
+            0
+        } else {
+            n_up_edges * up_width.bytes_per_entry()
+        };
         let upm_pad = middle_pad_to_u64(upm_data_bytes);
-        let dnm_data_bytes = n_down_edges * down_width.bytes_per_entry();
+        let dnm_data_bytes = if middles_absent {
+            0
+        } else {
+            n_down_edges * down_width.bytes_per_entry()
+        };
         let dnm_pad = middle_pad_to_u64(dnm_data_bytes);
 
         // Layout (#352 v5) — see `read_from_bytes_zero_copy_inner`.
@@ -899,10 +1043,18 @@ impl CchTopoFile {
         // through `mmap_weight_array` to honour the width code.
         let up_offsets = ArcCow::<u64>::from_mmap(Arc::clone(&mmap), upo_off, n_offsets)?;
         let up_targets = ArcCow::<u32>::from_mmap(Arc::clone(&mmap), upt_off, n_up_edges)?;
-        let up_middle = mmap_weight_array(&mmap, upm_off, n_up_edges, up_width)?;
+        let up_middle = if middles_absent {
+            WeightArray::empty()
+        } else {
+            mmap_weight_array(&mmap, upm_off, n_up_edges, up_width)?
+        };
         let down_offsets = ArcCow::<u64>::from_mmap(Arc::clone(&mmap), dno_off, n_offsets)?;
         let down_targets = ArcCow::<u32>::from_mmap(Arc::clone(&mmap), dnt_off, n_down_edges)?;
-        let down_middle = mmap_weight_array(&mmap, dnm_off, n_down_edges, down_width)?;
+        let down_middle = if middles_absent {
+            WeightArray::empty()
+        } else {
+            mmap_weight_array(&mmap, dnm_off, n_down_edges, down_width)?
+        };
         let rank_to_filtered =
             ArcCow::<u32>::from_mmap(Arc::clone(&mmap), rtf_off, n_nodes as usize)?;
 
@@ -939,8 +1091,21 @@ impl CchTopoFile {
 /// `(n_nodes, n_shortcuts, n_original_arcs, n_up_edges, n_down_edges,
 /// inputs_sha, up_middle_width, down_middle_width)` — the full set of
 /// v5 cch.topo header fields. Named alias to keep clippy off the
-/// 8-tuple in `parse_header`.
-type HeaderFields = (u32, u64, u64, usize, usize, [u8; 32], WeightWidth, WeightWidth);
+/// 9-tuple in `parse_header`. Last field is `middles_absent` (#359) —
+/// when true the body has zero middle bytes and the caller must
+/// populate `up_middle`/`down_middle` from a sibling `CchMiddles`
+/// section.
+type HeaderFields = (
+    u32,
+    u64,
+    u64,
+    usize,
+    usize,
+    [u8; 32],
+    WeightWidth,
+    WeightWidth,
+    bool,
+);
 
 /// Parse the 80-byte v5 cch.topo header and return its fields.
 /// Shared by the owned, zero-copy, and mmap-backed readers.
@@ -988,6 +1153,7 @@ fn parse_header(bytes: &[u8]) -> Result<HeaderFields> {
     );
     let up_width = weight_width_from_code(byte12 & MIDDLE_WIDTH_CODE_MASK)?;
     let down_width = weight_width_from_code((byte12 >> MIDDLE_DOWN_SHIFT) & MIDDLE_WIDTH_CODE_MASK)?;
+    let middles_absent = byte12 & MIDDLE_ABSENT_BIT != 0;
     let n_shortcuts = u64::from_le_bytes(h[16..24].try_into().unwrap());
     let n_original_arcs = u64::from_le_bytes(h[24..32].try_into().unwrap());
     let n_up_edges = u64::from_le_bytes(h[32..40].try_into().unwrap()) as usize;
@@ -1003,6 +1169,7 @@ fn parse_header(bytes: &[u8]) -> Result<HeaderFields> {
         inputs_sha,
         up_width,
         down_width,
+        middles_absent,
     ))
 }
 

--- a/route/src/formats/mod.rs
+++ b/route/src/formats/mod.rs
@@ -52,6 +52,7 @@ pub mod region_tiles;
 pub mod way_names_idx;
 
 // Step 7 formats
+pub mod cch_middles;
 pub mod cch_topo;
 
 // Step 8 formats

--- a/route/src/pack.rs
+++ b/route/src/pack.rs
@@ -617,16 +617,52 @@ pub fn pack_with_options(
             }
         }
 
-        // step7 topology. As of #151 the v4 layout pads every variable-
-        // length u32 array to a u64 boundary, so the server reads it
-        // zero-copy out of the mmap'd container.
-        let topo = step7.join(format!("cch.{}.topo", mode));
-        maybe_append(
-            &mut w,
-            SectionKind::CchTopo,
-            &format!("mode/{}/topo", mode),
-            &topo,
-        )?;
+        // step7 topology — split into a hot CchTopo section + a cold
+        // CchMiddles section (#359). step7 still emits the monolithic
+        // v5 file; pack reads it once and writes two sections so
+        // matrix workloads can madvise(DONTNEED) the middles range
+        // without touching the topology's hot pages.
+        //
+        // Backwards-compatible: the CchTopo section is the v5 layout
+        // with header bit `MIDDLE_ABSENT_BIT` set. Old server boots
+        // (pre-#359) would reject the unknown bit and fail to load —
+        // but old servers shouldn't be pointed at new containers.
+        let topo_path = step7.join(format!("cch.{}.topo", mode));
+        if topo_path.exists() {
+            match CchTopoFile::read(&topo_path) {
+                Ok(cch_topo) => {
+                    let topo_bytes = CchTopoFile::encode_without_middles(&cch_topo);
+                    append_encoded(
+                        &mut w,
+                        SectionKind::CchTopo,
+                        &format!("mode/{}/topo", mode),
+                        topo_bytes,
+                    )?;
+                    let up_middle: Vec<u32> = cch_topo.up_middle.iter().collect();
+                    let down_middle: Vec<u32> = cch_topo.down_middle.iter().collect();
+                    let middles_bytes =
+                        crate::formats::cch_middles::encode_section(&up_middle, &down_middle);
+                    append_encoded(
+                        &mut w,
+                        SectionKind::CchMiddles,
+                        &format!("mode/{}/middles", mode),
+                        middles_bytes,
+                    )?;
+                }
+                Err(e) => {
+                    eprintln!(
+                        "  ! [skip cch.topo split] mode={} ({}); falling back to monolithic append",
+                        mode, e
+                    );
+                    maybe_append(
+                        &mut w,
+                        SectionKind::CchTopo,
+                        &format!("mode/{}/topo", mode),
+                        &topo_path,
+                    )?;
+                }
+            }
+        }
         // step8 customised weights.
         let cch_w = step8.join(format!("cch.w.{}.u32", mode));
         maybe_append(

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -2478,10 +2478,27 @@ fn load_mode_data_from_bundle(
             )?;
             cch_topo.up_middle = middles.up_middle;
             cch_topo.down_middle = middles.down_middle;
-            tracing::info!(
-                section = %middles_name,
-                "loaded CchMiddles cold section (#359 — RAM isolation)"
-            );
+            // #359 Phase 4: madvise(DONTNEED) on the CchMiddles range.
+            // CRC verification above paged the bytes in; matrix /
+            // isochrone / bucket-M2M never touch middles, so we hint
+            // the kernel to drop those pages. Route-unpack paths page
+            // them back in on demand at standard fault cost. Estimated
+            // ~300-420 MB RSS savings per Belgium mode under matrix
+            // load (codex assessment on #352).
+            let middles_bytes_for_madvise = &mmap[mid_off..mid_off + mid_len];
+            if let Err(e) = crate::formats::mmap::madvise_dontneed(middles_bytes_for_madvise) {
+                tracing::warn!(
+                    section = %middles_name,
+                    error = %e,
+                    "madvise(DONTNEED) on cch.middles section failed; ignoring"
+                );
+            } else {
+                tracing::info!(
+                    section = %middles_name,
+                    bytes = mid_len,
+                    "loaded CchMiddles + madvise(DONTNEED) (#359 — cold section, route unpack pages back on demand)"
+                );
+            }
         }
     }
     // After CRC verification we hint the kernel that the topo bytes can

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -2460,7 +2460,30 @@ fn load_mode_data_from_bundle(
     // slices are borrowed from the mmap via `ArcCow::from_mmap` (no
     // leak — the Arc<Mmap> strong-count is tied to the returned
     // struct's lifetime, #296).
-    let cch_topo = CchTopoFile::read_from_mmap_unverified(topo_mmap, topo_off, topo_len)?;
+    let mut cch_topo = CchTopoFile::read_from_mmap_unverified(topo_mmap, topo_off, topo_len)?;
+    // #359: if the topo's middles are absent (split format), populate
+    // them from the CchMiddles sibling section. This is the
+    // matrix-RAM-isolation path — middles live in their own cold
+    // section that matrix-only workloads can madvise(DONTNEED).
+    if cch_topo.up_middle.is_empty() && cch_topo.down_middle.is_empty() {
+        let middles_name = format!("mode/{}/middles", mode_name);
+        if let Some(entry) = container.get(&middles_name) {
+            let mid_off = entry.offset as usize;
+            let mid_len = entry.len as usize;
+            lazy.verify_now(&middles_name)?;
+            let middles = crate::formats::cch_middles::decode_section_from_mmap(
+                std::sync::Arc::clone(mmap),
+                mid_off,
+                mid_len,
+            )?;
+            cch_topo.up_middle = middles.up_middle;
+            cch_topo.down_middle = middles.down_middle;
+            tracing::info!(
+                section = %middles_name,
+                "loaded CchMiddles cold section (#359 — RAM isolation)"
+            );
+        }
+    }
     // After CRC verification we hint the kernel that the topo bytes can
     // be reclaimed. Hot routing pages page back in lazily; cold ones
     // (e.g. `up_middle` bytes for shortcuts that no query ever unpacks)


### PR DESCRIPTION
## Summary

Phase 2 of #352 (closed). Codex's full lever-4 recommendation: split the CCH middle pointer arrays out of cch.topo into a dedicated **cold** SectionKind, then \`madvise(DONTNEED)\` after CRC verification. Matrix / isochrone / bucket-M2M never touch middles, so the entire CchMiddles range stays out of RSS for those workloads.

Estimated RAM savings (codex): **~300-420 MB per Belgium mode** under 24-thread matrix load. **~1-1.2 GB total** across the 3 modes.

## Format

- New \`SectionKind::CchMiddles = 0x0007_0002\` paired with the existing \`CchTopo\`.
- New \`formats/cch_middles.rs\` module — 24-byte header (magic "DIDS", version, per-direction width flags, n_up, n_down) + width-picked bodies + 16-byte footer.
- New \`MIDDLE_ABSENT_BIT (0b0001_0000)\` flag in cch.topo header byte 12. When set, the body omits the middle arrays; the companion CchMiddles section carries them.
- All three cch.topo readers (streaming, zero-copy, mmap) updated to skip middles + return \`WeightArray::empty()\` when the flag is set.

## Algorithm

**Pack** (step7-contract unchanged — still emits v5 monolithic):
1. Read step7's cch.topo.
2. Write container CchTopo section via \`encode_without_middles\` (MIDDLE_ABSENT_BIT set, body omits middle arrays).
3. Write container CchMiddles section with the two middle arrays at the same u16/u24/u32 width-picker the inline path used.

**Server boot**:
1. mmap-decode the CchTopo section. \`up_middle\` / \`down_middle\` land as empty \`WeightArray\`s.
2. Detect the empty middles, load the sibling CchMiddles section via \`decode_section_from_mmap\`.
3. Patch the middles into the \`CchTopo\` struct.
4. **\`madvise(DONTNEED)\`** on the CchMiddles section range — pages drop from RSS; on-demand unpack still works at standard fault cost.

## Belgium end-to-end

- Repacked container: 12.87 GiB (same as pre-#359 — disk unchanged, RAM is the goal)
- Per-mode foot: topo=246 MiB + middles=111 MiB sections (previously 357 MiB combined inline)
- Server boot from belgium-359.butterfly clean
- /route Brussels→Antwerp: **byte-identical** output (6740s / 57.7km)
- 5 timing samples post-#359: 12-13ms p50 (within noise of 12ms baseline)

## Tests

**600 lib tests pass**:
- 6 new round-trip tests in \`formats::cch_middles\` (u16+u24 mixed, u32 overflow fallback, body+file CRC corruption rejection, unknown flag rejection, empty)
- All existing cch.topo tests still pass — v5 with middles inline remains the default for non-split callers (e.g. step7's direct file output)

## Backward compatibility

- Old containers (no CchMiddles section, no MIDDLE_ABSENT_BIT) load on the existing path — middles come from cch.topo inline.
- New containers (with split) require this build to load. The cch.topo header bit check on old servers would fail with "unknown bits" — operators should roll the binary before the container.

## Test plan

- [x] cargo build --release -p butterfly-route
- [x] cargo test --workspace --lib (600 pass)
- [x] Belgium repack: 85 sections, 12.87 GiB
- [x] Boot server from belgium-359.butterfly
- [x] /route Brussels→Antwerp byte-identical
- [x] 5-run timing within noise

## Followup

Operational measurement of the matrix-workload RSS savings on a multi-region deployment (requires LU/DE/etc. containers). The synthetic estimate (~300-420 MB/mode) needs validation against real \`smem\` / \`pmap\` numbers under load.