### PR TITLE
chore(clippy): collapse 9 lints (no behaviour change)

### DIFF
--- a/route/src/formats/bitset.rs
+++ b/route/src/formats/bitset.rs
@@ -85,7 +85,7 @@ impl BitsetField {
         len: usize,
     ) -> Result<Self> {
         anyhow::ensure!(
-            byte_len % 8 == 0,
+            byte_len.is_multiple_of(8),
             "BitsetField byte_len must be a multiple of 8 (u64 words), got {byte_len}",
         );
         let n_words = byte_len / 8;

--- a/route/src/formats/cch_middles.rs
+++ b/route/src/formats/cch_middles.rs
@@ -91,13 +91,9 @@ pub fn encode_section(up_middle: &[u32], down_middle: &[u32]) -> Vec<u8> {
     debug_assert_eq!(out.len(), HEADER_LEN);
 
     out.extend_from_slice(&encode_middles_to_bytes(up_middle, up_width));
-    for _ in 0..up_pad {
-        out.push(0);
-    }
+    out.resize(out.len() + up_pad, 0);
     out.extend_from_slice(&encode_middles_to_bytes(down_middle, down_width));
-    for _ in 0..down_pad {
-        out.push(0);
-    }
+    out.resize(out.len() + down_pad, 0);
     debug_assert_eq!(out.len(), HEADER_LEN + body_size);
 
     let body_slice = &out[HEADER_LEN..];

--- a/route/src/formats/mmap.rs
+++ b/route/src/formats/mmap.rs
@@ -238,7 +238,7 @@ impl<T: bytemuck::Pod> ArcCow<T> {
         // `as_ptr() as usize` is safe; we just check the would-be address.
         let ptr_addr = (mmap.as_ptr() as usize).wrapping_add(byte_offset);
         anyhow::ensure!(
-            ptr_addr % align == 0,
+            ptr_addr.is_multiple_of(align),
             "ArcCow misaligned for {}: ptr={ptr_addr:#x} align={align}",
             std::any::type_name::<T>()
         );

--- a/route/src/formats/region_tiles.rs
+++ b/route/src/formats/region_tiles.rs
@@ -140,7 +140,7 @@ impl RegionTilesFile {
             "RegionTilesFile::encode: input must be sorted ascending"
         );
         let n = rt.len();
-        let body_len = n * std::mem::size_of::<u64>();
+        let body_len = std::mem::size_of_val(rt);
         let mut out = Vec::with_capacity(HEADER_SIZE + body_len + FOOTER_SIZE);
         out.extend_from_slice(&REGION_TILES_MAGIC.to_le_bytes());
         out.extend_from_slice(&REGION_TILES_VERSION.to_le_bytes());

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -83,7 +83,7 @@ fn build_weight_array(
                 let le = v.to_le_bytes();
                 bytes.extend_from_slice(&le[..3]);
             }
-            return WeightArray::from_u24_bytes(bytes, n);
+            WeightArray::from_u24_bytes(bytes, n)
         }
         WeightWidth::U16 => {
             let v16: Vec<u16> = weights_u32
@@ -611,20 +611,14 @@ pub fn encode_flat_topo_bytes(
             out.extend_from_slice(&off.to_le_bytes());
         }
     }
-    for _ in 0..offsets_pad {
-        out.push(0);
-    }
+    out.resize(out.len() + offsets_pad, 0);
     out.extend_from_slice(&encode_targets_to_bytes_split(targets, targets_width));
-    for _ in 0..targets_pad {
-        out.push(0);
-    }
+    out.resize(out.len() + targets_pad, 0);
     if has_topo_idx {
         for &t in topo_edge_idx {
             out.extend_from_slice(&t.to_le_bytes());
         }
-        for _ in 0..topo_idx_pad {
-            out.push(0);
-        }
+        out.resize(out.len() + topo_idx_pad, 0);
     }
     debug_assert_eq!(out.len(), FLAT_TOPO_HEADER_SIZE + body_size);
 
@@ -830,9 +824,7 @@ pub fn encode_flat_weights_bytes(weights: &crate::formats::WeightArray) -> Vec<u
         }
     }
     out.extend_from_slice(&body_bytes);
-    for _ in 0..body_pad {
-        out.push(0);
-    }
+    out.resize(out.len() + body_pad, 0);
     debug_assert_eq!(out.len(), FLAT_WEIGHTS_HEADER_SIZE + body_size);
 
     let body_slice = &out[FLAT_WEIGHTS_HEADER_SIZE..];


### PR DESCRIPTION
Mechanical cleanup of 9 clippy errors. All no-behaviour-change rewrites — `cargo build` and tests pass identically pre/post.

## Fixed

- 6 `for _ in 0..pad { push(0) }` → `resize(len + pad, 0)` in cch_middles + bucket_ch encoders (clippy `clippy::same_item_push`).
- 2 `x % n == 0` → `x.is_multiple_of(n)` in bitset + mmap (clippy `clippy::manual_is_multiple_of`).
- 1 `n * size_of::<u64>()` → `size_of_val(rt)` in region_tiles (clippy `clippy::manual_slice_size_calculation`).
- 1 unneeded `return` in bucket_ch::build_weight_array (clippy `clippy::needless_return`).

## Not in scope

5 clippy errors remain on main (larger refactors): `write_adj_flat_header` 8/7 args, regions.rs complex types, server/mod.rs doc markers + trim_split_whitespace. To be addressed in a separate dedicated PR if/when these matter for CI gating.

## Test plan

- [x] cargo build --release -p butterfly-route
- [x] cargo test --workspace --lib (600 pass)