### PR TITLE
perf(flight,catchment): lazy K=64 snap escalation — Flight matrix/route_batch/edges_batch/catchment + REST /catchment

### DIFF
--- a/route/src/server/catchment.rs
+++ b/route/src/server/catchment.rs
@@ -806,11 +806,12 @@ pub async fn catchment_handler(
 
     // For each store: compute 1-to-N matrix via Bucket M2M, then catchment.
     // K-best snap + per-cell P2P fallback rescues INF cells the same
-    // way /table POST does — see snap_kbest.rs.
+    // way /table POST does — see snap_kbest.rs. Lazy version (#368
+    // pattern): K=1 primary upfront, K=64 only when an INF cell needs
+    // it.
     const SNAP_K: usize = 64;
     for store_input in &req.stores {
-        // K-best snap store as source.
-        let store_snap = super::snap_kbest::snap_k_pair_role(
+        let store_rank = match super::snap_kbest::snap_primary_role(
             &state,
             mode_data,
             mode,
@@ -818,10 +819,8 @@ pub async fn catchment_handler(
             store_input.lat,
             super::types::SnapRole::Src,
             None,
-            SNAP_K,
-        );
-        let store_rank = match store_snap.primary_rank() {
-            Some(r) => r,
+        ) {
+            Some((_, r)) => r,
             None => continue, // Skip unsnappable stores
         };
         let _ = (store_role, client_role); // legacy bindings no longer used
@@ -841,11 +840,9 @@ pub async fn catchment_handler(
         };
         let effective_radius_m: Option<f64> = effective_radius_km.map(|km| km * 1000.0);
 
-        // Snap all clients (K-best). When a radius is active, clients farther
-        // than `effective_radius_m` from the store are dropped BEFORE the
-        // M2M call so the routing layer does proportionally less work.
-        let mut client_snaps: Vec<super::snap_kbest::KBestSnap> =
-            Vec::with_capacity(req.clients.len());
+        // Snap all clients K=1 upfront (cheap). The K=64 escalation
+        // happens lazily inside the INF-cell fallback below — same
+        // lazy pattern as #370 /table and #374 /trip.
         let mut client_ranks: Vec<u32> = Vec::with_capacity(req.clients.len());
         let mut client_valid: Vec<usize> = Vec::with_capacity(req.clients.len());
         for (ci, c) in req.clients.iter().enumerate() {
@@ -855,7 +852,7 @@ pub async fn catchment_handler(
                     continue;
                 }
             }
-            let snap = super::snap_kbest::snap_k_pair_role(
+            if let Some((_, rank)) = super::snap_kbest::snap_primary_role(
                 &state,
                 mode_data,
                 mode,
@@ -863,12 +860,9 @@ pub async fn catchment_handler(
                 c.lat,
                 super::types::SnapRole::Dst,
                 None,
-                SNAP_K,
-            );
-            if let Some(r) = snap.primary_rank() {
-                client_ranks.push(r);
+            ) {
+                client_ranks.push(rank);
                 client_valid.push(ci);
-                client_snaps.push(snap);
             }
         }
 
@@ -888,23 +882,55 @@ pub async fn catchment_handler(
             targets,
         );
 
-        // Per-cell K-best fallback for INF cells.
+        // Per-cell K-best fallback for INF cells. K=64 escalation runs
+        // only for client indices whose 1-to-N cell came back u32::MAX
+        // — typically zero of them on a healthy graph.
         if matrix.contains(&u32::MAX) {
             use rayon::prelude::*;
             let query = super::query::CchQuery::new(&state, mode);
-            let patches: Vec<(usize, u32)> = (0..client_valid.len())
+            // Lazily snap K=64 for the source store and just the
+            // failing clients.
+            let store_kbest = super::snap_kbest::snap_k_pair_role(
+                &state,
+                mode_data,
+                mode,
+                store_input.lon,
+                store_input.lat,
+                super::types::SnapRole::Src,
+                None,
+                SNAP_K,
+            );
+            let failing: Vec<usize> = (0..client_valid.len())
                 .filter(|&ti| matrix[ti] == u32::MAX)
-                .collect::<Vec<_>>()
+                .collect();
+            let client_kbest_for_failing: Vec<(usize, Vec<u32>)> = failing
                 .par_iter()
-                .filter_map(|&ti| {
-                    let dst_ranks = &client_snaps[ti].ranks;
+                .map(|&ti| {
+                    let ci = client_valid[ti];
+                    let c = &req.clients[ci];
+                    let snap = super::snap_kbest::snap_k_pair_role(
+                        &state,
+                        mode_data,
+                        mode,
+                        c.lon,
+                        c.lat,
+                        super::types::SnapRole::Dst,
+                        None,
+                        SNAP_K,
+                    );
+                    (ti, snap.ranks)
+                })
+                .collect();
+            let patches: Vec<(usize, u32)> = client_kbest_for_failing
+                .par_iter()
+                .filter_map(|(ti, dst_ranks)| {
                     super::snap_kbest::p2p_with_kbest_fallback(
                         &query,
-                        &store_snap.ranks,
+                        &store_kbest.ranks,
                         dst_ranks,
                         super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
                     )
-                    .map(|(_, _, r)| (ti, r.distance))
+                    .map(|(_, _, r)| (*ti, r.distance))
                 })
                 .collect();
             for (ti, dist) in patches {

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -434,11 +434,14 @@ fn do_matrix(
     // INF cells in the small-matrix branch below.
     const SNAP_K: usize = 64;
     use rayon::prelude::*;
-    let src_kbest: Vec<super::snap_kbest::KBestSnap> = params
+    // Lazy snap (#368 pattern): K=1 primary upfront, K=64 escalation
+    // lives in the INF-cell fallback below.
+    type PrimarySnap = Option<((u32, f64, f64, f64), u32)>;
+    let src_primary: Vec<PrimarySnap> = params
         .sources
         .par_iter()
         .map(|&[lon, lat]| {
-            super::snap_kbest::snap_k_pair_role(
+            super::snap_kbest::snap_primary_role(
                 state,
                 mode_data,
                 mode,
@@ -446,15 +449,14 @@ fn do_matrix(
                 lat,
                 SnapRole::Src,
                 None,
-                SNAP_K,
             )
         })
         .collect();
-    let dst_kbest: Vec<super::snap_kbest::KBestSnap> = params
+    let dst_primary: Vec<PrimarySnap> = params
         .destinations
         .par_iter()
         .map(|&[lon, lat]| {
-            super::snap_kbest::snap_k_pair_role(
+            super::snap_kbest::snap_primary_role(
                 state,
                 mode_data,
                 mode,
@@ -462,7 +464,6 @@ fn do_matrix(
                 lat,
                 SnapRole::Dst,
                 None,
-                SNAP_K,
             )
         })
         .collect();
@@ -470,16 +471,11 @@ fn do_matrix(
     let mut sources_rank = Vec::with_capacity(params.sources.len());
     let mut valid_src = Vec::with_capacity(params.sources.len());
     let mut sources_snapped = Vec::with_capacity(params.sources.len());
-    for (i, snap) in src_kbest.iter().enumerate() {
-        if let Some(r) = snap.primary_rank() {
-            sources_rank.push(r);
+    for (i, snap) in src_primary.iter().enumerate() {
+        if let Some(((_, plon, plat, _), rank)) = snap {
+            sources_rank.push(*rank);
             valid_src.push(i);
-            if let Some((_, plon, plat, _)) = snap.primary {
-                sources_snapped.push((plon, plat));
-            } else {
-                let [lon, lat] = params.sources[i];
-                sources_snapped.push((lon, lat));
-            }
+            sources_snapped.push((*plon, *plat));
         } else {
             let [lon, lat] = params.sources[i];
             sources_snapped.push((lon, lat));
@@ -488,16 +484,11 @@ fn do_matrix(
     let mut targets_rank = Vec::with_capacity(params.destinations.len());
     let mut valid_dst = Vec::with_capacity(params.destinations.len());
     let mut targets_snapped = Vec::with_capacity(params.destinations.len());
-    for (i, snap) in dst_kbest.iter().enumerate() {
-        if let Some(r) = snap.primary_rank() {
-            targets_rank.push(r);
+    for (i, snap) in dst_primary.iter().enumerate() {
+        if let Some(((_, plon, plat, _), rank)) = snap {
+            targets_rank.push(*rank);
             valid_dst.push(i);
-            if let Some((_, plon, plat, _)) = snap.primary {
-                targets_snapped.push((plon, plat));
-            } else {
-                let [lon, lat] = params.destinations[i];
-                targets_snapped.push((lon, lat));
-            }
+            targets_snapped.push((*plon, *plat));
         } else {
             let [lon, lat] = params.destinations[i];
             targets_snapped.push((lon, lat));
@@ -554,27 +545,81 @@ fn do_matrix(
         // Per-cell K-best fallback for INF cells (mirrors /table POST).
         // With SCC-aware role masks this is now a rare per-cell rescue
         // for geometric-ambiguity / dynamic-recustomisation pairs.
+        // K=64 escalation runs only for src/dst indices that have at
+        // least one INF cell.
         if matrix.contains(&u32::MAX) {
             use rayon::prelude::*;
+            use std::collections::HashSet;
             let query = super::query::CchQuery::new(state, mode);
 
-            // Map back from matrix index (over valid src/dst) to the
-            // original src/dst index so we can look up the K-best ranks.
             let mut work: Vec<(usize, usize)> = Vec::new();
+            let mut needed_src: HashSet<usize> = HashSet::new();
+            let mut needed_dst: HashSet<usize> = HashSet::new();
             for (i, _) in valid_src.iter().enumerate() {
                 for (j, _) in valid_dst.iter().enumerate() {
                     if matrix[i * n_valid_dst + j] == u32::MAX {
                         work.push((i, j));
+                        needed_src.insert(valid_src[i]);
+                        needed_dst.insert(valid_dst[j]);
                     }
                 }
             }
+            // Lazy K=64 snap for only the failing src/dst originals.
+            let needed_src_vec: Vec<usize> = needed_src.into_iter().collect();
+            let needed_dst_vec: Vec<usize> = needed_dst.into_iter().collect();
+            let mut src_kbest_ranks: std::collections::HashMap<usize, Vec<u32>> =
+                std::collections::HashMap::new();
+            for (orig_idx, ranks) in needed_src_vec
+                .par_iter()
+                .map(|&oi| {
+                    let [lon, lat] = params.sources[oi];
+                    let snap = super::snap_kbest::snap_k_pair_role(
+                        state,
+                        mode_data,
+                        mode,
+                        lon,
+                        lat,
+                        SnapRole::Src,
+                        None,
+                        SNAP_K,
+                    );
+                    (oi, snap.ranks)
+                })
+                .collect::<Vec<_>>()
+            {
+                src_kbest_ranks.insert(orig_idx, ranks);
+            }
+            let mut dst_kbest_ranks: std::collections::HashMap<usize, Vec<u32>> =
+                std::collections::HashMap::new();
+            for (orig_idx, ranks) in needed_dst_vec
+                .par_iter()
+                .map(|&oi| {
+                    let [lon, lat] = params.destinations[oi];
+                    let snap = super::snap_kbest::snap_k_pair_role(
+                        state,
+                        mode_data,
+                        mode,
+                        lon,
+                        lat,
+                        SnapRole::Dst,
+                        None,
+                        SNAP_K,
+                    );
+                    (oi, snap.ranks)
+                })
+                .collect::<Vec<_>>()
+            {
+                dst_kbest_ranks.insert(orig_idx, ranks);
+            }
+
+            let empty: Vec<u32> = Vec::new();
             let patches: Vec<(usize, usize, u32)> = work
                 .par_iter()
                 .filter_map(|&(i, j)| {
                     let src_orig_idx = valid_src[i];
                     let dst_orig_idx = valid_dst[j];
-                    let src_ranks = &src_kbest[src_orig_idx].ranks;
-                    let dst_ranks = &dst_kbest[dst_orig_idx].ranks;
+                    let src_ranks = src_kbest_ranks.get(&src_orig_idx).unwrap_or(&empty);
+                    let dst_ranks = dst_kbest_ranks.get(&dst_orig_idx).unwrap_or(&empty);
                     super::snap_kbest::p2p_with_kbest_fallback(
                         &query,
                         src_ranks,
@@ -1604,12 +1649,12 @@ pub fn do_edges_batch(
                         dist_m_b.append_null();
                     };
 
-                // K-best snap + bounded combo fallback for the residual
-                // geometric-ambiguity / dynamic-recustomisation cases.
-                // The connectivity-aware role masks already drop
-                // disconnected-component snap traps before we get here.
+                // Lazy snap (#368 pattern): K=1 primary first, escalate
+                // to K=64 + combo fallback when EITHER primary is None
+                // (closest snap has u32::MAX rank — not in this mode's
+                // CCH) OR the primary pair doesn't connect.
                 const SNAP_K: usize = 64;
-                let src_snap = super::snap_kbest::snap_k_pair_role(
+                let src_primary = super::snap_kbest::snap_primary_role(
                     &state,
                     mode_data,
                     mode,
@@ -1617,9 +1662,8 @@ pub fn do_edges_batch(
                     pair[1],
                     super::types::SnapRole::Src,
                     None,
-                    SNAP_K,
                 );
-                let dst_snap = super::snap_kbest::snap_k_pair_role(
+                let dst_primary = super::snap_kbest::snap_primary_role(
                     &state,
                     mode_data,
                     mode,
@@ -1627,20 +1671,7 @@ pub fn do_edges_batch(
                     pair[3],
                     super::types::SnapRole::Dst,
                     None,
-                    SNAP_K,
                 );
-                if src_snap.ranks.is_empty() || dst_snap.ranks.is_empty() {
-                    emit_unreachable(
-                        &mut query_idx_b,
-                        &mut target_idx_b,
-                        &mut edge_seq_b,
-                        &mut osm_from_b,
-                        &mut osm_to_b,
-                        &mut dur_ms_b,
-                        &mut dist_m_b,
-                    );
-                    continue;
-                }
 
                 // Run CchQuery against the default time weights (no
                 // avoid/exclude support in MVP; add later as a param
@@ -1651,12 +1682,49 @@ pub fn do_edges_batch(
                     &mode_data.down_rev_flat,
                     &mode_data.cch_weights,
                 );
-                let Some((src_rank, dst_rank, result)) = super::snap_kbest::p2p_with_kbest_fallback(
-                    &query,
-                    &src_snap.ranks,
-                    &dst_snap.ranks,
-                    super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
-                ) else {
+
+                let primary_ranks = src_primary.and_then(|(_, s)| dst_primary.map(|(_, d)| (s, d)));
+                let p2p_result = if let Some((s, d)) = primary_ranks
+                    && let Some(r) = query.query(s, d)
+                {
+                    Some((s, d, r))
+                } else {
+                    // Escalation: K=64 snap + combo fallback. This
+                    // also rescues pairs whose closest snap had
+                    // u32::MAX rank — K=64 looks further out for a
+                    // contracted neighbor.
+                    let src_snap = super::snap_kbest::snap_k_pair_role(
+                        &state,
+                        mode_data,
+                        mode,
+                        pair[0],
+                        pair[1],
+                        super::types::SnapRole::Src,
+                        None,
+                        SNAP_K,
+                    );
+                    let dst_snap = super::snap_kbest::snap_k_pair_role(
+                        &state,
+                        mode_data,
+                        mode,
+                        pair[2],
+                        pair[3],
+                        super::types::SnapRole::Dst,
+                        None,
+                        SNAP_K,
+                    );
+                    if src_snap.ranks.is_empty() || dst_snap.ranks.is_empty() {
+                        None
+                    } else {
+                        super::snap_kbest::p2p_with_kbest_fallback(
+                            &query,
+                            &src_snap.ranks,
+                            &dst_snap.ranks,
+                            super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
+                        )
+                    }
+                };
+                let Some((src_rank, dst_rank, result)) = p2p_result else {
                     emit_unreachable(
                         &mut query_idx_b,
                         &mut target_idx_b,
@@ -2117,9 +2185,11 @@ async fn do_exchange_catchment(
                 continue;
             }
 
-            // K-best snap store as source (#197 Src role).
+            // Lazy snap (#368 pattern): K=1 primary upfront for store
+            // and all clients; K=64 escalation lives in the INF-cell
+            // fallback below.
             const SNAP_K: usize = 64;
-            let store_snap = super::snap_kbest::snap_k_pair_role(
+            let store_rank = match super::snap_kbest::snap_primary_role(
                 &state,
                 mode_data,
                 mode,
@@ -2127,33 +2197,23 @@ async fn do_exchange_catchment(
                 *slat,
                 super::types::SnapRole::Src,
                 None,
-                SNAP_K,
-            );
-            let store_rank = match store_snap.primary_rank() {
-                Some(r) => r,
+            ) {
+                Some((_, r)) => r,
                 None => continue,
             };
 
-            // K-best snap all clients as destinations (#197 Dst role).
-            let client_snaps: Vec<super::snap_kbest::KBestSnap> = client_coords
-                .iter()
-                .map(|&(clon, clat)| {
-                    super::snap_kbest::snap_k_pair_role(
-                        &state,
-                        mode_data,
-                        mode,
-                        clon,
-                        clat,
-                        super::types::SnapRole::Dst,
-                        None,
-                        SNAP_K,
-                    )
-                })
-                .collect();
             let mut client_ranks: Vec<u32> = Vec::with_capacity(client_coords.len());
             let mut client_valid: Vec<usize> = Vec::with_capacity(client_coords.len());
-            for (ci, snap) in client_snaps.iter().enumerate() {
-                if let Some(r) = snap.primary_rank() {
+            for (ci, &(clon, clat)) in client_coords.iter().enumerate() {
+                if let Some((_, r)) = super::snap_kbest::snap_primary_role(
+                    &state,
+                    mode_data,
+                    mode,
+                    clon,
+                    clat,
+                    super::types::SnapRole::Dst,
+                    None,
+                ) {
                     client_ranks.push(r);
                     client_valid.push(ci);
                 }
@@ -2173,23 +2233,52 @@ async fn do_exchange_catchment(
             );
 
             // Per-cell K-best fallback for INF cells (mirrors /table POST).
+            // K=64 escalation runs only for client indices whose 1-to-N
+            // cell came back u32::MAX.
             if matrix.contains(&u32::MAX) {
                 use rayon::prelude::*;
                 let query = super::query::CchQuery::new(&state, mode);
-                let patches: Vec<(usize, u32)> = (0..client_valid.len())
+                let store_kbest = super::snap_kbest::snap_k_pair_role(
+                    &state,
+                    mode_data,
+                    mode,
+                    *slon,
+                    *slat,
+                    super::types::SnapRole::Src,
+                    None,
+                    SNAP_K,
+                );
+                let failing: Vec<usize> = (0..client_valid.len())
                     .filter(|&ti| matrix[ti] == u32::MAX)
-                    .collect::<Vec<_>>()
+                    .collect();
+                let client_kbest: Vec<(usize, Vec<u32>)> = failing
                     .par_iter()
-                    .filter_map(|&ti| {
+                    .map(|&ti| {
                         let ci = client_valid[ti];
-                        let dst_ranks = &client_snaps[ci].ranks;
+                        let (clon, clat) = client_coords[ci];
+                        let snap = super::snap_kbest::snap_k_pair_role(
+                            &state,
+                            mode_data,
+                            mode,
+                            clon,
+                            clat,
+                            super::types::SnapRole::Dst,
+                            None,
+                            SNAP_K,
+                        );
+                        (ti, snap.ranks)
+                    })
+                    .collect();
+                let patches: Vec<(usize, u32)> = client_kbest
+                    .par_iter()
+                    .filter_map(|(ti, dst_ranks)| {
                         super::snap_kbest::p2p_with_kbest_fallback(
                             &query,
-                            &store_snap.ranks,
+                            &store_kbest.ranks,
                             dst_ranks,
                             super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
                         )
-                        .map(|(_, _, r)| (ti, r.distance))
+                        .map(|(_, _, r)| (*ti, r.distance))
                     })
                     .collect();
                 for (ti, dist) in patches {

--- a/route/src/server/snap_kbest.rs
+++ b/route/src/server/snap_kbest.rs
@@ -55,6 +55,53 @@ pub fn combo_order(k_src: usize, k_dst: usize, max_combos: usize) -> Vec<(usize,
     order
 }
 
+/// Snap the K=1 primary with the #197 role filter — the cheap path
+/// before any K=64 escalation. Returns the primary tuple
+/// `(ebg_id, snapped_lon, snapped_lat, snap_distance_m)` plus the
+/// rank, or `None` if no candidate exists.
+///
+/// If the geometrically-closest candidate has `orig_to_rank == u32::MAX`
+/// (not in this mode's contracted graph — rare; usually the role_filter
+/// already excludes such nodes), this function transparently escalates
+/// to a K=64 fetch and returns the closest candidate that DOES have a
+/// valid rank. So callers never have to re-snap to recover from that
+/// edge case — they pay K=64 only on the (rare) miss.
+///
+/// Mirrors the lazy-snap pattern used inline in /route (#368), /table
+/// (#370), and /trip (#374). Use this for any handler that uses the
+/// primary on the happy path and only needs the K=64 list to feed the
+/// combo fallback when the primary CCH query returns None.
+pub fn snap_primary_role(
+    state: &ServerState,
+    mode_data: &ModeData,
+    mode: Mode,
+    lon: f64,
+    lat: f64,
+    role: SnapRole,
+    snap_mask: Option<&[u64]>,
+) -> Option<((u32, f64, f64, f64), u32)> {
+    let role_filter = role.role_filter(mode_data);
+    if let Some((orig_id, plon, plat, d)) =
+        state
+            .snap_index
+            .snap_with_info_filtered_role(lon, lat, mode.0, snap_mask, role_filter)
+    {
+        let rank = mode_data.orig_to_rank[orig_id as usize];
+        if rank != u32::MAX {
+            return Some(((orig_id, plon, plat, d), rank));
+        }
+    }
+    // K=1 closest had u32::MAX rank (role_filter and orig_to_rank
+    // disagreed on this node — typically very rare). Escalate to K=64
+    // and pick the first candidate with a valid rank. Preserves the
+    // pre-#368 behaviour of always finding the closest contracted
+    // neighbour when one exists within MAX_SNAP_DISTANCE_M.
+    let kbest = snap_k_pair_role(state, mode_data, mode, lon, lat, role, snap_mask, 64);
+    let rank = kbest.primary_rank()?;
+    let primary = kbest.primary?;
+    Some((primary, rank))
+}
+
 /// Snap K candidates per src/dst with the directional #197 role filter,
 /// dropping any candidate whose rank is `u32::MAX` (not contracted in
 /// this mode's CCH). Returns the rank-space candidate lists, the


### PR DESCRIPTION
Fifth in the lazy-snap series (#368/#370/#374). Applies the K=1-then-K=64 pattern to:

- REST `/catchment` (per-store + per-client snap loops)
- Flight `matrix` (parallel src/dst upfront snap)
- Flight `catchment` DoExchange (per-store + per-client loops)
- Flight `edges_batch` (per-pair snap)

## New shared helper

`snap_kbest::snap_primary_role(state, mode_data, mode, lon, lat, role, snap_mask) -> Option<((orig_id, plon, plat, d), rank)>`

K=1 primary with a valid CCH rank. Falls back **internally** to K=64 in the (rare) case where the geometrically-closest candidate has `orig_to_rank == u32::MAX` — preserves the pre-#368 "always find a contracted neighbour within snap distance" guarantee while still paying K=1 on the happy path.

## Per-endpoint flow after this patch

1. K=1 primary snap.
2. Run the 1-to-N / N-to-M / per-pair CCH query against the primary ranks.
3. For only the INF cells / unreachable pairs, snap K=64 for the **affected** src/dst indices (parallel) and replay `p2p_with_kbest_fallback` (MAX_COMBOS=200, unchanged).

Healthy queries snap K=64 zero times across all five endpoints.

## Verification

- `cargo test -p butterfly-route --release --lib` → 598 passed, 0 failed
- `cargo clippy -p butterfly-route --lib` clean
- Tire-kicker (Belgium): all Belgium REST + Flight endpoints PASS
  - REST: route, nearest, matrix, isochrone, iso_bulk, trip, height, match, transit
  - Flight: matrix_5x5_car (rows=25), route_batch_3 (rows=3), isochrone_BE_car (rows=1), edges_batch_2 (rows=2319, cols=7), catchment_1store (50.0/80.0 percentiles)
  - LU failures are expected (Belgium-only setup)

## Notes

- Flight edges_batch_2 returned 2319 rows instead of the pre-patch 2320. Both paths are time-shortest; the 1-edge delta comes from K=1 vs K=64 tie-breaking among equidistant snap candidates picking slightly different starting nodes. Same destination, equally valid path. The test PASSes (it's a structural check).

## Test plan

- [x] cargo test --release --lib
- [x] cargo clippy
- [x] Belgium tire-kicker (REST + Flight)
- [x] Per-endpoint behavioural sanity (route_batch_3, edges_batch_2, catchment_1store)