### PR TITLE
chore(clippy): finish cleanup — zero clippy errors on butterfly-route

### DIFF
--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -1061,8 +1061,10 @@ fn width_code_of(w: crate::formats::WeightWidth) -> u8 {
     }
 }
 
-fn write_adj_flat_header(
-    out: &mut Vec<u8>,
+/// Fields that go into the v4 flat-adjacency header. Grouped into a
+/// struct so [`write_adj_flat_header`] takes a single argument
+/// instead of an 8-tuple (clippy `too_many_arguments`).
+struct AdjFlatHeader {
     magic: u32,
     has_topo_idx: bool,
     width: crate::formats::WeightWidth,
@@ -1070,18 +1072,20 @@ fn write_adj_flat_header(
     targets_width: crate::formats::WeightWidth,
     n_nodes: u64,
     n_edges: u64,
-) {
-    let mut flags: u8 = width_code_of(width);
-    if offsets_u32 {
+}
+
+fn write_adj_flat_header(out: &mut Vec<u8>, h: AdjFlatHeader) {
+    let mut flags: u8 = width_code_of(h.width);
+    if h.offsets_u32 {
         flags |= ADJ_FLAT_OFFSETS_U32_BIT;
     }
-    flags |= width_code_of(targets_width) << ADJ_FLAT_TARGETS_CODE_SHIFT;
-    out.extend_from_slice(&magic.to_le_bytes());
+    flags |= width_code_of(h.targets_width) << ADJ_FLAT_TARGETS_CODE_SHIFT;
+    out.extend_from_slice(&h.magic.to_le_bytes());
     out.extend_from_slice(&ADJ_FLAT_VERSION.to_le_bytes());
-    out.push(if has_topo_idx { 1 } else { 0 });
+    out.push(if h.has_topo_idx { 1 } else { 0 });
     out.push(flags); // byte 7: see ADJ_FLAT_* constants above
-    out.extend_from_slice(&n_nodes.to_le_bytes());
-    out.extend_from_slice(&n_edges.to_le_bytes());
+    out.extend_from_slice(&h.n_nodes.to_le_bytes());
+    out.extend_from_slice(&h.n_edges.to_le_bytes());
     out.extend_from_slice(&0u64.to_le_bytes()); // _resv2
     debug_assert!(out.len().is_multiple_of(ADJ_FLAT_HEADER_SIZE));
 }
@@ -1492,13 +1496,15 @@ impl UpAdjFlatFile {
         let mut out = Vec::with_capacity(body_end + ADJ_FLAT_FOOTER_SIZE);
         write_adj_flat_header(
             &mut out,
-            UP_ADJ_FLAT_MAGIC,
-            has_topo_idx,
-            width,
-            offsets_u32,
-            targets_width,
-            n_nodes as u64,
-            n_edges as u64,
+            AdjFlatHeader {
+                magic: UP_ADJ_FLAT_MAGIC,
+                has_topo_idx,
+                width,
+                offsets_u32,
+                targets_width,
+                n_nodes: n_nodes as u64,
+                n_edges: n_edges as u64,
+            },
         );
         let topo: Option<&[u32]> = if has_topo_idx {
             Some(&flat.topo_edge_idx)
@@ -1674,13 +1680,15 @@ impl DownAdjFlatFile {
         let mut out = Vec::with_capacity(body_end + ADJ_FLAT_FOOTER_SIZE);
         write_adj_flat_header(
             &mut out,
-            DOWN_ADJ_FLAT_MAGIC,
-            false,
-            width,
-            offsets_u32,
-            targets_width,
-            n_nodes as u64,
-            n_edges as u64,
+            AdjFlatHeader {
+                magic: DOWN_ADJ_FLAT_MAGIC,
+                has_topo_idx: false,
+                width,
+                offsets_u32,
+                targets_width,
+                n_nodes: n_nodes as u64,
+                n_edges: n_edges as u64,
+            },
         );
         write_adj_flat_body_and_footer(
             &mut out,
@@ -1816,13 +1824,15 @@ impl DownReverseAdjFlatFile {
         let mut out = Vec::with_capacity(body_end + ADJ_FLAT_FOOTER_SIZE);
         write_adj_flat_header(
             &mut out,
-            DOWN_REV_ADJ_FLAT_MAGIC,
-            has_topo_idx,
-            width,
-            offsets_u32,
-            targets_width,
-            n_nodes as u64,
-            n_edges as u64,
+            AdjFlatHeader {
+                magic: DOWN_REV_ADJ_FLAT_MAGIC,
+                has_topo_idx,
+                width,
+                offsets_u32,
+                targets_width,
+                n_nodes: n_nodes as u64,
+                n_edges: n_edges as u64,
+            },
         );
         let topo: Option<&[u32]> = if has_topo_idx {
             Some(&flat.topo_edge_idx)

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -149,9 +149,9 @@ pub fn set_rss_budget_override(gib: f64) {
 
 /// #292 Phase 6: read the server's RSS budget in bytes.
 ///
-/// Source order: process-wide override (`--rss-budget-gb` CLI flag)
-/// > environment variable `BUTTERFLY_RSS_BUDGET_GB` if set and
-/// parseable > 80% of the system's MemTotal (read from
+/// Source order: process-wide override (`--rss-budget-gb` CLI flag),
+/// then environment variable `BUTTERFLY_RSS_BUDGET_GB` if set and
+/// parseable, then 80% of the system's MemTotal (read from
 /// `/proc/meminfo` on Linux). The final number is clamped to at
 /// least 1 GiB and at most 1 TiB to catch operator typos.
 fn rss_budget_bytes() -> u64 {
@@ -188,7 +188,6 @@ fn default_rss_budget_gib() -> f64 {
         if let Some(rest) = line.strip_prefix("MemTotal:") {
             // e.g. "MemTotal:       65789012 kB"
             let kb: u64 = rest
-                .trim()
                 .split_whitespace()
                 .next()
                 .and_then(|n| n.parse().ok())
@@ -211,7 +210,6 @@ fn read_proc_vm_rss_bytes() -> Option<u64> {
     for line in s.lines() {
         if let Some(rest) = line.strip_prefix("VmRSS:") {
             let kb: u64 = rest
-                .trim()
                 .split_whitespace()
                 .next()
                 .and_then(|n| n.parse().ok())?;

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -548,13 +548,14 @@ impl RegionsState {
         // lazy path's snap_winner / has_mode can filter without
         // loading. The whole pre-pass is <1 ms per container (manifest
         // section read + a 40-byte snap_points header read).
-        let mut to_load: Vec<(
+        type RegionPreloadEntry = (
             String,
             Option<crate::formats::SnapBbox>,
             Vec<String>,
             Option<crate::formats::RegionTiles>,
             PathBuf,
-        )> = Vec::new();
+        );
+        let mut to_load: Vec<RegionPreloadEntry> = Vec::new();
         let mut skipped: Vec<String> = Vec::new();
         for path in &containers {
             let (region, bbox, modes, tiles) = peek_region_meta(path)
@@ -1427,14 +1428,18 @@ impl DispatchError {
 /// Used by the lazy-region boot path so `snap_winner` / `has_mode` /
 /// `available_modes` can answer Pending-region questions without
 /// triggering a full load.
-fn peek_region_meta(
-    path: &Path,
-) -> Result<(
+/// `(region_id, optional snap bbox, mode names, optional region tiles)`
+/// — the tuple shape [`peek_region_meta`] returns. Promoted to a type
+/// alias so the signature stays readable and the clippy
+/// `clippy::type_complexity` lint stops firing.
+type RegionMetaPeek = (
     String,
     Option<crate::formats::SnapBbox>,
     Vec<String>,
     Option<crate::formats::RegionTiles>,
-)> {
+);
+
+fn peek_region_meta(path: &Path) -> Result<RegionMetaPeek> {
     use crate::formats::butterfly_dat::Container;
     let container =
         Container::open(path).with_context(|| format!("opening container {}", path.display()))?;


### PR DESCRIPTION
Picks up the 4 lints #363 deferred:

- `write_adj_flat_header` 8/7 args → `AdjFlatHeader` struct.
- regions.rs 2× complex tuple types → type aliases (`RegionPreloadEntry`, `RegionMetaPeek`).
- mod.rs 3× doc `>` markers reworded so they don't look like blockquote markers.
- mod.rs 2× redundant `.trim().split_whitespace()` → just `.split_whitespace()`.

`cargo clippy -p butterfly-route --lib --all-features` reports **0 errors** on this branch. 600 lib tests pass. No behaviour change.

## Test plan
- [x] cargo build
- [x] cargo test --workspace --lib
- [x] cargo clippy: 0 errors