### PR TITLE
feat(pack): #372 bundle cch.lat.<mode>.u32 into container as CchWeightsLat section

### DIFF
--- a/route/src/formats/butterfly_dat.rs
+++ b/route/src/formats/butterfly_dat.rs
@@ -156,6 +156,12 @@ pub enum SectionKind {
     CchWeightsTime = 0x0008_0001,
     /// `step8/cch.d.<mode>.u32` — per-mode customised distance weights.
     CchWeightsDist = 0x0008_0002,
+    /// `step8/cch.lat.<mode>.u32` — per-mode length-along-time-shortest
+    /// weights (#371/#372). For every CCH shortcut, the sum of physical
+    /// edge lengths along the time-optimal expansion. Replaces
+    /// `CchWeightsDist` for matrix/trip/Flight distance reporting so
+    /// the returned distance belongs to the same path as the duration.
+    CchWeightsLat = 0x0008_0003,
 
     /// Pre-built flat UP adjacency for a (mode, metric). Built at pack
     /// time from cch_topo + cch_weights. Mmapped at server boot — the
@@ -290,6 +296,7 @@ impl SectionKind {
 
             0x0008_0001 => Self::CchWeightsTime,
             0x0008_0002 => Self::CchWeightsDist,
+            0x0008_0003 => Self::CchWeightsLat,
 
             0x0009_0001 => Self::UpAdjFlat,
             0x0009_0002 => Self::DownAdjFlat,
@@ -345,6 +352,7 @@ impl SectionKind {
             Self::CchMiddles => "step7/cch.middles",
             Self::CchWeightsTime => "step8/cch.w.u32",
             Self::CchWeightsDist => "step8/cch.d.u32",
+            Self::CchWeightsLat => "step8/cch.lat.u32",
             Self::UpAdjFlat => "flat/up_adj",
             Self::DownAdjFlat => "flat/down_adj",
             Self::DownReverseAdjFlat => "flat/down_reverse_adj",

--- a/route/src/pack.rs
+++ b/route/src/pack.rs
@@ -678,6 +678,18 @@ pub fn pack_with_options(
             &format!("mode/{}/weights.dist", mode),
             &cch_d,
         )?;
+        // #371/#372: length-along-time-shortest weights, when present.
+        // Pre-PR #377 step8 outputs don't have this file; older runs
+        // skip it and the server reverts to the broken distance-shortest
+        // metric. Once everyone re-runs step8, cch.lat ships in every
+        // container.
+        let cch_lat = step8.join(format!("cch.lat.{}.u32", mode));
+        maybe_append(
+            &mut w,
+            SectionKind::CchWeightsLat,
+            &format!("mode/{}/weights.lat", mode),
+            &cch_lat,
+        )?;
 
         // ---- Pre-built flat adjacencies (#150) -----------------------
         // Flats are built once at pack time from (cch_topo, cch_weights),
@@ -1460,6 +1472,7 @@ fn path_for_section(out_dir: &Path, name: &str) -> Option<PathBuf> {
             "topo" => Some(out_dir.join("step7").join(format!("cch.{}.topo", mode))),
             "weights.time" => Some(out_dir.join("step8").join(format!("cch.w.{}.u32", mode))),
             "weights.dist" => Some(out_dir.join("step8").join(format!("cch.d.{}.u32", mode))),
+            "weights.lat" => Some(out_dir.join("step8").join(format!("cch.lat.{}.u32", mode))),
             _ => None,
         };
     }

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -961,7 +961,7 @@ impl ServerState {
         // slices into them remain valid; subsequent rare reads page
         // them back in at standard fault cost.
         for mode_name in &discovered_modes {
-            for leaf in ["weights.time", "weights.dist"] {
+            for leaf in ["weights.time", "weights.dist", "weights.lat"] {
                 let section = format!("mode/{}/{}", mode_name, leaf);
                 if let Some(entry) = container.get(&section) {
                     let off = entry.offset as usize;
@@ -2669,10 +2669,34 @@ fn load_mode_data_from_bundle(
         };
     madvise_section_in_container(container, mmap, &down_adj_flat_dist_section);
 
-    // #371/#372: cch_weights_lat not yet wired through pack.rs for the
-    // container path. Until that ships, the container-mode boot uses
-    // None (matrix endpoints fall back to cch_weights_dist).
-    let cch_weights_lat = None;
+    // #371/#372: length-along-time weights section, when present.
+    // Pre-PR #377 containers don't have this section; we boot with
+    // None and matrix endpoints fall back to cch_weights_dist
+    // (broken metric, see #371 / #372). Once everyone repacks, this
+    // becomes a hard load like weights.dist above.
+    let cch_weights_lat = {
+        let name = format!("mode/{}/weights.lat", mode_name);
+        if let Some(entry) = container.get(&name) {
+            let off = entry.offset as usize;
+            let len = entry.len as usize;
+            anyhow::ensure!(
+                off + len <= mmap.len(),
+                "section '{}' bytes [{},{}) exceed mmap len {}",
+                name,
+                off,
+                off + len,
+                mmap.len()
+            );
+            lazy.verify_now(&name)?;
+            Some(CchWeightsFile::read_from_mmap_unverified(
+                mmap.clone(),
+                off,
+                len,
+            )?)
+        } else {
+            None
+        }
+    };
 
     Ok(ModeData {
         mode,


### PR DESCRIPTION
Step 3 of #372 (after #377 emit-the-file and #378 load-in-state). Adds a new container section kind `CchWeightsLat = 0x0008_0003` for the length-along-time-shortest weights.

## Pack side

`pack.rs` does `maybe_append` from `step8/cch.lat.<mode>.u32` when present. Old step8 outputs that don't have the file simply skip — container builds with or without the section.

## Load side

`load_mode_data_from_bundle` reads the new section if the container has it, returning `None` otherwise. Same graceful-fallback shape as #378's `--data-dir` loader. The madvise(DONTNEED) post-load eviction loop now covers `weights.lat` alongside `.time` / `.dist`.

## Disk impact

Belgium container will grow ~+250 MiB after step8 is rerun and the container is repacked. Until then, both old and new containers boot fine with `cch_weights_lat = None`.

## Verified

- 598 lib tests pass
- clippy clean
- Belgium serve with pre-PR #377 `be.butterfly`: boots OK; `cch_weights_lat` is `None`; `/route` returns 6740 s / 57693 m unchanged
- All Belgium REST + Flight tire-kicker checks PASS

## Next

- 2-channel bucket-M2M algorithm itself (the big lift)
- `/table`, `/trip`, Flight matrix consumers switch
- Drop `cch_weights_dist` once nothing uses it
- Belgium repipeline + repack