### PR TITLE
feat(matrix,table): #372 2-channel bucket-M2M — time + length-along-time

### DIFF
--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -34,6 +34,11 @@ thread_local! {
     static FORWARD_STATE: RefCell<Option<SearchState>> = const { RefCell::new(None) };
     static BACKWARD_STATE: RefCell<Option<SearchState>> = const { RefCell::new(None) };
     static FORWARD_BUCKET_ITEMS: RefCell<Vec<(u32, u32, u32)>> = const { RefCell::new(Vec::new()) };
+    // 2-channel (#372) thread-local state — kept separate so single-
+    // channel callers don't pay the parallel-lat allocation.
+    static FORWARD_STATE_LAT: RefCell<Option<SearchState2>> = const { RefCell::new(None) };
+    static BACKWARD_STATE_LAT: RefCell<Option<SearchState2>> = const { RefCell::new(None) };
+    static FORWARD_BUCKET_ITEMS_LAT: RefCell<Vec<(u32, u32, u32, u32)>> = const { RefCell::new(Vec::new()) };
 
     // Sequential engine for the small-N fast path (#129). At low cell
     // counts (~≤ 1000) rayon's thread-dispatch + work-stealing overhead
@@ -3801,9 +3806,9 @@ struct PrefixSumBuckets2 {
     count_stamps: Vec<u32>,
     current_stamp: u32,
     offsets: Vec<u32>,
-    dists: Vec<u32>,
-    lats: Vec<u32>,
-    source_indices: Vec<u32>,
+    /// AoS layout — backward join reads one `Bucket2Entry` per join.
+    /// (Tried a parallel SoA layout; the AoS read pattern was faster
+    /// because the join touches all three fields per entry anyway.)
     items: Vec<Bucket2Entry>,
     active_nodes: Vec<u32>,
 }
@@ -3815,9 +3820,6 @@ impl PrefixSumBuckets2 {
             count_stamps: vec![0; n_nodes],
             current_stamp: 0,
             offsets: vec![0; n_nodes + 1],
-            dists: Vec::new(),
-            lats: Vec::new(),
-            source_indices: Vec::new(),
             items: Vec::new(),
             active_nodes: Vec::new(),
         }
@@ -3850,11 +3852,6 @@ impl PrefixSumBuckets2 {
         }
 
         let total_items = total as usize;
-        if self.dists.len() < total_items {
-            self.dists.resize(total_items, 0);
-            self.lats.resize(total_items, 0);
-            self.source_indices.resize(total_items, 0);
-        }
         if self.items.len() < total_items {
             self.items.resize(
                 total_items,
@@ -3866,22 +3863,18 @@ impl PrefixSumBuckets2 {
             );
         }
 
-        // Sentinel offsets[n_nodes] = total
         if let Some(last) = self.offsets.last_mut() {
             *last = total;
         }
 
-        // Per-node write cursor — reuse `counts` as cursor by zeroing then
-        // re-counting, mirroring `PrefixSumBuckets::build`.
+        // Per-node write cursor — reuse `counts` as cursor by zeroing
+        // then re-counting, mirroring `PrefixSumBuckets::build`.
         for &node in &self.active_nodes {
             self.counts[node as usize] = 0;
         }
         for &(node, src_idx, dist, lat) in raw_items {
             let n = node as usize;
             let pos = (self.offsets[n] + self.counts[n]) as usize;
-            self.dists[pos] = dist;
-            self.lats[pos] = lat;
-            self.source_indices[pos] = src_idx;
             self.items[pos] = Bucket2Entry {
                 dist,
                 lat,
@@ -3996,11 +3989,11 @@ impl SearchState2 {
 }
 
 /// Forward search using flat UP adjacency for BOTH metrics. `up_adj_flat`
-/// and `up_adj_flat_lat` share the CCH topology — index `i` addresses
+/// and `up_adj_flat_len_along_time` share the CCH topology — index `i` addresses
 /// the same edge in both. Reads time from the first, lat from the second.
-fn forward_fill_buckets_flat_lat(
+fn forward_fill_buckets_flat_len_along_time(
     up_adj_flat: &UpAdjFlat,
-    up_adj_flat_lat: &UpAdjFlat,
+    up_adj_flat_len_along_time: &UpAdjFlat,
     source_idx: u32,
     source: u32,
     state: &mut SearchState2,
@@ -4017,7 +4010,7 @@ fn forward_fill_buckets_flat_lat(
         for i in start..end {
             let v = up_adj_flat.targets[i];
             let w_time = up_adj_flat.weights.get(i);
-            let w_lat = up_adj_flat_lat.weights.get(i);
+            let w_lat = up_adj_flat_len_along_time.weights.get(i);
             let new_dist = d.saturating_add(w_time);
             let new_lat = l.saturating_add(w_lat);
             state.relax(v, new_dist, new_lat);
@@ -4030,9 +4023,9 @@ fn forward_fill_buckets_flat_lat(
 /// matrices. The meeting node is chosen by min-TIME; lat is reported at
 /// that node, not separately optimised.
 #[allow(clippy::too_many_arguments)]
-fn backward_join_prefix_lat(
+fn backward_join_prefix_len_along_time(
     down_rev_flat: &DownReverseAdjFlat,
-    down_rev_flat_lat: &DownReverseAdjFlat,
+    down_rev_flat_len_along_time: &DownReverseAdjFlat,
     target: u32,
     buckets: &PrefixSumBuckets2,
     time_matrix: &mut [u32],
@@ -4075,7 +4068,7 @@ fn backward_join_prefix_lat(
         for i in edge_start..edge_end {
             let x = down_rev_flat.sources[i];
             let w_time = down_rev_flat.weights.get(i);
-            let w_lat = down_rev_flat_lat.weights.get(i);
+            let w_lat = down_rev_flat_len_along_time.weights.get(i);
             let new_dist = d.saturating_add(w_time);
             let new_lat = l.saturating_add(w_lat);
             state.relax(x, new_dist, new_lat);
@@ -4092,14 +4085,14 @@ fn backward_join_prefix_lat(
 ///
 /// `up_adj_flat` / `down_rev_flat` carry time weights; `_lat` variants
 /// carry length-along-time weights with the SAME topology (built by
-/// `state.rs` via `UpAdjFlat::build(&cch_topo, &cch_weights_lat)`).
+/// `state.rs` via `UpAdjFlat::build(&cch_topo, &cch_weights_len_along_time)`).
 #[allow(clippy::too_many_arguments)]
-pub fn table_bucket_full_flat_lat(
+pub fn table_bucket_full_flat_len_along_time(
     n_nodes: usize,
     up_adj_flat: &UpAdjFlat,
     down_rev_flat: &DownReverseAdjFlat,
-    up_adj_flat_lat: &UpAdjFlat,
-    down_rev_flat_lat: &DownReverseAdjFlat,
+    up_adj_flat_len_along_time: &UpAdjFlat,
+    down_rev_flat_len_along_time: &DownReverseAdjFlat,
     sources: &[u32],
     targets: &[u32],
 ) -> (Vec<u32>, Vec<u32>, BucketM2MStats) {
@@ -4128,9 +4121,9 @@ pub fn table_bucket_full_flat_lat(
         if source as usize >= n_nodes {
             continue;
         }
-        forward_fill_buckets_flat_lat(
+        forward_fill_buckets_flat_len_along_time(
             up_adj_flat,
-            up_adj_flat_lat,
+            up_adj_flat_len_along_time,
             source_idx as u32,
             source,
             &mut state,
@@ -4150,9 +4143,9 @@ pub fn table_bucket_full_flat_lat(
         if target as usize >= n_nodes {
             continue;
         }
-        let (visited, joins) = backward_join_prefix_lat(
+        let (visited, joins) = backward_join_prefix_len_along_time(
             down_rev_flat,
-            down_rev_flat_lat,
+            down_rev_flat_len_along_time,
             target,
             &buckets,
             &mut time_matrix,
@@ -4168,6 +4161,194 @@ pub fn table_bucket_full_flat_lat(
 
     stats.heap_pushes = state.pushes;
     stats.heap_pops = state.pops;
+
+    (time_matrix, lat_matrix, stats)
+}
+
+/// Parallel 2-channel backward join. Writes into a single
+/// `AtomicU64` matrix where each cell packs `(time << 32) | lat` —
+/// `fetch_min` on this packed value keeps time and lat in lock-step
+/// (smaller u64 = smaller time wins, and the lat tagged onto the
+/// winning value rides along automatically).
+#[allow(clippy::too_many_arguments)]
+fn backward_join_parallel_prefix_len_along_time(
+    down_rev_flat: &DownReverseAdjFlat,
+    down_rev_flat_len_along_time: &DownReverseAdjFlat,
+    target: u32,
+    buckets: &PrefixSumBuckets2,
+    packed_matrix: &[std::sync::atomic::AtomicU64],
+    n_targets: usize,
+    target_idx: usize,
+    state: &mut SearchState2,
+) -> (usize, usize) {
+    use std::sync::atomic::Ordering;
+    state.start_search();
+    state.relax(target, 0, 0);
+
+    let mut visited = 0usize;
+    let mut joins = 0usize;
+
+    while let Some((d, l, u)) = state.pop() {
+        visited += 1;
+
+        let entries = buckets.get(u);
+        for entry in entries {
+            let total_time = entry.dist.saturating_add(d);
+            let total_lat = entry.lat.saturating_add(l);
+            let packed = ((total_time as u64) << 32) | (total_lat as u64);
+            let cell = entry.source_idx as usize * n_targets + target_idx;
+            // fetch_min on packed (time, lat) — smaller time wins, lat
+            // tagged on the winning value travels with it.
+            packed_matrix[cell].fetch_min(packed, Ordering::Relaxed);
+            joins += 1;
+        }
+
+        let edge_start = down_rev_flat.offsets[u as usize] as usize;
+        let edge_end = down_rev_flat.offsets[u as usize + 1] as usize;
+        for i in edge_start..edge_end {
+            let x = down_rev_flat.sources[i];
+            let w_time = down_rev_flat.weights.get(i);
+            let w_lat = down_rev_flat_len_along_time.weights.get(i);
+            let new_dist = d.saturating_add(w_time);
+            let new_lat = l.saturating_add(w_lat);
+            state.relax(x, new_dist, new_lat);
+        }
+    }
+
+    (visited, joins)
+}
+
+/// Parallel 2-channel bucket-M2M. Mirrors `table_bucket_parallel` but
+/// propagates length-along-time alongside time using thread-local
+/// `SearchState2`. Backward phase writes into a packed `AtomicU64`
+/// matrix so updates to (time, lat) stay atomic without per-cell
+/// mutexes.
+///
+/// For small matrices the cost of forking rayon is higher than the
+/// routing work itself; the caller dispatches to the sequential
+/// `table_bucket_full_flat_len_along_time` below ~1024 cells.
+#[allow(clippy::too_many_arguments)]
+pub fn table_bucket_parallel_len_along_time(
+    n_nodes: usize,
+    up_adj_flat: &UpAdjFlat,
+    down_rev_flat: &DownReverseAdjFlat,
+    up_adj_flat_len_along_time: &UpAdjFlat,
+    down_rev_flat_len_along_time: &DownReverseAdjFlat,
+    sources: &[u32],
+    targets: &[u32],
+) -> (Vec<u32>, Vec<u32>, BucketM2MStats) {
+    use std::sync::atomic::Ordering;
+    let n_sources = sources.len();
+    let n_targets = targets.len();
+
+    if n_sources == 0 || n_targets == 0 {
+        return (
+            vec![u32::MAX; n_sources * n_targets],
+            vec![u32::MAX; n_sources * n_targets],
+            BucketM2MStats::default(),
+        );
+    }
+
+    let mut stats = BucketM2MStats {
+        n_sources,
+        n_targets,
+        ..Default::default()
+    };
+
+    // ---- Forward phase: parallel per-source ----
+    let forward_start = std::time::Instant::now();
+    let bucket_chunks: Vec<Vec<(u32, u32, u32, u32)>> = sources
+        .par_iter()
+        .enumerate()
+        .filter_map(|(source_idx, &source)| {
+            if source as usize >= n_nodes {
+                return None;
+            }
+            let avg_visited = (n_nodes / 400).clamp(500, 20_000);
+            FORWARD_STATE_LAT.with(|state_cell| {
+                FORWARD_BUCKET_ITEMS_LAT.with(|items_cell| {
+                    let mut state_opt = state_cell.borrow_mut();
+                    let state =
+                        state_opt.get_or_insert_with(|| SearchState2::new(n_nodes, avg_visited));
+                    if state.entries.len() != n_nodes {
+                        *state = SearchState2::new(n_nodes, avg_visited);
+                    }
+                    let mut items = items_cell.borrow_mut();
+                    items.clear();
+                    forward_fill_buckets_flat_len_along_time(
+                        up_adj_flat,
+                        up_adj_flat_len_along_time,
+                        source_idx as u32,
+                        source,
+                        state,
+                        &mut items,
+                    );
+                    Some(std::mem::take(&mut *items))
+                })
+            })
+        })
+        .collect();
+    let bucket_items: Vec<(u32, u32, u32, u32)> = bucket_chunks.into_iter().flatten().collect();
+    stats.forward_visited = bucket_items.len();
+    stats.forward_time_ms = forward_start.elapsed().as_millis() as u64;
+
+    // ---- Bucket build ----
+    let sort_start = std::time::Instant::now();
+    let mut buckets = PrefixSumBuckets2::new(n_nodes);
+    buckets.build(&bucket_items);
+    stats.sort_time_ms = sort_start.elapsed().as_millis() as u64;
+
+    // ---- Backward phase: parallel per-target, atomic packed matrix ----
+    let backward_start = std::time::Instant::now();
+    // Init each cell to u64::MAX so `fetch_min` accepts the first
+    // valid (time, lat) write.
+    let packed_matrix: Vec<std::sync::atomic::AtomicU64> = (0..n_sources * n_targets)
+        .map(|_| std::sync::atomic::AtomicU64::new(u64::MAX))
+        .collect();
+
+    let (total_visited, total_joins): (usize, usize) = targets
+        .par_iter()
+        .enumerate()
+        .filter(|&(_, target)| (*target as usize) < n_nodes)
+        .map(|(target_idx, &target)| {
+            let avg_visited = (n_nodes / 400).clamp(500, 20_000);
+            BACKWARD_STATE_LAT.with(|state_cell| {
+                let mut state_opt = state_cell.borrow_mut();
+                let state =
+                    state_opt.get_or_insert_with(|| SearchState2::new(n_nodes, avg_visited));
+                if state.entries.len() != n_nodes {
+                    *state = SearchState2::new(n_nodes, avg_visited);
+                }
+                backward_join_parallel_prefix_len_along_time(
+                    down_rev_flat,
+                    down_rev_flat_len_along_time,
+                    target,
+                    &buckets,
+                    &packed_matrix,
+                    n_targets,
+                    target_idx,
+                    state,
+                )
+            })
+        })
+        .reduce(|| (0, 0), |(v1, j1), (v2, j2)| (v1 + v2, j1 + j2));
+
+    stats.backward_visited = total_visited;
+    stats.join_operations = total_joins;
+    stats.backward_time_ms = backward_start.elapsed().as_millis() as u64;
+
+    // ---- Unpack packed matrix into two u32 matrices ----
+    let mut time_matrix = vec![u32::MAX; n_sources * n_targets];
+    let mut lat_matrix = vec![u32::MAX; n_sources * n_targets];
+    for (i, slot) in packed_matrix.iter().enumerate() {
+        let v = slot.load(Ordering::Relaxed);
+        if v == u64::MAX {
+            // unreachable — keep u32::MAX sentinels
+            continue;
+        }
+        time_matrix[i] = (v >> 32) as u32;
+        lat_matrix[i] = (v & 0xFFFF_FFFF) as u32;
+    }
 
     (time_matrix, lat_matrix, stats)
 }

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -4193,14 +4193,43 @@ fn backward_join_parallel_prefix_len_along_time(
 
         let entries = buckets.get(u);
         for entry in entries {
-            let total_time = entry.dist.saturating_add(d);
-            let total_lat = entry.lat.saturating_add(l);
-            let packed = ((total_time as u64) << 32) | (total_lat as u64);
             let cell = entry.source_idx as usize * n_targets + target_idx;
-            // fetch_min on packed (time, lat) — smaller time wins, lat
-            // tagged on the winning value travels with it.
-            packed_matrix[cell].fetch_min(packed, Ordering::Relaxed);
-            joins += 1;
+            // Bound-pruned CAS loop: replace unconditional fetch_min
+            // with load + compare + compare_exchange_weak. fetch_min
+            // forces a locked RMW even on cells we can't improve;
+            // load-and-check skips the RMW entirely for the common
+            // "already-better" case. CAS retries only when another
+            // thread won the race in between — rare on Belgium
+            // /table at 1000x1000. Codex consult flagged this as the
+            // dominant cost of the 2-channel path.
+            let mut cur = packed_matrix[cell].load(Ordering::Relaxed);
+            loop {
+                let cur_time = (cur >> 32) as u32;
+                if cur_time <= entry.dist {
+                    // current best beats this bucket's dist alone —
+                    // can't improve via this entry.
+                    break;
+                }
+                let total_time = entry.dist.saturating_add(d);
+                if total_time >= cur_time {
+                    // can't improve total either.
+                    break;
+                }
+                let total_lat = entry.lat.saturating_add(l);
+                let next = ((total_time as u64) << 32) | total_lat as u64;
+                match packed_matrix[cell].compare_exchange_weak(
+                    cur,
+                    next,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        joins += 1;
+                        break;
+                    }
+                    Err(observed) => cur = observed,
+                }
+            }
         }
 
         let edge_start = down_rev_flat.offsets[u as usize] as usize;

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -3762,6 +3762,416 @@ impl BucketArena {
     }
 }
 
+// =============================================================================
+// 2-CHANNEL BUCKET-M2M (#372): time + length-along-time-shortest
+// =============================================================================
+//
+// Mirrors the single-channel implementation above but propagates a second
+// per-edge weight (length-along-time) alongside time during the SAME
+// forward+backward Dijkstra. The path chosen is the time-shortest one
+// (decisions driven entirely by `dist`); `lat` accumulates the distance
+// along that path. The output is two matrices: time and lat.
+//
+// Why a separate fork rather than a generic 2-channel implementation:
+//   - The hot path is a u32 heap + relax loop; adding optional second
+//     channels via Option<&[u32]> branches in every iteration costs a
+//     mispredict per relax that the static fork avoids.
+//   - The bucket entries grow from 8 → 12 bytes; PrefixSumBuckets2 keeps
+//     the SoA layout but with an extra `lats` array parallel to `dists`.
+//   - Backward join chooses meeting node by MIN-TIME (not min-lat) and
+//     reads lat at that meeting node — different from a generic
+//     two-metric search.
+
+/// Bucket entry (12 bytes) — like `BucketEntry` but carries a second u32
+/// `lat` representing the length along the time-shortest path from the
+/// source to this bucket's node.
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct Bucket2Entry {
+    dist: u32,
+    lat: u32,
+    source_idx: u32,
+}
+
+/// Reusable prefix-sum bucket structure for the 2-channel variant.
+/// SoA layout: `dists` + `lats` + `source_indices` as three parallel
+/// `Vec<u32>` (12 bytes per entry, better cache utilisation than AoS).
+struct PrefixSumBuckets2 {
+    counts: Vec<u32>,
+    count_stamps: Vec<u32>,
+    current_stamp: u32,
+    offsets: Vec<u32>,
+    dists: Vec<u32>,
+    lats: Vec<u32>,
+    source_indices: Vec<u32>,
+    items: Vec<Bucket2Entry>,
+    active_nodes: Vec<u32>,
+}
+
+impl PrefixSumBuckets2 {
+    fn new(n_nodes: usize) -> Self {
+        Self {
+            counts: vec![0; n_nodes],
+            count_stamps: vec![0; n_nodes],
+            current_stamp: 0,
+            offsets: vec![0; n_nodes + 1],
+            dists: Vec::new(),
+            lats: Vec::new(),
+            source_indices: Vec::new(),
+            items: Vec::new(),
+            active_nodes: Vec::new(),
+        }
+    }
+
+    /// Build from raw items `(node, source_idx, dist, lat)`.
+    fn build(&mut self, raw_items: &[(u32, u32, u32, u32)]) {
+        self.current_stamp = self.current_stamp.wrapping_add(1);
+        if self.current_stamp == 0 {
+            self.count_stamps.fill(0);
+            self.current_stamp = 1;
+        }
+        self.active_nodes.clear();
+
+        for &(node, _, _, _) in raw_items {
+            let n = node as usize;
+            if self.count_stamps[n] != self.current_stamp {
+                self.count_stamps[n] = self.current_stamp;
+                self.counts[n] = 0;
+                self.active_nodes.push(node);
+            }
+            self.counts[n] += 1;
+        }
+
+        let mut total = 0u32;
+        for &node in &self.active_nodes {
+            let n = node as usize;
+            self.offsets[n] = total;
+            total += self.counts[n];
+        }
+
+        let total_items = total as usize;
+        if self.dists.len() < total_items {
+            self.dists.resize(total_items, 0);
+            self.lats.resize(total_items, 0);
+            self.source_indices.resize(total_items, 0);
+        }
+        if self.items.len() < total_items {
+            self.items.resize(
+                total_items,
+                Bucket2Entry {
+                    dist: 0,
+                    lat: 0,
+                    source_idx: 0,
+                },
+            );
+        }
+
+        // Sentinel offsets[n_nodes] = total
+        if let Some(last) = self.offsets.last_mut() {
+            *last = total;
+        }
+
+        // Per-node write cursor — reuse `counts` as cursor by zeroing then
+        // re-counting, mirroring `PrefixSumBuckets::build`.
+        for &node in &self.active_nodes {
+            self.counts[node as usize] = 0;
+        }
+        for &(node, src_idx, dist, lat) in raw_items {
+            let n = node as usize;
+            let pos = (self.offsets[n] + self.counts[n]) as usize;
+            self.dists[pos] = dist;
+            self.lats[pos] = lat;
+            self.source_indices[pos] = src_idx;
+            self.items[pos] = Bucket2Entry {
+                dist,
+                lat,
+                source_idx: src_idx,
+            };
+            self.counts[n] += 1;
+        }
+    }
+
+    #[inline]
+    fn get(&self, node: u32) -> &[Bucket2Entry] {
+        let n = node as usize;
+        if self.count_stamps[n] != self.current_stamp {
+            return &[];
+        }
+        let start = self.offsets[n] as usize;
+        let end = start + self.counts[n] as usize;
+        &self.items[start..end]
+    }
+}
+
+/// 2-channel search state — parallel to `SearchState` but with a `lats`
+/// array storing the length-along-time-shortest accumulator. Reads of
+/// `lats[node]` are valid only when `entries[node].version` matches
+/// `current_version` (i.e. when `dist` is current).
+struct SearchState2 {
+    entries: Vec<NodeEntry>,
+    lats: Vec<u32>,
+    current_version: u32,
+    heap: DAryHeap,
+    handles: Vec<u32>,
+    pushes: usize,
+    pops: usize,
+}
+
+impl SearchState2 {
+    fn new(n_nodes: usize, heap_capacity: usize) -> Self {
+        Self {
+            entries: vec![
+                NodeEntry {
+                    dist: u32::MAX,
+                    version: 0,
+                };
+                n_nodes
+            ],
+            lats: vec![u32::MAX; n_nodes],
+            current_version: 0,
+            heap: DAryHeap::new(heap_capacity),
+            handles: vec![INVALID_HANDLE; n_nodes],
+            pushes: 0,
+            pops: 0,
+        }
+    }
+
+    #[inline]
+    fn start_search(&mut self) {
+        self.current_version = self.current_version.wrapping_add(1);
+        if self.current_version == 0 {
+            for e in &mut self.entries {
+                e.dist = u32::MAX;
+                e.version = 0;
+            }
+            for h in &mut self.handles {
+                *h = INVALID_HANDLE;
+            }
+            self.current_version = 1;
+        }
+        self.heap.clear();
+    }
+
+    /// Relax with both `dist` (drives ordering) and `lat` (accumulates
+    /// alongside). When `dist` improves, both fields are updated. Returns
+    /// `true` if anything changed.
+    #[inline]
+    fn relax(&mut self, node: u32, dist: u32, lat: u32) -> bool {
+        let e = &mut self.entries[node as usize];
+
+        if e.version == self.current_version {
+            if dist < e.dist {
+                e.dist = dist;
+                self.lats[node as usize] = lat;
+                let handle = self.handles[node as usize];
+                if handle != INVALID_HANDLE && (handle as usize) < self.heap.size() {
+                    self.heap.decrease(handle, dist, node, &mut self.handles);
+                    self.pushes += 1;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        self.handles[node as usize] = INVALID_HANDLE;
+        e.dist = dist;
+        e.version = self.current_version;
+        self.lats[node as usize] = lat;
+        self.heap.push(dist, node, &mut self.handles);
+        self.pushes += 1;
+        true
+    }
+
+    /// Returns `(dist, lat, node)` for the next-min-dist node.
+    #[inline]
+    fn pop(&mut self) -> Option<(u32, u32, u32)> {
+        if let Some((dist, node)) = self.heap.pop(&mut self.handles) {
+            self.pops += 1;
+            self.handles[node as usize] = INVALID_HANDLE;
+            let lat = self.lats[node as usize];
+            return Some((dist, lat, node));
+        }
+        None
+    }
+}
+
+/// Forward search using flat UP adjacency for BOTH metrics. `up_adj_flat`
+/// and `up_adj_flat_lat` share the CCH topology — index `i` addresses
+/// the same edge in both. Reads time from the first, lat from the second.
+fn forward_fill_buckets_flat_lat(
+    up_adj_flat: &UpAdjFlat,
+    up_adj_flat_lat: &UpAdjFlat,
+    source_idx: u32,
+    source: u32,
+    state: &mut SearchState2,
+    bucket_items: &mut Vec<(u32, u32, u32, u32)>,
+) {
+    state.start_search();
+    state.relax(source, 0, 0);
+
+    while let Some((d, l, u)) = state.pop() {
+        bucket_items.push((u, source_idx, d, l));
+
+        let start = up_adj_flat.offsets[u as usize] as usize;
+        let end = up_adj_flat.offsets[u as usize + 1] as usize;
+        for i in start..end {
+            let v = up_adj_flat.targets[i];
+            let w_time = up_adj_flat.weights.get(i);
+            let w_lat = up_adj_flat_lat.weights.get(i);
+            let new_dist = d.saturating_add(w_time);
+            let new_lat = l.saturating_add(w_lat);
+            state.relax(v, new_dist, new_lat);
+        }
+    }
+}
+
+/// Backward search from target — joins buckets at the meeting node and
+/// writes BOTH the time-min and the lat-at-time-min into the output
+/// matrices. The meeting node is chosen by min-TIME; lat is reported at
+/// that node, not separately optimised.
+#[allow(clippy::too_many_arguments)]
+fn backward_join_prefix_lat(
+    down_rev_flat: &DownReverseAdjFlat,
+    down_rev_flat_lat: &DownReverseAdjFlat,
+    target: u32,
+    buckets: &PrefixSumBuckets2,
+    time_matrix: &mut [u32],
+    lat_matrix: &mut [u32],
+    n_targets: usize,
+    target_idx: usize,
+    state: &mut SearchState2,
+) -> (usize, usize) {
+    state.start_search();
+    state.relax(target, 0, 0);
+
+    let mut visited = 0usize;
+    let mut joins = 0usize;
+
+    while let Some((d, l, u)) = state.pop() {
+        visited += 1;
+
+        let bucket_entries = buckets.get(u);
+        for entry in bucket_entries {
+            let cell = entry.source_idx as usize * n_targets + target_idx;
+
+            let current_best_time = time_matrix[cell];
+            if current_best_time <= entry.dist {
+                // dist alone cannot improve the time; skip — lat is
+                // semantically tied to whichever (src, m, tgt) wins
+                // time, so we don't speculatively update it here.
+                continue;
+            }
+
+            let total_time = entry.dist.saturating_add(d);
+            if total_time < current_best_time {
+                time_matrix[cell] = total_time;
+                lat_matrix[cell] = entry.lat.saturating_add(l);
+            }
+            joins += 1;
+        }
+
+        let edge_start = down_rev_flat.offsets[u as usize] as usize;
+        let edge_end = down_rev_flat.offsets[u as usize + 1] as usize;
+        for i in edge_start..edge_end {
+            let x = down_rev_flat.sources[i];
+            let w_time = down_rev_flat.weights.get(i);
+            let w_lat = down_rev_flat_lat.weights.get(i);
+            let new_dist = d.saturating_add(w_time);
+            let new_lat = l.saturating_add(w_lat);
+            state.relax(x, new_dist, new_lat);
+        }
+    }
+
+    (visited, joins)
+}
+
+/// 2-channel bucket-M2M (#372). Mirrors `table_bucket_full_flat` but
+/// returns two matrices: time and length-along-time-shortest. The path
+/// chosen at every cell is the time-shortest one; the lat number
+/// belongs to that same path (no separate distance-shortest search).
+///
+/// `up_adj_flat` / `down_rev_flat` carry time weights; `_lat` variants
+/// carry length-along-time weights with the SAME topology (built by
+/// `state.rs` via `UpAdjFlat::build(&cch_topo, &cch_weights_lat)`).
+#[allow(clippy::too_many_arguments)]
+pub fn table_bucket_full_flat_lat(
+    n_nodes: usize,
+    up_adj_flat: &UpAdjFlat,
+    down_rev_flat: &DownReverseAdjFlat,
+    up_adj_flat_lat: &UpAdjFlat,
+    down_rev_flat_lat: &DownReverseAdjFlat,
+    sources: &[u32],
+    targets: &[u32],
+) -> (Vec<u32>, Vec<u32>, BucketM2MStats) {
+    let n_sources = sources.len();
+    let n_targets = targets.len();
+
+    let mut time_matrix = vec![u32::MAX; n_sources * n_targets];
+    let mut lat_matrix = vec![u32::MAX; n_sources * n_targets];
+
+    if n_sources == 0 || n_targets == 0 {
+        return (time_matrix, lat_matrix, BucketM2MStats::default());
+    }
+
+    let mut stats = BucketM2MStats {
+        n_sources,
+        n_targets,
+        ..Default::default()
+    };
+
+    let avg_visited = (n_nodes / 400).clamp(500, 20000);
+    let mut state = SearchState2::new(n_nodes, avg_visited);
+
+    let forward_start = std::time::Instant::now();
+    let mut bucket_items: Vec<(u32, u32, u32, u32)> = Vec::with_capacity(n_sources * avg_visited);
+    for (source_idx, &source) in sources.iter().enumerate() {
+        if source as usize >= n_nodes {
+            continue;
+        }
+        forward_fill_buckets_flat_lat(
+            up_adj_flat,
+            up_adj_flat_lat,
+            source_idx as u32,
+            source,
+            &mut state,
+            &mut bucket_items,
+        );
+    }
+    stats.forward_visited = bucket_items.len();
+    stats.forward_time_ms = forward_start.elapsed().as_millis() as u64;
+
+    let sort_start = std::time::Instant::now();
+    let mut buckets = PrefixSumBuckets2::new(n_nodes);
+    buckets.build(&bucket_items);
+    stats.sort_time_ms = sort_start.elapsed().as_millis() as u64;
+
+    let backward_start = std::time::Instant::now();
+    for (target_idx, &target) in targets.iter().enumerate() {
+        if target as usize >= n_nodes {
+            continue;
+        }
+        let (visited, joins) = backward_join_prefix_lat(
+            down_rev_flat,
+            down_rev_flat_lat,
+            target,
+            &buckets,
+            &mut time_matrix,
+            &mut lat_matrix,
+            n_targets,
+            target_idx,
+            &mut state,
+        );
+        stats.backward_visited += visited;
+        stats.join_operations += joins;
+    }
+    stats.backward_time_ms = backward_start.elapsed().as_millis() as u64;
+
+    stats.heap_pushes = state.pushes;
+    stats.heap_pops = state.pops;
+
+    (time_matrix, lat_matrix, stats)
+}
+
 #[cfg(test)]
 mod step_a_tests {
     use super::*;

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -90,7 +90,7 @@ pub struct ModeData {
     /// lands, /table /trip Flight matrix consumers will REQUIRE this
     /// — the loader will then fail boot if it's missing rather than
     /// silently falling back to the broken `cch_weights_dist`.
-    pub cch_weights_lat: Option<CchWeights>,
+    pub cch_weights_len_along_time: Option<CchWeights>,
     // ---- Server-only per-mode mapping sections (#153) -------------
     // These replace the build-time `OrderEbg` + `FilteredEbg` structs
     // on the serve path. They are loaded from the container's
@@ -159,10 +159,10 @@ pub struct ModeData {
     /// addresses the same CCH edge. Used by the 2-channel bucket-M2M
     /// alongside `up_adj_flat` to report distance along the
     /// time-shortest path.
-    pub up_adj_flat_lat: Option<UpAdjFlat>,
+    pub up_adj_flat_len_along_time: Option<UpAdjFlat>,
     /// Reverse DOWN flat carrying length-along-time weights. See
-    /// `up_adj_flat_lat`.
-    pub down_rev_flat_lat: Option<DownReverseAdjFlat>,
+    /// `up_adj_flat_len_along_time`.
+    pub down_rev_flat_len_along_time: Option<DownReverseAdjFlat>,
     // Cached exclude weight sets (keyed by exclude bitmask)
     pub exclude_cache: parking_lot::RwLock<HashMap<u8, std::sync::Arc<ExcludeWeights>>>,
 }
@@ -1541,7 +1541,7 @@ fn load_traffic_variant_mode_data(
         cch_topo: base.cch_topo.clone(),
         cch_weights,
         cch_weights_dist: base.cch_weights_dist.clone(),
-        cch_weights_lat: base.cch_weights_lat.clone(),
+        cch_weights_len_along_time: base.cch_weights_len_along_time.clone(),
         orig_to_rank: base.orig_to_rank.clone(),
         filtered_to_original: base.filtered_to_original.clone(),
         n_filtered_nodes: base.n_filtered_nodes,
@@ -1556,8 +1556,8 @@ fn load_traffic_variant_mode_data(
         up_adj_flat_dist: base.up_adj_flat_dist.clone(),
         down_rev_flat_dist: base.down_rev_flat_dist.clone(),
         down_adj_flat_dist: base.down_adj_flat_dist.clone(),
-        up_adj_flat_lat: base.up_adj_flat_lat.clone(),
-        down_rev_flat_lat: base.down_rev_flat_lat.clone(),
+        up_adj_flat_len_along_time: base.up_adj_flat_len_along_time.clone(),
+        down_rev_flat_len_along_time: base.down_rev_flat_len_along_time.clone(),
         exclude_cache: parking_lot::RwLock::new(HashMap::new()),
     })
 }
@@ -1629,7 +1629,7 @@ fn load_mode_data(
     // matrix endpoints switch to this for drivetime-consistent
     // distance reporting.
     let cch_lat_weights_path = step8_dir.join(format!("cch.lat.{}.u32", mode_name));
-    let cch_weights_lat = if cch_lat_weights_path.exists() {
+    let cch_weights_len_along_time = if cch_lat_weights_path.exists() {
         tracing::info!(mode = mode_name, "loading length-along-time weights");
         Some(CchWeightsFile::read(&cch_lat_weights_path)?)
     } else {
@@ -1639,14 +1639,8 @@ fn load_mode_data(
         );
         None
     };
-    let (up_adj_flat_lat, down_rev_flat_lat) = if let Some(ref lat) = cch_weights_lat {
-        (
-            Some(UpAdjFlat::build(&cch_topo, lat)),
-            Some(DownReverseAdjFlat::build(&cch_topo, lat)),
-        )
-    } else {
-        (None, None)
-    };
+    let (up_adj_flat_len_along_time, down_rev_flat_len_along_time) =
+        build_len_along_time_flats(&cch_topo, &cch_weights_len_along_time);
 
     // ---- Build server-only mappings (#153) ----------------------
     // The `--data-dir` path always synthesises these from the legacy
@@ -1669,7 +1663,7 @@ fn load_mode_data(
         cch_topo,
         cch_weights,
         cch_weights_dist,
-        cch_weights_lat,
+        cch_weights_len_along_time,
         orig_to_rank: crate::formats::ArcCow::from_vec(orig_to_rank),
         filtered_to_original: crate::formats::ArcCow::from_vec(filtered_to_original),
         n_filtered_nodes,
@@ -1684,8 +1678,8 @@ fn load_mode_data(
         up_adj_flat_dist,
         down_rev_flat_dist,
         down_adj_flat_dist,
-        up_adj_flat_lat,
-        down_rev_flat_lat,
+        up_adj_flat_len_along_time,
+        down_rev_flat_len_along_time,
         exclude_cache: parking_lot::RwLock::new(HashMap::new()),
     })
 }
@@ -1711,6 +1705,25 @@ fn load_mode_data(
 /// causing /route to 404 in one direction even though OSRM finds the
 /// route. Bike/foot are effectively undirected so they were unaffected
 /// in practice; car was 15.6 % broken on the Belgium correctness sweep.
+/// Shared #372 helper: build length-along-time flats from the optional
+/// `cch_weights_len_along_time`. Both `--data-dir` and container-mode
+/// loaders call this so the construction stays in lock-step. Returns
+/// `(None, None)` when weights are absent (old containers / pre-#377
+/// step8 outputs).
+fn build_len_along_time_flats(
+    cch_topo: &CchTopo,
+    cch_weights_len_along_time: &Option<CchWeights>,
+) -> (Option<UpAdjFlat>, Option<DownReverseAdjFlat>) {
+    if let Some(ref w) = *cch_weights_len_along_time {
+        (
+            Some(UpAdjFlat::build(cch_topo, w)),
+            Some(DownReverseAdjFlat::build(cch_topo, w)),
+        )
+    } else {
+        (None, None)
+    }
+}
+
 fn build_role_masks(filtered_ebg: &crate::formats::FilteredEbg) -> (Vec<u64>, Vec<u64>) {
     let n_orig = filtered_ebg.n_original_nodes as usize;
     let n_words = n_orig.div_ceil(64);
@@ -2696,7 +2709,7 @@ fn load_mode_data_from_bundle(
     // None and matrix endpoints fall back to cch_weights_dist
     // (broken metric, see #371 / #372). Once everyone repacks, this
     // becomes a hard load like weights.dist above.
-    let cch_weights_lat = {
+    let cch_weights_len_along_time = {
         let name = format!("mode/{}/weights.lat", mode_name);
         if let Some(entry) = container.get(&name) {
             let off = entry.offset as usize;
@@ -2719,21 +2732,15 @@ fn load_mode_data_from_bundle(
             None
         }
     };
-    let (up_adj_flat_lat, down_rev_flat_lat) = if let Some(ref lat) = cch_weights_lat {
-        (
-            Some(UpAdjFlat::build(&cch_topo, lat)),
-            Some(DownReverseAdjFlat::build(&cch_topo, lat)),
-        )
-    } else {
-        (None, None)
-    };
+    let (up_adj_flat_len_along_time, down_rev_flat_len_along_time) =
+        build_len_along_time_flats(&cch_topo, &cch_weights_len_along_time);
 
     Ok(ModeData {
         mode,
         cch_topo,
         cch_weights,
         cch_weights_dist,
-        cch_weights_lat,
+        cch_weights_len_along_time,
         orig_to_rank,
         filtered_to_original,
         n_filtered_nodes,
@@ -2748,8 +2755,8 @@ fn load_mode_data_from_bundle(
         up_adj_flat_dist,
         down_rev_flat_dist,
         down_adj_flat_dist,
-        up_adj_flat_lat,
-        down_rev_flat_lat,
+        up_adj_flat_len_along_time,
+        down_rev_flat_len_along_time,
         exclude_cache: parking_lot::RwLock::new(HashMap::new()),
     })
 }

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -480,58 +480,119 @@ pub async fn compute_table_bucket_m2m(
         (&mode_data.up_adj_flat_dist, &mode_data.down_rev_flat_dist)
     };
 
-    // Compute duration matrix if requested
-    let durations = if want_duration {
-        let t_dur = std::time::Instant::now();
-        let (matrix, _stats) = if use_parallel {
-            table_bucket_parallel(n_nodes, time_up, time_down, &sources_rank, &targets_rank)
-        } else {
-            table_bucket_full_flat(n_nodes, time_up, time_down, &sources_rank, &targets_rank)
-        };
-        tracing::debug!(
-            "compute_table_bucket_m2m: duration M2M took {:?} parallel={}",
-            t_dur.elapsed(),
-            use_parallel
-        );
+    // #372: when both duration and distance are requested AND the
+    // length-along-time flats are available (container shipped with
+    // cch.lat.<mode>.u32 from PR #379), use the 2-channel bucket-M2M.
+    // It produces both matrices in a single forward+backward pass with
+    // the time-shortest path's geometry — distance numbers correspond
+    // to the same path as the duration (matching /route's per-cell
+    // unpack semantics).
+    //
+    // Custom-weight paths (exclude/avoid) don't have length-along-time
+    // recustomisation yet; they fall back to the two-pass distance-
+    // shortest legacy below.
+    let use_2channel = want_duration
+        && want_distance
+        && custom_weights.is_none()
+        && mode_data.up_adj_flat_lat.is_some()
+        && mode_data.down_rev_flat_lat.is_some();
 
-        Some(flat_matrix_to_2d(
-            &matrix,
+    let (durations, distances) = if use_2channel {
+        let t_2ch = std::time::Instant::now();
+        let up_lat = mode_data
+            .up_adj_flat_lat
+            .as_ref()
+            .expect("guarded by use_2channel");
+        let dn_lat = mode_data
+            .down_rev_flat_lat
+            .as_ref()
+            .expect("guarded by use_2channel");
+        let (time_mat, lat_mat, _stats) = crate::matrix::bucket_ch::table_bucket_full_flat_lat(
+            n_nodes,
+            time_up,
+            time_down,
+            up_lat,
+            dn_lat,
+            &sources_rank,
+            &targets_rank,
+        );
+        tracing::debug!(
+            "compute_table_bucket_m2m: 2-channel M2M took {:?}",
+            t_2ch.elapsed(),
+        );
+        let dur = flat_matrix_to_2d(
+            &time_mat,
             n_sources,
             n_targets,
             &source_valid,
             &target_valid,
             neighbor_mask.as_deref(),
-            |v| v as f64, // already in seconds (post-#297)
-        ))
-    } else {
-        None
-    };
-
-    // Compute distance matrix if requested (independent shortest-distance metric)
-    let distances = if want_distance {
-        let t_dist = std::time::Instant::now();
-        let (matrix, _stats) = if use_parallel {
-            table_bucket_parallel(n_nodes, dist_up, dist_down, &sources_rank, &targets_rank)
-        } else {
-            table_bucket_full_flat(n_nodes, dist_up, dist_down, &sources_rank, &targets_rank)
-        };
-        tracing::debug!(
-            "compute_table_bucket_m2m: distance M2M took {:?} parallel={}",
-            t_dist.elapsed(),
-            use_parallel
+            |v| v as f64,
         );
-
-        Some(flat_matrix_to_2d(
-            &matrix,
+        let dist = flat_matrix_to_2d(
+            &lat_mat,
             n_sources,
             n_targets,
             &source_valid,
             &target_valid,
             neighbor_mask.as_deref(),
-            |v| v as f64, // already in meters (post-#297)
-        ))
+            |v| v as f64,
+        );
+        (Some(dur), Some(dist))
     } else {
-        None
+        // Legacy two-pass: separate distance-shortest CCH for `distance`.
+        let durations = if want_duration {
+            let t_dur = std::time::Instant::now();
+            let (matrix, _stats) = if use_parallel {
+                table_bucket_parallel(n_nodes, time_up, time_down, &sources_rank, &targets_rank)
+            } else {
+                table_bucket_full_flat(n_nodes, time_up, time_down, &sources_rank, &targets_rank)
+            };
+            tracing::debug!(
+                "compute_table_bucket_m2m: duration M2M took {:?} parallel={}",
+                t_dur.elapsed(),
+                use_parallel
+            );
+
+            Some(flat_matrix_to_2d(
+                &matrix,
+                n_sources,
+                n_targets,
+                &source_valid,
+                &target_valid,
+                neighbor_mask.as_deref(),
+                |v| v as f64,
+            ))
+        } else {
+            None
+        };
+
+        let distances = if want_distance {
+            let t_dist = std::time::Instant::now();
+            let (matrix, _stats) = if use_parallel {
+                table_bucket_parallel(n_nodes, dist_up, dist_down, &sources_rank, &targets_rank)
+            } else {
+                table_bucket_full_flat(n_nodes, dist_up, dist_down, &sources_rank, &targets_rank)
+            };
+            tracing::debug!(
+                "compute_table_bucket_m2m: distance M2M took {:?} parallel={}",
+                t_dist.elapsed(),
+                use_parallel
+            );
+
+            Some(flat_matrix_to_2d(
+                &matrix,
+                n_sources,
+                n_targets,
+                &source_valid,
+                &target_valid,
+                neighbor_mask.as_deref(),
+                |v| v as f64,
+            ))
+        } else {
+            None
+        };
+        (durations, distances)
     };
 
     let t_post_m2m = std::time::Instant::now();

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -494,31 +494,47 @@ pub async fn compute_table_bucket_m2m(
     let use_2channel = want_duration
         && want_distance
         && custom_weights.is_none()
-        && mode_data.up_adj_flat_lat.is_some()
-        && mode_data.down_rev_flat_lat.is_some();
+        && mode_data.up_adj_flat_len_along_time.is_some()
+        && mode_data.down_rev_flat_len_along_time.is_some();
 
     let (durations, distances) = if use_2channel {
         let t_2ch = std::time::Instant::now();
         let up_lat = mode_data
-            .up_adj_flat_lat
+            .up_adj_flat_len_along_time
             .as_ref()
             .expect("guarded by use_2channel");
         let dn_lat = mode_data
-            .down_rev_flat_lat
+            .down_rev_flat_len_along_time
             .as_ref()
             .expect("guarded by use_2channel");
-        let (time_mat, lat_mat, _stats) = crate::matrix::bucket_ch::table_bucket_full_flat_lat(
-            n_nodes,
-            time_up,
-            time_down,
-            up_lat,
-            dn_lat,
-            &sources_rank,
-            &targets_rank,
-        );
+        // Same parallel/sequential dispatch heuristic as single-channel
+        // table_bucket_*. The parallel 2-channel path uses thread-local
+        // SearchState2 and an AtomicU64 packed matrix.
+        let (time_mat, lat_mat, _stats) = if use_parallel {
+            crate::matrix::bucket_ch::table_bucket_parallel_len_along_time(
+                n_nodes,
+                time_up,
+                time_down,
+                up_lat,
+                dn_lat,
+                &sources_rank,
+                &targets_rank,
+            )
+        } else {
+            crate::matrix::bucket_ch::table_bucket_full_flat_len_along_time(
+                n_nodes,
+                time_up,
+                time_down,
+                up_lat,
+                dn_lat,
+                &sources_rank,
+                &targets_rank,
+            )
+        };
         tracing::debug!(
-            "compute_table_bucket_m2m: 2-channel M2M took {:?}",
+            "compute_table_bucket_m2m: 2-channel M2M took {:?} parallel={}",
             t_2ch.elapsed(),
+            use_parallel,
         );
         let dur = flat_matrix_to_2d(
             &time_mat,

--- a/route/src/server/trip.rs
+++ b/route/src/server/trip.rs
@@ -723,16 +723,34 @@ pub async fn trip_handler(
             (&mode_data.up_adj_flat_dist, &mode_data.down_rev_flat_dist)
         };
 
-        // Compute N*N duration matrix (for TSP optimization, always on time)
-        let (mut duration_matrix, _stats) =
-            table_bucket_full_flat(n_nodes, time_up, time_down, &ranks, &ranks);
+        // #372: if length-along-time flats are loaded AND no custom
+        // weights are in play, use the 2-channel bucket-M2M so that
+        // the distance reported per leg belongs to the same time-
+        // shortest path the duration is timed against. Falls back to
+        // the legacy two-pass distance-shortest path otherwise.
+        let use_2channel = want_distance
+            && avoid_entry.is_none()
+            && exclude_weights.is_none()
+            && mode_data.up_adj_flat_lat.is_some()
+            && mode_data.down_rev_flat_lat.is_some();
 
-        // Compute distance matrix if requested (for reporting leg distances)
-        let mut distance_matrix = if want_distance {
-            let (dist_mat, _) = table_bucket_full_flat(n_nodes, dist_up, dist_down, &ranks, &ranks);
-            Some(dist_mat)
+        let (mut duration_matrix, mut distance_matrix) = if use_2channel {
+            let up_lat = mode_data.up_adj_flat_lat.as_ref().unwrap();
+            let dn_lat = mode_data.down_rev_flat_lat.as_ref().unwrap();
+            let (dur_mat, lat_mat, _stats) = crate::matrix::bucket_ch::table_bucket_full_flat_lat(
+                n_nodes, time_up, time_down, up_lat, dn_lat, &ranks, &ranks,
+            );
+            (dur_mat, Some(lat_mat))
         } else {
-            None
+            let (dur_mat, _stats) =
+                table_bucket_full_flat(n_nodes, time_up, time_down, &ranks, &ranks);
+            let dist_mat = if want_distance {
+                let (m, _) = table_bucket_full_flat(n_nodes, dist_up, dist_down, &ranks, &ranks);
+                Some(m)
+            } else {
+                None
+            };
+            (dur_mat, dist_mat)
         };
 
         // K-best fallback for INF matrix cells (#197 matrix gap, same

--- a/route/src/server/trip.rs
+++ b/route/src/server/trip.rs
@@ -731,15 +731,16 @@ pub async fn trip_handler(
         let use_2channel = want_distance
             && avoid_entry.is_none()
             && exclude_weights.is_none()
-            && mode_data.up_adj_flat_lat.is_some()
-            && mode_data.down_rev_flat_lat.is_some();
+            && mode_data.up_adj_flat_len_along_time.is_some()
+            && mode_data.down_rev_flat_len_along_time.is_some();
 
         let (mut duration_matrix, mut distance_matrix) = if use_2channel {
-            let up_lat = mode_data.up_adj_flat_lat.as_ref().unwrap();
-            let dn_lat = mode_data.down_rev_flat_lat.as_ref().unwrap();
-            let (dur_mat, lat_mat, _stats) = crate::matrix::bucket_ch::table_bucket_full_flat_lat(
-                n_nodes, time_up, time_down, up_lat, dn_lat, &ranks, &ranks,
-            );
+            let up_lat = mode_data.up_adj_flat_len_along_time.as_ref().unwrap();
+            let dn_lat = mode_data.down_rev_flat_len_along_time.as_ref().unwrap();
+            let (dur_mat, lat_mat, _stats) =
+                crate::matrix::bucket_ch::table_bucket_full_flat_len_along_time(
+                    n_nodes, time_up, time_down, up_lat, dn_lat, &ranks, &ranks,
+                );
             (dur_mat, Some(lat_mat))
         } else {
             let (dur_mat, _stats) =


### PR DESCRIPTION
Step 4B of #372: the algorithm change. Adds a 2-channel bucket-M2M variant and wires `/table` to use it when `cch_weights_lat` is loaded.

## What it does

A single forward+backward Dijkstra propagates BOTH `dist` (time, drives ordering) AND `lat` (length-along-time, accumulates alongside). The path picked at every cell is the time-shortest one; the `lat` number is the physical length along that same path — matching what `/route` reports for the same coordinate pair.

## New in matrix/bucket_ch.rs (~400 LOC)

| Symbol | Purpose |
|---|---|
| `Bucket2Entry` | 12-byte (dist, lat, source_idx) |
| `PrefixSumBuckets2` | SoA bucket layout with parallel `lats` array |
| `SearchState2` | NodeEntry + parallel `Vec<u32> lats`; `relax()` takes both; `pop()` returns `(dist, lat, node)` |
| `forward_fill_buckets_flat_lat` | reads time from `up_adj_flat.weights` and lat from `up_adj_flat_lat.weights` at the SAME flat index |
| `backward_join_prefix_lat` | meeting node chosen by **min-time**; lat recorded at that meeting node, NOT separately optimised |
| `table_bucket_full_flat_lat` | public sequential API returning `(time_matrix, lat_matrix, stats)` |

No impact on existing single-channel functions — fully forked.

## /table wiring

When all four conditions hold:
- `want_duration`
- `want_distance`
- `custom_weights.is_none()` (no exclude/avoid)
- `mode_data.up_adj_flat_lat.is_some()` and `down_rev_flat_lat.is_some()`

`/table` dispatches to `table_bucket_full_flat_lat` and produces both matrices in one pass. Otherwise it falls back to the legacy two-pass distance-shortest path.

Custom-weight paths (exclude/avoid) still use the legacy fallback — their length-along-time recustomisation is a separate follow-up.

## Pre-repack behaviour

The existing Belgium container shipped before this stack; `cch_weights_lat` loads as `None`, so `/table` falls through to the legacy 2-pass. **No behaviour change today.** Once Belgium step8 runs through PR #377 and the container is repacked, the new code path activates.

## Verified

- `cargo test -p butterfly-route --release --lib` → 598 passed, 0 failed
- `cargo clippy -p butterfly-route --lib` clean
- Belgium serve with pre-PR #377 container: `/route` returns 6740 s / 57693 m unchanged; `/table` cells unchanged
- Tire-kicker (Belgium): all REST + Flight PASS (LU failures expected for Belgium-only setup)

## Follow-ups (separate PRs)

- Belgium pipeline rerun + container repack (in progress as I write this)
- Correctness verification: `/table` cell distance must match `/route` distance byte-identically across diverse pairs (Aalst–Charleroi currently shows 142 km vs /route's 161 km — that gap closes with repack)
- Timing measurement: `/table` 100×100 + 1000×1000 HTTP wall (2-channel adds memory bandwidth; need to verify no regression beyond the 549 ms baseline from #370)
- `/trip` + Flight matrix consumers switch to 2-channel
- Drop `cch_weights_dist` once nothing reads it