### PR TITLE
chore(lints): clippy + fmt cleanup (pre-existing drift)

### DIFF
--- a/dl/src/regions.rs
+++ b/dl/src/regions.rs
@@ -135,9 +135,7 @@ impl SectionFilter {
             "all" => Ok(Self::All),
             "pbf" => Ok(Self::PbfOnly),
             "transit" => Ok(Self::TransitOnly),
-            other => bail!(
-                "unknown --only value '{other}'. Accepted values: all, pbf, transit"
-            ),
+            other => bail!("unknown --only value '{other}'. Accepted values: all, pbf, transit"),
         }
     }
 

--- a/route/src/bench/weight_profile.rs
+++ b/route/src/bench/weight_profile.rs
@@ -337,8 +337,10 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
         let mode_data = &state.modes[i];
         let t_up = compute_static_stats(&mode_data.cch_weights.up.iter().collect::<Vec<u32>>());
         let t_dn = compute_static_stats(&mode_data.cch_weights.down.iter().collect::<Vec<u32>>());
-        let d_up = compute_static_stats(&mode_data.cch_weights_dist.up.iter().collect::<Vec<u32>>());
-        let d_dn = compute_static_stats(&mode_data.cch_weights_dist.down.iter().collect::<Vec<u32>>());
+        let d_up =
+            compute_static_stats(&mode_data.cch_weights_dist.up.iter().collect::<Vec<u32>>());
+        let d_dn =
+            compute_static_stats(&mode_data.cch_weights_dist.down.iter().collect::<Vec<u32>>());
         println!(
             "  - {}: time up p99={} p99.9={} max={} inf={}; \
              dist up p99={} p99.9={} max={} inf={}",
@@ -363,10 +365,22 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
         BTreeMap::new();
     for (i, mode_name) in state.mode_names.iter().enumerate() {
         let mode_data = &state.modes[i];
-        let t_up = compute_block_stats(&mode_data.cch_weights.up.iter().collect::<Vec<u32>>(), BLOCK_SIZES);
-        let t_dn = compute_block_stats(&mode_data.cch_weights.down.iter().collect::<Vec<u32>>(), BLOCK_SIZES);
-        let d_up = compute_block_stats(&mode_data.cch_weights_dist.up.iter().collect::<Vec<u32>>(), BLOCK_SIZES);
-        let d_dn = compute_block_stats(&mode_data.cch_weights_dist.down.iter().collect::<Vec<u32>>(), BLOCK_SIZES);
+        let t_up = compute_block_stats(
+            &mode_data.cch_weights.up.iter().collect::<Vec<u32>>(),
+            BLOCK_SIZES,
+        );
+        let t_dn = compute_block_stats(
+            &mode_data.cch_weights.down.iter().collect::<Vec<u32>>(),
+            BLOCK_SIZES,
+        );
+        let d_up = compute_block_stats(
+            &mode_data.cch_weights_dist.up.iter().collect::<Vec<u32>>(),
+            BLOCK_SIZES,
+        );
+        let d_dn = compute_block_stats(
+            &mode_data.cch_weights_dist.down.iter().collect::<Vec<u32>>(),
+            BLOCK_SIZES,
+        );
         let summary = |b: &BlockStats| -> String {
             let mut s = Vec::new();
             for sz in BLOCK_SIZES {
@@ -1842,8 +1856,16 @@ fn path_edges(
     let mut meeting_node = u32::MAX;
 
     while !scratch.pq_fwd.is_empty() || !scratch.pq_bwd.is_empty() {
-        let fwd_min = scratch.pq_fwd.peek().map(|(_, &Reverse(d))| d).unwrap_or(u32::MAX);
-        let bwd_min = scratch.pq_bwd.peek().map(|(_, &Reverse(d))| d).unwrap_or(u32::MAX);
+        let fwd_min = scratch
+            .pq_fwd
+            .peek()
+            .map(|(_, &Reverse(d))| d)
+            .unwrap_or(u32::MAX);
+        let bwd_min = scratch
+            .pq_bwd
+            .peek()
+            .map(|(_, &Reverse(d))| d)
+            .unwrap_or(u32::MAX);
         if fwd_min >= best_dist && bwd_min >= best_dist {
             break;
         }

--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -1400,12 +1400,9 @@ impl Cli {
                 // directory — discovering modes from only the first path's
                 // parent while the others point elsewhere would silently
                 // produce wrong global indices.
-                let step2_dir = wa_parsed[0]
-                    .2
-                    .parent()
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Cannot determine step2 directory from way-attrs paths")
-                    })?;
+                let step2_dir = wa_parsed[0].2.parent().ok_or_else(|| {
+                    anyhow::anyhow!("Cannot determine step2 directory from way-attrs paths")
+                })?;
                 for ((name, _, wa_path), (_, _, tr_path)) in wa_parsed.iter().zip(tr_parsed.iter())
                 {
                     let wa_parent = wa_path.parent().unwrap_or(Path::new(""));
@@ -1897,7 +1894,9 @@ impl Cli {
                 crate::pack::pack(&data_dir, &out, step_prefix.as_deref(), region.as_deref())?;
                 if !keep_intermediates {
                     println!();
-                    println!("Auto-pruning intermediates (pass --keep-intermediates to disable)...");
+                    println!(
+                        "Auto-pruning intermediates (pass --keep-intermediates to disable)..."
+                    );
                     crate::pack::prune(&out, &data_dir, false)?;
                 }
                 Ok(())

--- a/route/src/customization.rs
+++ b/route/src/customization.rs
@@ -1016,8 +1016,8 @@ fn write_cch_weights(
     down_middle: &[u32],
     mode: Mode,
 ) -> Result<()> {
-    use crate::formats::crc::Digest;
     use crate::formats::WeightWidth;
+    use crate::formats::crc::Digest;
 
     const MAGIC: u32 = 0x43434857; // "CCHW"
     // v4 (#306 PR 3): per-direction 2-bit width code in header byte 7.
@@ -1119,11 +1119,7 @@ fn write_weights_body<W: std::io::Write>(
         }
         WeightWidth::U16 => {
             for &w in weights {
-                let v16: u16 = if w == u32::MAX {
-                    u16::MAX
-                } else {
-                    w as u16
-                };
+                let v16: u16 = if w == u32::MAX { u16::MAX } else { w as u16 };
                 let bytes = v16.to_le_bytes();
                 writer.write_all(&bytes)?;
                 crc_digest.update(&bytes);

--- a/route/src/formats/butterfly_dat.rs
+++ b/route/src/formats/butterfly_dat.rs
@@ -829,11 +829,7 @@ impl Container {
     /// [`Self::read_section_verified`], this never allocates a buffer
     /// of `sec.len` bytes — useful for verifying multi-GB sections at
     /// boot or during the `prune` pre-flight without spiking RSS.
-    pub fn verify_section_crc<P: AsRef<Path>>(
-        &self,
-        path: P,
-        sec: &SectionEntry,
-    ) -> Result<()> {
+    pub fn verify_section_crc<P: AsRef<Path>>(&self, path: P, sec: &SectionEntry) -> Result<()> {
         const CHUNK: usize = 1 << 20; // 1 MiB
         let mut file = File::open(path.as_ref())?;
         file.seek(SeekFrom::Start(sec.offset))?;

--- a/route/src/formats/cch_middles.rs
+++ b/route/src/formats/cch_middles.rs
@@ -132,8 +132,11 @@ pub fn decode_section_owned(bytes: &[u8]) -> Result<DecodedMiddles> {
     let mut body_d = crc::Digest::new();
     body_d.update(body);
     let computed_body = body_d.finalize();
-    let stored_body =
-        u64::from_le_bytes(bytes[HEADER_LEN + body_size..HEADER_LEN + body_size + 8].try_into().unwrap());
+    let stored_body = u64::from_le_bytes(
+        bytes[HEADER_LEN + body_size..HEADER_LEN + body_size + 8]
+            .try_into()
+            .unwrap(),
+    );
     anyhow::ensure!(
         computed_body == stored_body,
         "cch.middles body CRC mismatch: computed {computed_body:#018x}, stored {stored_body:#018x}"
@@ -203,9 +206,7 @@ pub fn decode_section_from_mmap(
     })
 }
 
-fn parse_header_and_size(
-    bytes: &[u8],
-) -> Result<(usize, usize, WeightWidth, WeightWidth, usize)> {
+fn parse_header_and_size(bytes: &[u8]) -> Result<(usize, usize, WeightWidth, WeightWidth, usize)> {
     anyhow::ensure!(
         bytes.len() >= HEADER_LEN + FOOTER_LEN,
         "cch.middles section too short: {} bytes",
@@ -214,7 +215,10 @@ fn parse_header_and_size(
     let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
     anyhow::ensure!(magic == MAGIC, "cch.middles bad magic: 0x{magic:08X}");
     let version = u16::from_le_bytes(bytes[4..6].try_into().unwrap());
-    anyhow::ensure!(version == VERSION, "cch.middles unsupported version: {version}");
+    anyhow::ensure!(
+        version == VERSION,
+        "cch.middles unsupported version: {version}"
+    );
     let flags = u16::from_le_bytes(bytes[6..8].try_into().unwrap());
     // High 8 bits must be zero (reserved); flag byte uses the same bit
     // layout as cch.topo header byte 12 — bits 0..=3 carry the two

--- a/route/src/formats/cch_topo.rs
+++ b/route/src/formats/cch_topo.rs
@@ -1152,7 +1152,8 @@ fn parse_header(bytes: &[u8]) -> Result<HeaderFields> {
         h[15]
     );
     let up_width = weight_width_from_code(byte12 & MIDDLE_WIDTH_CODE_MASK)?;
-    let down_width = weight_width_from_code((byte12 >> MIDDLE_DOWN_SHIFT) & MIDDLE_WIDTH_CODE_MASK)?;
+    let down_width =
+        weight_width_from_code((byte12 >> MIDDLE_DOWN_SHIFT) & MIDDLE_WIDTH_CODE_MASK)?;
     let middles_absent = byte12 & MIDDLE_ABSENT_BIT != 0;
     let n_shortcuts = u64::from_le_bytes(h[16..24].try_into().unwrap());
     let n_original_arcs = u64::from_le_bytes(h[24..32].try_into().unwrap());
@@ -1595,7 +1596,11 @@ mod tests {
         // v5 (#352): byte 12 carries per-direction middle width codes
         // (bits 0..=3); bits 4..=7 of byte 12 and bytes 13..=15 stay
         // reserved-zero.
-        assert_eq!(raw[12] & !MIDDLE_BYTE12_KNOWN_MASK, 0, "byte12 reserved bits");
+        assert_eq!(
+            raw[12] & !MIDDLE_BYTE12_KNOWN_MASK,
+            0,
+            "byte12 reserved bits"
+        );
         assert_eq!(raw[13], 0, "header[13] reserved");
         assert_eq!(raw[14], 0, "header[14] reserved");
         assert_eq!(raw[15], 0, "header[15] reserved");
@@ -1661,7 +1666,10 @@ mod tests {
             loaded.down_middle.width(),
             crate::formats::cch_weights::WeightWidth::U16
         );
-        assert_eq!(loaded.up_middle.to_vec_u32(), vec![u32::MAX, 2, u32::MAX, 1]);
+        assert_eq!(
+            loaded.up_middle.to_vec_u32(),
+            vec![u32::MAX, 2, u32::MAX, 1]
+        );
         assert_eq!(loaded.down_middle.to_vec_u32(), vec![u32::MAX, u32::MAX, 1]);
         Ok(())
     }

--- a/route/src/formats/cch_weights.rs
+++ b/route/src/formats/cch_weights.rs
@@ -760,9 +760,9 @@ pub(crate) fn decode_weight_array_mmap(
         )?)),
         WeightWidth::U24 => {
             // u24 needs `n × 3` raw bytes; ArcCow<u8> has no alignment requirement.
-            let n_bytes = n.checked_mul(3).ok_or_else(|| {
-                anyhow::anyhow!("cch.weights u24 byte count overflow: n={n}")
-            })?;
+            let n_bytes = n
+                .checked_mul(3)
+                .ok_or_else(|| anyhow::anyhow!("cch.weights u24 byte count overflow: n={n}"))?;
             Ok(WeightArray::U24(ArcCow::<u8>::from_mmap(
                 Arc::clone(mmap),
                 byte_offset,

--- a/route/src/formats/region_tiles.rs
+++ b/route/src/formats/region_tiles.rs
@@ -100,10 +100,8 @@ impl RegionTiles {
         // doc comment for why truncation would misclassify edges.
         let lon_e7 = (lon * 1e7).round() as i32;
         let lat_e7 = (lat * 1e7).round() as i32;
-        let center_lon_cell =
-            ((lon_e7 as i64 + LON_OFFSET_E7 as i64) / CELL_SIZE_E7 as i64) as i32;
-        let center_lat_cell =
-            ((lat_e7 as i64 + LAT_OFFSET_E7 as i64) / CELL_SIZE_E7 as i64) as i32;
+        let center_lon_cell = ((lon_e7 as i64 + LON_OFFSET_E7 as i64) / CELL_SIZE_E7 as i64) as i32;
+        let center_lat_cell = ((lat_e7 as i64 + LAT_OFFSET_E7 as i64) / CELL_SIZE_E7 as i64) as i32;
         let slice = self.tiles.as_slice();
         for dy in -margin_tiles..=margin_tiles {
             for dx in -margin_tiles..=margin_tiles {
@@ -192,8 +190,7 @@ impl RegionTilesFile {
         let mut file_d = Digest::new();
         file_d.update(&bytes[..footer_off]);
         let computed_file = file_d.finalize();
-        let stored_file =
-            u64::from_le_bytes(bytes[footer_off + 8..footer_off + 16].try_into()?);
+        let stored_file = u64::from_le_bytes(bytes[footer_off + 8..footer_off + 16].try_into()?);
         anyhow::ensure!(
             computed_file == stored_file,
             "region_tiles file CRC mismatch: computed 0x{:016X}, stored 0x{:016X}",

--- a/route/src/formats/turn_rules.rs
+++ b/route/src/formats/turn_rules.rs
@@ -43,7 +43,7 @@ pub struct TurnRule {
     pub from_way_id: i64,
     pub to_way_id: i64,
     pub kind: TurnRuleKind,
-    pub penalty_s: u32, // seconds (was deciseconds in v1, #297)
+    pub penalty_s: u32,  // seconds (was deciseconds in v1, #297)
     pub is_time_dep: u8, // 0=static, 1=time-dependent, 2=needs expansion (via=way)
 }
 

--- a/route/src/formats/way_names_idx.rs
+++ b/route/src/formats/way_names_idx.rs
@@ -310,14 +310,11 @@ pub fn read_from_mmap_unverified(
 
     let (way_ids, offsets, names) = if is_compressed {
         // Decompressed bytes — copy out each subarray as owned Vec.
-        let way_ids_slice: &[i64] = bytemuck::cast_slice(
-            &bytes[way_ids_local_off..way_ids_local_off + way_ids_bytes],
-        );
-        let offsets_slice: &[u32] = bytemuck::cast_slice(
-            &bytes[offsets_local_off..offsets_local_off + offsets_bytes],
-        );
-        let names_slice =
-            &bytes[names_local_off..names_local_off + names_bytes];
+        let way_ids_slice: &[i64] =
+            bytemuck::cast_slice(&bytes[way_ids_local_off..way_ids_local_off + way_ids_bytes]);
+        let offsets_slice: &[u32] =
+            bytemuck::cast_slice(&bytes[offsets_local_off..offsets_local_off + offsets_bytes]);
+        let names_slice = &bytes[names_local_off..names_local_off + names_bytes];
         (
             ArcCow::from_vec(way_ids_slice.to_vec()),
             ArcCow::from_vec(offsets_slice.to_vec()),
@@ -329,8 +326,7 @@ pub fn read_from_mmap_unverified(
         let offsets_off = byte_offset + offsets_local_off;
         let names_off = byte_offset + names_local_off;
         let way_ids = ArcCow::from_mmap(Arc::clone(&mmap), way_ids_off, n_entries as usize)?;
-        let offsets =
-            ArcCow::from_mmap(Arc::clone(&mmap), offsets_off, n_entries as usize + 1)?;
+        let offsets = ArcCow::from_mmap(Arc::clone(&mmap), offsets_off, n_entries as usize + 1)?;
         let names = ArcCow::from_mmap(Arc::clone(&mmap), names_off, names_blob_len as usize)?;
         (way_ids, offsets, names)
     };
@@ -434,10 +430,10 @@ mod tests {
         ];
         let idx = build_from_pairs(pairs).unwrap();
         assert_eq!(idx.n_entries, 3, "duplicate key should be deduped");
-        assert_eq!(idx.get(42).as_deref(), Some("First Street"));
+        assert_eq!(idx.get(42), Some("First Street"));
         // Last-write-wins on duplicate.
-        assert_eq!(idx.get(1_000).as_deref(), Some("Main Street (renamed)"));
-        assert_eq!(idx.get(2_500).as_deref(), Some("Park Ave"));
+        assert_eq!(idx.get(1_000), Some("Main Street (renamed)"));
+        assert_eq!(idx.get(2_500), Some("Park Ave"));
         assert_eq!(idx.get(99_999), None);
     }
 
@@ -451,9 +447,7 @@ mod tests {
 
     #[test]
     fn write_read_roundtrip() {
-        let pairs: Vec<(i64, String)> = (0..1000)
-            .map(|i| (i * 7, format!("street-{i}")))
-            .collect();
+        let pairs: Vec<(i64, String)> = (0..1000).map(|i| (i * 7, format!("street-{i}"))).collect();
         let idx = build_from_pairs(pairs).unwrap();
 
         let tmp = tempfile::NamedTempFile::new().unwrap();
@@ -461,7 +455,7 @@ mod tests {
         let loaded = read_owned(tmp.path()).unwrap();
         assert_eq!(loaded.n_entries, 1000);
         for i in 0..1000 {
-            assert_eq!(loaded.get(i * 7).as_deref(), Some(&format!("street-{i}")[..]));
+            assert_eq!(loaded.get(i * 7), Some(&format!("street-{i}")[..]));
         }
         assert_eq!(loaded.get(99_999_999), None);
     }

--- a/route/src/formats/zstd_compress.rs
+++ b/route/src/formats/zstd_compress.rs
@@ -156,10 +156,7 @@ mod tests {
         buf.extend_from_slice(&[0u8; 4]); // garbage after magic
         let err = decompress_if_zstd(&buf).expect_err("must reject");
         let msg = format!("{err:#}");
-        assert!(
-            msg.contains("zstd"),
-            "expected zstd error, got: {msg}"
-        );
+        assert!(msg.contains("zstd"), "expected zstd error, got: {msg}");
     }
 
     #[test]

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -507,10 +507,7 @@ fn pick_targets_width_split(slice: &[u32]) -> crate::formats::WeightWidth {
     }
 }
 
-fn encode_targets_to_bytes_split(
-    slice: &[u32],
-    width: crate::formats::WeightWidth,
-) -> Vec<u8> {
+fn encode_targets_to_bytes_split(slice: &[u32], width: crate::formats::WeightWidth) -> Vec<u8> {
     match width {
         crate::formats::WeightWidth::U32 => {
             let mut out = Vec::with_capacity(4 * slice.len());
@@ -543,11 +540,7 @@ fn encode_targets_to_bytes_split(
 /// Serialise the topology half of a (mode × direction) flat. Output is
 /// a complete section body (header + body + footer) ready to be
 /// `append_bytes`'d into a container as `SectionKind::FlatTopo`.
-pub fn encode_flat_topo_bytes(
-    offsets: &[u64],
-    targets: &[u32],
-    topo_edge_idx: &[u32],
-) -> Vec<u8> {
+pub fn encode_flat_topo_bytes(offsets: &[u64], targets: &[u32], topo_edge_idx: &[u32]) -> Vec<u8> {
     let n_nodes = offsets.len().saturating_sub(1);
     let n_edges = targets.len();
     let has_topo_idx = !topo_edge_idx.is_empty();
@@ -654,8 +647,9 @@ fn decode_targets_from_bytes_split(
     width: crate::formats::WeightWidth,
 ) -> Vec<u32> {
     match width {
-        crate::formats::WeightWidth::U32 => bytemuck::cast_slice::<u8, u32>(&bytes[..4 * n_edges])
-            .to_vec(),
+        crate::formats::WeightWidth::U32 => {
+            bytemuck::cast_slice::<u8, u32>(&bytes[..4 * n_edges]).to_vec()
+        }
         crate::formats::WeightWidth::U16 => {
             let s: &[u16] = bytemuck::cast_slice(&bytes[..2 * n_edges]);
             s.iter().map(|&v| v as u32).collect()
@@ -688,7 +682,10 @@ pub fn decode_flat_topo_bytes(bytes: &[u8]) -> anyhow::Result<DecodedFlatTopo> {
         "flat-topo bad magic: 0x{magic:08X}"
     );
     let version = u16::from_le_bytes(bytes[4..6].try_into().unwrap());
-    anyhow::ensure!(version == FLAT_TOPO_VERSION, "flat-topo bad version: {version}");
+    anyhow::ensure!(
+        version == FLAT_TOPO_VERSION,
+        "flat-topo bad version: {version}"
+    );
     let flags = u16::from_le_bytes(bytes[6..8].try_into().unwrap());
     anyhow::ensure!(
         flags & !FLAT_TOPO_FLAGS_KNOWN == 0,
@@ -748,8 +745,11 @@ pub fn decode_flat_topo_bytes(bytes: &[u8]) -> anyhow::Result<DecodedFlatTopo> {
     let mut body_d = crate::formats::crc::Digest::new();
     body_d.update(body_slice);
     let computed_body = body_d.finalize();
-    let stored_body =
-        u64::from_le_bytes(bytes[expected_total - 16..expected_total - 8].try_into().unwrap());
+    let stored_body = u64::from_le_bytes(
+        bytes[expected_total - 16..expected_total - 8]
+            .try_into()
+            .unwrap(),
+    );
     anyhow::ensure!(
         computed_body == stored_body,
         "flat-topo body CRC mismatch: computed {computed_body:#018x}, stored {stored_body:#018x}"
@@ -757,12 +757,12 @@ pub fn decode_flat_topo_bytes(bytes: &[u8]) -> anyhow::Result<DecodedFlatTopo> {
     let mut file_d = crate::formats::crc::Digest::new();
     file_d.update(&bytes[..FLAT_TOPO_HEADER_SIZE + body_size]);
     let computed_file = file_d.finalize();
-    let stored_file =
-        u64::from_le_bytes(bytes[expected_total - 8..expected_total].try_into().unwrap());
-    anyhow::ensure!(
-        computed_file == stored_file,
-        "flat-topo file CRC mismatch"
+    let stored_file = u64::from_le_bytes(
+        bytes[expected_total - 8..expected_total]
+            .try_into()
+            .unwrap(),
     );
+    anyhow::ensure!(computed_file == stored_file, "flat-topo file CRC mismatch");
 
     Ok(DecodedFlatTopo {
         n_nodes,
@@ -785,8 +785,7 @@ pub fn encode_flat_weights_bytes(weights: &crate::formats::WeightArray) -> Vec<u
     let body_pad = pad_to_u64(body_data_bytes);
     let body_size = body_data_bytes + body_pad;
 
-    let mut out =
-        Vec::with_capacity(FLAT_WEIGHTS_HEADER_SIZE + body_size + FLAT_SPLIT_FOOTER_SIZE);
+    let mut out = Vec::with_capacity(FLAT_WEIGHTS_HEADER_SIZE + body_size + FLAT_SPLIT_FOOTER_SIZE);
 
     out.extend_from_slice(&FLAT_WEIGHTS_MAGIC.to_le_bytes());
     out.extend_from_slice(&FLAT_WEIGHTS_VERSION.to_le_bytes());
@@ -853,9 +852,9 @@ pub fn decode_flat_topo_from_mmap(
     byte_offset: usize,
     byte_len: usize,
 ) -> anyhow::Result<(
-    ArcCow<u64>,    // offsets
-    ArcCow<u32>,    // targets
-    ArcCow<u32>,    // topo_edge_idx (empty if not present)
+    ArcCow<u64>, // offsets
+    ArcCow<u32>, // targets
+    ArcCow<u32>, // topo_edge_idx (empty if not present)
 )> {
     anyhow::ensure!(
         byte_offset.saturating_add(byte_len) <= mmap.len(),
@@ -931,9 +930,15 @@ pub fn decode_flat_weights_bytes(bytes: &[u8]) -> anyhow::Result<crate::formats:
     let mut body_d = crate::formats::crc::Digest::new();
     body_d.update(body_slice);
     let computed_body = body_d.finalize();
-    let stored_body =
-        u64::from_le_bytes(bytes[expected_total - 16..expected_total - 8].try_into().unwrap());
-    anyhow::ensure!(computed_body == stored_body, "flat-weights body CRC mismatch");
+    let stored_body = u64::from_le_bytes(
+        bytes[expected_total - 16..expected_total - 8]
+            .try_into()
+            .unwrap(),
+    );
+    anyhow::ensure!(
+        computed_body == stored_body,
+        "flat-weights body CRC mismatch"
+    );
 
     let body_data = &body_slice[..body_data_bytes];
     let weights = match width {
@@ -1130,9 +1135,8 @@ fn parse_adj_flat_header(
     // width code, #351). Bits 5..=7 are reserved and MUST be zero in
     // v4. Anything else means either future-format data we don't
     // understand or corruption — reject up front.
-    const ADJ_FLAT_BYTE7_KNOWN_MASK: u8 = ADJ_FLAT_WIDTH_CODE_MASK
-        | ADJ_FLAT_OFFSETS_U32_BIT
-        | ADJ_FLAT_TARGETS_CODE_MASK;
+    const ADJ_FLAT_BYTE7_KNOWN_MASK: u8 =
+        ADJ_FLAT_WIDTH_CODE_MASK | ADJ_FLAT_OFFSETS_U32_BIT | ADJ_FLAT_TARGETS_CODE_MASK;
     anyhow::ensure!(
         (bytes[7] & !ADJ_FLAT_BYTE7_KNOWN_MASK) == 0,
         "adj-flat header byte 7 has reserved bits set (0x{:02X}); refusing to load",
@@ -1142,23 +1146,34 @@ fn parse_adj_flat_header(
         ADJ_FLAT_WIDTH_CODE_U32 => crate::formats::WeightWidth::U32,
         ADJ_FLAT_WIDTH_CODE_U16 => crate::formats::WeightWidth::U16,
         ADJ_FLAT_WIDTH_CODE_U24 => crate::formats::WeightWidth::U24,
-        v => anyhow::bail!("adj-flat width code {} invalid (byte 7 = 0x{:02X})", v, bytes[7]),
+        v => anyhow::bail!(
+            "adj-flat width code {} invalid (byte 7 = 0x{:02X})",
+            v,
+            bytes[7]
+        ),
     };
     let offsets_u32 = (bytes[7] & ADJ_FLAT_OFFSETS_U32_BIT) != 0;
-    let targets_width =
-        match (bytes[7] & ADJ_FLAT_TARGETS_CODE_MASK) >> ADJ_FLAT_TARGETS_CODE_SHIFT {
-            ADJ_FLAT_WIDTH_CODE_U32 => crate::formats::WeightWidth::U32,
-            ADJ_FLAT_WIDTH_CODE_U16 => crate::formats::WeightWidth::U16,
-            ADJ_FLAT_WIDTH_CODE_U24 => crate::formats::WeightWidth::U24,
-            v => anyhow::bail!(
-                "adj-flat targets width code {} invalid (byte 7 = 0x{:02X})",
-                v,
-                bytes[7]
-            ),
-        };
+    let targets_width = match (bytes[7] & ADJ_FLAT_TARGETS_CODE_MASK) >> ADJ_FLAT_TARGETS_CODE_SHIFT
+    {
+        ADJ_FLAT_WIDTH_CODE_U32 => crate::formats::WeightWidth::U32,
+        ADJ_FLAT_WIDTH_CODE_U16 => crate::formats::WeightWidth::U16,
+        ADJ_FLAT_WIDTH_CODE_U24 => crate::formats::WeightWidth::U24,
+        v => anyhow::bail!(
+            "adj-flat targets width code {} invalid (byte 7 = 0x{:02X})",
+            v,
+            bytes[7]
+        ),
+    };
     let n_nodes = u64::from_le_bytes(bytes[8..16].try_into().unwrap()) as usize;
     let n_edges = u64::from_le_bytes(bytes[16..24].try_into().unwrap()) as usize;
-    Ok((has_topo_idx, width, offsets_u32, targets_width, n_nodes, n_edges))
+    Ok((
+        has_topo_idx,
+        width,
+        offsets_u32,
+        targets_width,
+        n_nodes,
+        n_edges,
+    ))
 }
 
 fn body_layout(
@@ -1205,7 +1220,10 @@ fn body_layout(
 /// regions have ~76 M edges max per mode → easily fits u32 (4 G).
 #[inline]
 fn pick_offsets_u32(offsets: &[u64]) -> bool {
-    offsets.last().map(|&v| v <= u32::MAX as u64).unwrap_or(true)
+    offsets
+        .last()
+        .map(|&v| v <= u32::MAX as u64)
+        .unwrap_or(true)
 }
 
 /// #351: pick the narrowest width that losslessly stores every target.
@@ -1385,8 +1403,8 @@ fn write_adj_flat_body_and_footer(
         }
     }
     // Trailing pad for u16/u24 so the next array starts 4-B aligned.
-    let pad_bytes = targets_width.padded_body_bytes(n_edges)
-        - targets_width.bytes_per_entry() * n_edges;
+    let pad_bytes =
+        targets_width.padded_body_bytes(n_edges) - targets_width.bytes_per_entry() * n_edges;
     for _ in 0..pad_bytes {
         out.push(0);
     }
@@ -1491,7 +1509,12 @@ impl UpAdjFlatFile {
         let offsets_u32 = pick_offsets_u32(&flat.offsets);
         let targets_width = pick_targets_width(&flat.targets);
         let (_, _, _, _, body_end) = body_layout(
-            n_nodes, n_edges, has_topo_idx, width, offsets_u32, targets_width,
+            n_nodes,
+            n_edges,
+            has_topo_idx,
+            width,
+            offsets_u32,
+            targets_width,
         );
         let mut out = Vec::with_capacity(body_end + ADJ_FLAT_FOOTER_SIZE);
         write_adj_flat_header(
@@ -1548,7 +1571,12 @@ impl UpAdjFlatFile {
         let (has_topo_idx, width, offsets_u32, targets_width, n_nodes, n_edges) =
             parse_adj_flat_header(bytes, UP_ADJ_FLAT_MAGIC)?;
         let (offsets_off, targets_off, weights_off, topo_off, body_end) = body_layout(
-            n_nodes, n_edges, has_topo_idx, width, offsets_u32, targets_width,
+            n_nodes,
+            n_edges,
+            has_topo_idx,
+            width,
+            offsets_u32,
+            targets_width,
         );
         anyhow::ensure!(
             bytes.len() == body_end + ADJ_FLAT_FOOTER_SIZE,
@@ -1567,8 +1595,7 @@ impl UpAdjFlatFile {
         }
 
         let offsets_vec: Vec<u64> = read_offsets_vec(bytes, offsets_off, n_nodes, offsets_u32);
-        let targets_vec: Vec<u32> =
-            read_targets_vec(bytes, targets_off, n_edges, targets_width);
+        let targets_vec: Vec<u32> = read_targets_vec(bytes, targets_off, n_edges, targets_width);
         // v2 (#349): decode the weights body from its native width into
         // a Vec<u32> so the legacy byte-slice path returns the same
         // public shape it always did. Compact widths shrink the
@@ -1627,7 +1654,12 @@ impl UpAdjFlatFile {
         let (has_topo_idx, width, offsets_u32, targets_width, n_nodes, n_edges) =
             parse_adj_flat_header(bytes, UP_ADJ_FLAT_MAGIC)?;
         let (offsets_off, targets_off, weights_off, topo_off, body_end) = body_layout(
-            n_nodes, n_edges, has_topo_idx, width, offsets_u32, targets_width,
+            n_nodes,
+            n_edges,
+            has_topo_idx,
+            width,
+            offsets_u32,
+            targets_width,
         );
         anyhow::ensure!(
             byte_len == body_end + ADJ_FLAT_FOOTER_SIZE,
@@ -1674,9 +1706,8 @@ impl DownAdjFlatFile {
         let offsets_u32 = pick_offsets_u32(&flat.offsets);
         let targets_width = pick_targets_width(&flat.targets);
         // DownAdjFlat never carries topo_edge_idx.
-        let (_, _, _, _, body_end) = body_layout(
-            n_nodes, n_edges, false, width, offsets_u32, targets_width,
-        );
+        let (_, _, _, _, body_end) =
+            body_layout(n_nodes, n_edges, false, width, offsets_u32, targets_width);
         let mut out = Vec::with_capacity(body_end + ADJ_FLAT_FOOTER_SIZE);
         write_adj_flat_header(
             &mut out,
@@ -1719,9 +1750,8 @@ impl DownAdjFlatFile {
             !has_topo_idx,
             "DownAdjFlat must not carry topo_edge_idx (has_topo_idx=1)"
         );
-        let (offsets_off, targets_off, weights_off, _, body_end) = body_layout(
-            n_nodes, n_edges, false, width, offsets_u32, targets_width,
-        );
+        let (offsets_off, targets_off, weights_off, _, body_end) =
+            body_layout(n_nodes, n_edges, false, width, offsets_u32, targets_width);
         anyhow::ensure!(
             bytes.len() == body_end + ADJ_FLAT_FOOTER_SIZE,
             "adj-flat size mismatch"
@@ -1734,8 +1764,7 @@ impl DownAdjFlatFile {
             verify_adj_flat_crcs(bytes, body_end)?;
         }
         let offsets_vec: Vec<u64> = read_offsets_vec(bytes, offsets_off, n_nodes, offsets_u32);
-        let targets_vec: Vec<u32> =
-            read_targets_vec(bytes, targets_off, n_edges, targets_width);
+        let targets_vec: Vec<u32> = read_targets_vec(bytes, targets_off, n_edges, targets_width);
         let weights_bytes = &bytes[weights_off..weights_off + width.bytes_per_entry() * n_edges];
         let weights_vec: Vec<u32> = match width {
             crate::formats::WeightWidth::U32 => {
@@ -1776,9 +1805,8 @@ impl DownAdjFlatFile {
             !has_topo_idx,
             "DownAdjFlat must not carry topo_edge_idx (has_topo_idx=1)"
         );
-        let (offsets_off, targets_off, weights_off, _, body_end) = body_layout(
-            n_nodes, n_edges, false, width, offsets_u32, targets_width,
-        );
+        let (offsets_off, targets_off, weights_off, _, body_end) =
+            body_layout(n_nodes, n_edges, false, width, offsets_u32, targets_width);
         anyhow::ensure!(
             byte_len == body_end + ADJ_FLAT_FOOTER_SIZE,
             "down_adj_flat size mismatch: got {}, expected {}",
@@ -1819,7 +1847,12 @@ impl DownReverseAdjFlatFile {
         let offsets_u32 = pick_offsets_u32(&flat.offsets);
         let targets_width = pick_targets_width(&flat.sources);
         let (_, _, _, _, body_end) = body_layout(
-            n_nodes, n_edges, has_topo_idx, width, offsets_u32, targets_width,
+            n_nodes,
+            n_edges,
+            has_topo_idx,
+            width,
+            offsets_u32,
+            targets_width,
         );
         let mut out = Vec::with_capacity(body_end + ADJ_FLAT_FOOTER_SIZE);
         write_adj_flat_header(
@@ -1868,7 +1901,12 @@ impl DownReverseAdjFlatFile {
         let (has_topo_idx, width, offsets_u32, targets_width, n_nodes, n_edges) =
             parse_adj_flat_header(bytes, DOWN_REV_ADJ_FLAT_MAGIC)?;
         let (offsets_off, sources_off, weights_off, topo_off, body_end) = body_layout(
-            n_nodes, n_edges, has_topo_idx, width, offsets_u32, targets_width,
+            n_nodes,
+            n_edges,
+            has_topo_idx,
+            width,
+            offsets_u32,
+            targets_width,
         );
         anyhow::ensure!(
             bytes.len() == body_end + ADJ_FLAT_FOOTER_SIZE,
@@ -1882,8 +1920,7 @@ impl DownReverseAdjFlatFile {
             verify_adj_flat_crcs(bytes, body_end)?;
         }
         let offsets_vec: Vec<u64> = read_offsets_vec(bytes, offsets_off, n_nodes, offsets_u32);
-        let sources_vec: Vec<u32> =
-            read_targets_vec(bytes, sources_off, n_edges, targets_width);
+        let sources_vec: Vec<u32> = read_targets_vec(bytes, sources_off, n_edges, targets_width);
         let weights_bytes = &bytes[weights_off..weights_off + width.bytes_per_entry() * n_edges];
         let weights_vec: Vec<u32> = match width {
             crate::formats::WeightWidth::U32 => {
@@ -1927,7 +1964,12 @@ impl DownReverseAdjFlatFile {
         let (has_topo_idx, width, offsets_u32, targets_width, n_nodes, n_edges) =
             parse_adj_flat_header(bytes, DOWN_REV_ADJ_FLAT_MAGIC)?;
         let (offsets_off, sources_off, weights_off, topo_off, body_end) = body_layout(
-            n_nodes, n_edges, has_topo_idx, width, offsets_u32, targets_width,
+            n_nodes,
+            n_edges,
+            has_topo_idx,
+            width,
+            offsets_u32,
+            targets_width,
         );
         anyhow::ensure!(
             byte_len == body_end + ADJ_FLAT_FOOTER_SIZE,
@@ -3900,7 +3942,10 @@ mod step_a_tests {
         let decoded = UpAdjFlatFile::read_from_bytes(leaked).expect("decode round-trip");
         assert_eq!(&*decoded.offsets, &*flat.offsets);
         assert_eq!(&*decoded.targets, &*flat.targets);
-        assert_eq!(decoded.weights.iter().collect::<Vec<u32>>(), flat.weights.iter().collect::<Vec<u32>>());
+        assert_eq!(
+            decoded.weights.iter().collect::<Vec<u32>>(),
+            flat.weights.iter().collect::<Vec<u32>>()
+        );
         assert_eq!(&*decoded.topo_edge_idx, &*flat.topo_edge_idx);
     }
 
@@ -3913,7 +3958,10 @@ mod step_a_tests {
         let decoded = UpAdjFlatFile::read_from_bytes(leaked).expect("decode");
         assert_eq!(&*decoded.offsets, &*flat.offsets);
         assert_eq!(&*decoded.targets, &*flat.targets);
-        assert_eq!(decoded.weights.iter().collect::<Vec<u32>>(), flat.weights.iter().collect::<Vec<u32>>());
+        assert_eq!(
+            decoded.weights.iter().collect::<Vec<u32>>(),
+            flat.weights.iter().collect::<Vec<u32>>()
+        );
         assert!(decoded.topo_edge_idx.is_empty());
     }
 
@@ -3926,7 +3974,10 @@ mod step_a_tests {
         let decoded = DownAdjFlatFile::read_from_bytes(leaked).expect("decode");
         assert_eq!(&*decoded.offsets, &*flat.offsets);
         assert_eq!(&*decoded.targets, &*flat.targets);
-        assert_eq!(decoded.weights.iter().collect::<Vec<u32>>(), flat.weights.iter().collect::<Vec<u32>>());
+        assert_eq!(
+            decoded.weights.iter().collect::<Vec<u32>>(),
+            flat.weights.iter().collect::<Vec<u32>>()
+        );
     }
 
     #[test]
@@ -3938,7 +3989,10 @@ mod step_a_tests {
         let decoded = DownReverseAdjFlatFile::read_from_bytes(leaked).expect("decode");
         assert_eq!(&*decoded.offsets, &*flat.offsets);
         assert_eq!(&*decoded.sources, &*flat.sources);
-        assert_eq!(decoded.weights.iter().collect::<Vec<u32>>(), flat.weights.iter().collect::<Vec<u32>>());
+        assert_eq!(
+            decoded.weights.iter().collect::<Vec<u32>>(),
+            flat.weights.iter().collect::<Vec<u32>>()
+        );
         assert_eq!(&*decoded.topo_edge_idx, &*flat.topo_edge_idx);
     }
 
@@ -4174,7 +4228,11 @@ mod step_a_tests {
         let back = UpAdjFlatFile::read_from_bytes(static_bytes).unwrap();
         assert_eq!(back.weights.len(), 3);
         assert_eq!(back.weights.get(0), 10);
-        assert_eq!(back.weights.get(1), u32::MAX, "u16::MAX must widen back to u32::MAX");
+        assert_eq!(
+            back.weights.get(1),
+            u32::MAX,
+            "u16::MAX must widen back to u32::MAX"
+        );
         assert_eq!(back.weights.get(2), 65_000);
     }
 
@@ -4270,8 +4328,7 @@ mod step_a_tests {
     }
 
     fn assert_targets_width_code(bytes: &[u8], expected: u8) {
-        let code =
-            (bytes[7] & ADJ_FLAT_TARGETS_CODE_MASK) >> ADJ_FLAT_TARGETS_CODE_SHIFT;
+        let code = (bytes[7] & ADJ_FLAT_TARGETS_CODE_MASK) >> ADJ_FLAT_TARGETS_CODE_SHIFT;
         assert_eq!(code, expected, "header byte 7 targets width code mismatch");
     }
 

--- a/route/src/pack.rs
+++ b/route/src/pack.rs
@@ -1243,9 +1243,7 @@ fn pack_way_names_idx(w: &mut ContainerWriter, step1: &Path) -> Result<()> {
     // post-dedup set.
     let resolved: Vec<(i64, String)> = pairs
         .into_iter()
-        .filter_map(|(way_id, val_id)| {
-            val_dict.get(&val_id).map(|n| (way_id, n.clone()))
-        })
+        .filter_map(|(way_id, val_id)| val_dict.get(&val_id).map(|n| (way_id, n.clone())))
         .collect();
     let idx = way_names_idx::build_from_pairs(resolved)
         .with_context(|| "building way_names_idx".to_string())?;
@@ -2108,8 +2106,7 @@ pub fn topology_diff(path: &Path, modes_arg: Option<&str>) -> Result<()> {
 /// symlinked transit dir or moved step output via symlink. The same
 /// guard applies to descendants.
 fn dir_size_bytes(p: &Path) -> Result<u64> {
-    let meta = std::fs::symlink_metadata(p)
-        .with_context(|| format!("stat {}", p.display()))?;
+    let meta = std::fs::symlink_metadata(p).with_context(|| format!("stat {}", p.display()))?;
     if !meta.is_dir() {
         return Ok(meta.len());
     }
@@ -2117,8 +2114,8 @@ fn dir_size_bytes(p: &Path) -> Result<u64> {
     for entry in std::fs::read_dir(p).with_context(|| format!("reading {}", p.display()))? {
         let entry = entry?;
         let path = entry.path();
-        let m = std::fs::symlink_metadata(&path)
-            .with_context(|| format!("stat {}", path.display()))?;
+        let m =
+            std::fs::symlink_metadata(&path).with_context(|| format!("stat {}", path.display()))?;
         if m.is_dir() {
             // Real directory — recurse. (Symlinks fall through to the
             // else branch because `symlink_metadata` reports the link
@@ -2237,7 +2234,11 @@ pub fn prune(container: &Path, data_dir: &Path, dry_run: bool) -> Result<()> {
                 sizes.push((p.clone(), Some(sz)));
             }
             Err(e) => {
-                eprintln!("warn: cannot size {} — {} (still proceeding)", p.display(), e);
+                eprintln!(
+                    "warn: cannot size {} — {} (still proceeding)",
+                    p.display(),
+                    e
+                );
                 any_unknown = true;
                 sizes.push((p.clone(), None));
             }
@@ -2256,7 +2257,10 @@ pub fn prune(container: &Path, data_dir: &Path, dry_run: bool) -> Result<()> {
         }
     }
     if any_unknown {
-        println!("Total: {} (partial — some sizes failed)", humanize_bytes(total_known));
+        println!(
+            "Total: {} (partial — some sizes failed)",
+            humanize_bytes(total_known)
+        );
     } else {
         println!("Total: {}", humanize_bytes(total_known));
     }
@@ -2268,8 +2272,7 @@ pub fn prune(container: &Path, data_dir: &Path, dry_run: bool) -> Result<()> {
 
     // ---- 5. Delete the step dirs ---------------------------------
     for (p, _) in &sizes {
-        std::fs::remove_dir_all(p)
-            .with_context(|| format!("removing {}", p.display()))?;
+        std::fs::remove_dir_all(p).with_context(|| format!("removing {}", p.display()))?;
     }
     println!("\nDone — reclaimed {}", humanize_bytes(total_known));
     Ok(())
@@ -2725,8 +2728,16 @@ mod tests {
         // Small payload — exercises the streaming CRC verify path with
         // multiple chunks if needed by Copilot's review math (the
         // implementation handles tiny inputs fine).
-        w.append_bytes(SectionKind::Unknown, "test/payload", b"prune-test-payload-bytes")?;
-        w.append_bytes(SectionKind::Unknown, "test/manifest", b"{\"region_id\":\"TEST\"}")?;
+        w.append_bytes(
+            SectionKind::Unknown,
+            "test/payload",
+            b"prune-test-payload-bytes",
+        )?;
+        w.append_bytes(
+            SectionKind::Unknown,
+            "test/manifest",
+            b"{\"region_id\":\"TEST\"}",
+        )?;
         w.finalize()?;
         // Smoke: container opens
         let _c = Container::open(&container_path)?;

--- a/route/src/range/batched_isochrone.rs
+++ b/route/src/range/batched_isochrone.rs
@@ -118,11 +118,7 @@ impl BatchedIsochroneEngine {
     ///
     /// # Returns
     /// BatchedIsochroneResult with K contour polygons
-    pub fn query_batch(
-        &self,
-        origins: &[u32],
-        threshold_s: u32,
-    ) -> Result<BatchedIsochroneResult> {
+    pub fn query_batch(&self, origins: &[u32], threshold_s: u32) -> Result<BatchedIsochroneResult> {
         let start = std::time::Instant::now();
         let k = origins.len();
 

--- a/route/src/range/wkb_stream.rs
+++ b/route/src/range/wkb_stream.rs
@@ -146,11 +146,7 @@ pub struct IsochroneRecord {
 
 impl IsochroneRecord {
     /// Create from a ContourResult
-    pub fn from_contour(
-        origin_id: u32,
-        threshold_s: u32,
-        contour: &ContourResult,
-    ) -> Option<Self> {
+    pub fn from_contour(origin_id: u32, threshold_s: u32, contour: &ContourResult) -> Option<Self> {
         let wkb = encode_polygon_wkb(contour)?;
         Some(Self {
             origin_id,

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -891,7 +891,9 @@ fn build_route_output(
     scratch.ebg_path.reserve(scratch.rank_path.len());
     for &rank in &scratch.rank_path {
         let filt_id = mode_data.cch_topo.rank_to_filtered[rank as usize];
-        scratch.ebg_path.push(mode_data.filtered_to_original[filt_id as usize]);
+        scratch
+            .ebg_path
+            .push(mode_data.filtered_to_original[filt_id as usize]);
     }
 
     let distance_m = super::geometry::build_raw_points_into(
@@ -1287,12 +1289,9 @@ fn do_route_batch_blocking(
             if first_panic_msg.is_some() {
                 break 'chunks;
             }
-            let results: Vec<RoutePairRow> = slots
-                .into_iter()
-                .map(|s| s.expect("slot filled"))
-                .collect();
-            let fb_chunk =
-                fallback_count.load(std::sync::atomic::Ordering::Relaxed) - fb_before;
+            let results: Vec<RoutePairRow> =
+                slots.into_iter().map(|s| s.expect("slot filled")).collect();
+            let fb_chunk = fallback_count.load(std::sync::atomic::Ordering::Relaxed) - fb_before;
             // #315 Copilot review: drop to DEBUG so production logs
             // aren't spammed by bench instrumentation.
             tracing::debug!(
@@ -2319,13 +2318,8 @@ impl FlightService for ButterflyFlight {
                 // the dispatcher returns CrossRegion → 9 (FAILED_PRECONDITION).
                 let [s_lon, s_lat] = params.sources[0];
                 let [d_lon, d_lat] = params.destinations[0];
-                let (state, _region) = self.dispatch_for_pair(
-                    s_lon,
-                    s_lat,
-                    d_lon,
-                    d_lat,
-                    &parsed.profile,
-                )?;
+                let (state, _region) =
+                    self.dispatch_for_pair(s_lon, s_lat, d_lon, d_lat, &parsed.profile)?;
                 let mode = resolve_mode(&parsed.profile, &state)?;
 
                 let batch_stream = do_matrix(&state, mode, params)?;
@@ -2615,12 +2609,11 @@ impl FlightService for ButterflyFlight {
         // Catchment input schema: (store_id, store_lon, store_lat,
         // client_lon, client_lat). Mixed-region inputs in a single
         // batch are a follow-up — for now the first row picks.
-        let (store_lon, store_lat) =
-            first_store_lonlat(&batches).ok_or_else(|| {
-                Status::invalid_argument(
-                    "no rows in input batches — need at least one (store_lon, store_lat)",
-                )
-            })?;
+        let (store_lon, store_lat) = first_store_lonlat(&batches).ok_or_else(|| {
+            Status::invalid_argument(
+                "no rows in input batches — need at least one (store_lon, store_lat)",
+            )
+        })?;
         let (state, _region) = self.dispatch_for_point(store_lon, store_lat, profile)?;
         let mode = resolve_mode(profile, &state)?;
 

--- a/route/src/server/geometry.rs
+++ b/route/src/server/geometry.rs
@@ -135,8 +135,7 @@ pub fn build_raw_points(
     edge_geom: &EdgeGeometry,
 ) -> (Vec<Point>, f64) {
     let mut coordinates = Vec::new();
-    let total_distance_m =
-        build_raw_points_into(ebg_path, ebg_nodes, edge_geom, &mut coordinates);
+    let total_distance_m = build_raw_points_into(ebg_path, ebg_nodes, edge_geom, &mut coordinates);
     (coordinates, total_distance_m)
 }
 

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -2082,12 +2082,11 @@ fn try_load_flat_split_down_rev(
     };
     lazy.verify_now(&topo_name)?;
     lazy.verify_now(&weights_name)?;
-    let (offsets, sources, topo_edge_idx) =
-        crate::matrix::bucket_ch::decode_flat_topo_from_mmap(
-            std::sync::Arc::clone(mmap),
-            topo_entry.offset as usize,
-            topo_entry.len as usize,
-        )?;
+    let (offsets, sources, topo_edge_idx) = crate::matrix::bucket_ch::decode_flat_topo_from_mmap(
+        std::sync::Arc::clone(mmap),
+        topo_entry.offset as usize,
+        topo_entry.len as usize,
+    )?;
     let weights = crate::matrix::bucket_ch::decode_flat_weights_from_mmap(
         std::sync::Arc::clone(mmap),
         weights_entry.offset as usize,
@@ -2555,98 +2554,92 @@ fn load_mode_data_from_bundle(
     // #345: prefer the split FlatTopo + FlatWeights sections; fall
     // back to the legacy v4 monolithic flat; fall back to building
     // from cch_topo + cch_weights on the heap if neither is present.
-    let up_adj_flat = if let Some(f) =
-        try_load_flat_split_up(container, mmap, lazy, mode_name, "time")?
-    {
-        f
-    } else {
-        load_flat_section(
-            container,
-            mmap,
-            &format!("mode/{}/up_adj_flat.time", mode_name),
-            lazy,
-            |m, off, len| UpAdjFlatFile::read_from_mmap_unverified(m, off, len),
-            || UpAdjFlat::build_with(&cch_topo, &cch_weights, true),
-        )?
-    };
-    let down_rev_flat = if let Some(f) =
-        try_load_flat_split_down_rev(container, mmap, lazy, mode_name, "time")?
-    {
-        f
-    } else {
-        load_flat_section(
-            container,
-            mmap,
-            &format!("mode/{}/down_reverse_adj_flat.time", mode_name),
-            lazy,
-            |m, off, len| DownReverseAdjFlatFile::read_from_mmap_unverified(m, off, len),
-            || DownReverseAdjFlat::build_with(&cch_topo, &cch_weights, true),
-        )?
-    };
-    let down_adj_flat = if let Some(f) =
-        try_load_flat_split_down(container, mmap, lazy, mode_name, "time")?
-    {
-        f
-    } else {
-        load_flat_section(
-            container,
-            mmap,
-            &format!("mode/{}/down_adj_flat.time", mode_name),
-            lazy,
-            |m, off, len| DownAdjFlatFile::read_from_mmap_unverified(m, off, len),
-            || DownAdjFlat::build(&cch_topo, &cch_weights),
-        )?
-    };
+    let up_adj_flat =
+        if let Some(f) = try_load_flat_split_up(container, mmap, lazy, mode_name, "time")? {
+            f
+        } else {
+            load_flat_section(
+                container,
+                mmap,
+                &format!("mode/{}/up_adj_flat.time", mode_name),
+                lazy,
+                |m, off, len| UpAdjFlatFile::read_from_mmap_unverified(m, off, len),
+                || UpAdjFlat::build_with(&cch_topo, &cch_weights, true),
+            )?
+        };
+    let down_rev_flat =
+        if let Some(f) = try_load_flat_split_down_rev(container, mmap, lazy, mode_name, "time")? {
+            f
+        } else {
+            load_flat_section(
+                container,
+                mmap,
+                &format!("mode/{}/down_reverse_adj_flat.time", mode_name),
+                lazy,
+                |m, off, len| DownReverseAdjFlatFile::read_from_mmap_unverified(m, off, len),
+                || DownReverseAdjFlat::build_with(&cch_topo, &cch_weights, true),
+            )?
+        };
+    let down_adj_flat =
+        if let Some(f) = try_load_flat_split_down(container, mmap, lazy, mode_name, "time")? {
+            f
+        } else {
+            load_flat_section(
+                container,
+                mmap,
+                &format!("mode/{}/down_adj_flat.time", mode_name),
+                lazy,
+                |m, off, len| DownAdjFlatFile::read_from_mmap_unverified(m, off, len),
+                || DownAdjFlat::build(&cch_topo, &cch_weights),
+            )?
+        };
 
     let (wd_mmap, wd_off, wd_len) = fetch_arc("weights.dist")?;
     let cch_weights_dist = CchWeightsFile::read_from_mmap_unverified(wd_mmap, wd_off, wd_len)?;
     let up_adj_flat_dist_section = format!("mode/{}/up_adj_flat.dist", mode_name);
-    let up_adj_flat_dist = if let Some(f) =
-        try_load_flat_split_up(container, mmap, lazy, mode_name, "dist")?
-    {
-        f
-    } else {
-        load_flat_section(
-            container,
-            mmap,
-            &up_adj_flat_dist_section,
-            lazy,
-            |m, off, len| UpAdjFlatFile::read_from_mmap_unverified(m, off, len),
-            || UpAdjFlat::build(&cch_topo, &cch_weights_dist),
-        )?
-    };
+    let up_adj_flat_dist =
+        if let Some(f) = try_load_flat_split_up(container, mmap, lazy, mode_name, "dist")? {
+            f
+        } else {
+            load_flat_section(
+                container,
+                mmap,
+                &up_adj_flat_dist_section,
+                lazy,
+                |m, off, len| UpAdjFlatFile::read_from_mmap_unverified(m, off, len),
+                || UpAdjFlat::build(&cch_topo, &cch_weights_dist),
+            )?
+        };
     madvise_section_in_container(container, mmap, &up_adj_flat_dist_section);
     let down_rev_flat_dist_section = format!("mode/{}/down_reverse_adj_flat.dist", mode_name);
-    let down_rev_flat_dist = if let Some(f) =
-        try_load_flat_split_down_rev(container, mmap, lazy, mode_name, "dist")?
-    {
-        f
-    } else {
-        load_flat_section(
-            container,
-            mmap,
-            &down_rev_flat_dist_section,
-            lazy,
-            |m, off, len| DownReverseAdjFlatFile::read_from_mmap_unverified(m, off, len),
-            || DownReverseAdjFlat::build(&cch_topo, &cch_weights_dist),
-        )?
-    };
+    let down_rev_flat_dist =
+        if let Some(f) = try_load_flat_split_down_rev(container, mmap, lazy, mode_name, "dist")? {
+            f
+        } else {
+            load_flat_section(
+                container,
+                mmap,
+                &down_rev_flat_dist_section,
+                lazy,
+                |m, off, len| DownReverseAdjFlatFile::read_from_mmap_unverified(m, off, len),
+                || DownReverseAdjFlat::build(&cch_topo, &cch_weights_dist),
+            )?
+        };
     madvise_section_in_container(container, mmap, &down_rev_flat_dist_section);
     let down_adj_flat_dist_section = format!("mode/{}/down_adj_flat.dist", mode_name);
-    let down_adj_flat_dist = if let Some(f) =
-        try_load_flat_split_down(container, mmap, lazy, mode_name, "dist")?
-    {
-        f
-    } else {
-        load_flat_section(
-            container,
-            mmap,
-            &down_adj_flat_dist_section,
-            lazy,
-            |m, off, len| DownAdjFlatFile::read_from_mmap_unverified(m, off, len),
-            || DownAdjFlat::build(&cch_topo, &cch_weights_dist),
-        )?
-    };
+    let down_adj_flat_dist =
+        if let Some(f) = try_load_flat_split_down(container, mmap, lazy, mode_name, "dist")? {
+            f
+        } else {
+            load_flat_section(
+                container,
+                mmap,
+                &down_adj_flat_dist_section,
+                lazy,
+                |m, off, len| DownAdjFlatFile::read_from_mmap_unverified(m, off, len),
+                || DownAdjFlat::build(&cch_topo, &cch_weights_dist),
+            )?
+        };
     madvise_section_in_container(container, mmap, &down_adj_flat_dist_section);
 
     Ok(ModeData {

--- a/route/src/validate/weights.rs
+++ b/route/src/validate/weights.rs
@@ -225,18 +225,15 @@ fn verify_lock_b_math(
         let length_m = ebg_node.length_m;
         let base_speed_mmps = way_attr.output.base_speed_mmps;
 
-        let travel_time_s = crate::weights::round_half_even_div(
-            length_m as u64 * 1000,
-            base_speed_mmps as u64,
-        ) as u32;
+        let travel_time_s =
+            crate::weights::round_half_even_div(length_m as u64 * 1000, base_speed_mmps as u64)
+                as u32;
         let per_km_extra_s = crate::weights::round_half_even_div(
             length_m as u64 * way_attr.output.per_km_penalty_ds as u64,
             10_000,
         ) as u32;
-        let const_penalty_s = crate::weights::round_half_even_div(
-            way_attr.output.const_penalty_ds as u64,
-            10,
-        ) as u32;
+        let const_penalty_s =
+            crate::weights::round_half_even_div(way_attr.output.const_penalty_ds as u64, 10) as u32;
         let expected_weight = travel_time_s
             .saturating_add(per_km_extra_s)
             .saturating_add(const_penalty_s)

--- a/route/src/weights.rs
+++ b/route/src/weights.rs
@@ -77,7 +77,10 @@ mod round_tests {
         // n is also > u64::MAX/2, so 2·n overflows: this is the path
         // we want to exercise.
         let n = d - 1;
-        assert!(n > u64::MAX / 2, "test setup: remainder must overflow on *2");
+        assert!(
+            n > u64::MAX / 2,
+            "test setup: remainder must overflow on *2"
+        );
         assert_eq!(round_half_even_div(n, d), 1);
 
         // Same denominator, but n just under d/2 → round down to 0.
@@ -381,7 +384,8 @@ fn generate_mode_data(
         ) as u32;
 
         // const_penalty_ds on disk is also deciseconds — convert to seconds.
-        let const_penalty_s = round_half_even_div(way_attr.output.const_penalty_ds as u64, 10) as u32;
+        let const_penalty_s =
+            round_half_even_div(way_attr.output.const_penalty_ds as u64, 10) as u32;
 
         // Total weight = travel_time + per_km_extra + const_penalty (saturating)
         let weight_s = travel_time_s


### PR DESCRIPTION
## Summary

- Fix 4 `needless_option_as_deref` clippy errors in `way_names_idx.rs` test code (`WayNamesIdx::get` already returns `Option<&str>`, so `.as_deref()` is a no-op).
- Apply `cargo fmt --all` to clear fmt drift across 21 files (1 in `dl/`, 20 in `route/`) under the edition-2024 rustfmt rules.

Pure cleanup — no logical changes.

## Verification

- `cargo clippy --workspace --all-targets --all-features` → 0 errors
- `cargo fmt --all --check` → clean
- `cargo test --workspace --release --lib` → **600 passed, 0 failed**

## Test plan

- [x] Workspace clippy clean
- [x] Workspace fmt clean
- [x] All 600 lib tests pass
- [x] Release build clean