### PR TITLE
review: address Copilot feedback on #382/#383

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 For detailed tool-specific changes, see individual tool changelogs:
 - [butterfly-dl](./tools/butterfly-dl/CHANGELOG.md) - OSM data downloader
 
-## [Unreleased] — 2026-05-27 — Drivetime distance consistency (2-channel bucket-M2M)
+## [Unreleased]
+
+### 2026-05-27 — Drivetime distance consistency (2-channel bucket-M2M)
 
 Closed #371/#372 — the matrix endpoints (`/table`, `/trip`, Flight)
 now report distance values that belong to the SAME path as the
@@ -23,13 +25,11 @@ semantically consistent AND faster than the broken legacy.
 
 | state | latency | distance metric |
 |---|---:|---|
-| Pre-#372 legacy 2-pass (single-channel time + single-channel dist) | 549 ms | wrong (distance-shortest CCH, different geometric path) |
-| 2-channel sequential | 5408 ms | correct |
-| 2-channel parallel, unconditional fetch_min | 817–876 ms | correct |
-| **2-channel parallel + bound-pruned CAS loop (shipped)** | **459 ms** | **correct (matches /route to within 0.45 % u32 rounding)** |
+| Pre-#372 legacy 2-pass | 549 ms | wrong (distance-shortest CCH, different geometric path) |
+| **Shipped: 2-channel + target-owned local columns** | **379 ms** | **correct (matches /route to within 0.45 % u32 rounding)** |
 | OSRM CH reference (HTTP wall) | 684 ms | — |
 
-Butterfly is now **1.49× faster than OSRM** at 1000×1000 with the
+Butterfly is now **1.81× faster than OSRM** at 1000×1000 with the
 correct drivetime distance metric.
 
 ### Correctness sweep (4 Belgium pairs)
@@ -110,20 +110,15 @@ geometry sum.
   was reported for a path geometry different from every other
   endpoint. Requests now return 400.
 
-### PRs landing this sprint
+### PRs
 
-| PR | Title |
-|---|---|
-| #373 | fix(isochrone): #371 remove distance_m (isodistance) parameter |
-| #377 | feat(customize): #371/#372 emit cch.lat.<mode>.u32 alongside cch.d |
-| #378 | feat(state): #372 load cch.lat.<mode>.u32 into ModeData.cch_weights_lat |
-| #379 | feat(pack): #372 bundle cch.lat.<mode>.u32 into container as CchWeightsLat section |
-| #380 | feat(state): #372 build up_adj_flat_lat / down_rev_flat_lat at boot |
-| #381 | feat(matrix,table): #372 2-channel bucket-M2M — time + length-along-time |
-
-Plus the post-merge cleanups (rename `lat` → `len_along_time` in
-Rust identifiers per Copilot review on #380; CAS-loop replaces
-fetch_min per codex consult — both squashed into #381).
+- #373 fix(isochrone): #371 remove `distance_m` (isodistance) parameter
+- #377 feat(customize): #371/#372 emit `cch.lat.<mode>.u32` alongside `cch.d`
+- #378 feat(state): #372 load `cch.lat.<mode>.u32` into `ModeData.cch_weights_len_along_time`
+- #379 feat(pack): #372 bundle `cch.lat.<mode>.u32` into container as `CchWeightsLat` section
+- #380 feat(state): #372 build `up_adj_flat_len_along_time` / `down_rev_flat_len_along_time` at boot
+- #381 feat(matrix,table): #372 2-channel bucket-M2M (time + length-along-time)
+- #383 perf(matrix): #372 target-owned local columns — eliminate `AtomicU64` in 2-channel backward
 
 ### Known follow-up
 
@@ -132,7 +127,7 @@ fetch_min per codex consult — both squashed into #381).
   in play. Once the exclude/avoid recustomiser also computes
   length-along-time, drop the dist plumbing entirely.
 
-## [Unreleased] — 2026-05-26 — Lazy snap escalation + isodistance removal
+### 2026-05-26 — Lazy snap escalation + isodistance removal
 
 Closed the OSRM gap on the headline `/route` endpoint and pushed `/table`
 ahead of OSRM on the HTTP wall, all by deferring the K=64 candidate
@@ -216,7 +211,7 @@ beats it on the tail (16 ms vs OSRM 33 ms max).
   edition-2024 rustfmt; 4 `needless_option_as_deref` warnings
   collapsed in `way_names_idx` test code.
 
-## [Unreleased] — 2026-05-26 — Disk/RAM codec sprint
+### 2026-05-26 — Disk/RAM codec sprint
 
 End-to-end disk + RAM reduction sweep landed across nine PRs. Belgium
 packed container shrank from 16.06 GiB to 12.87 GiB (**−20%**) with
@@ -301,7 +296,7 @@ no query-latency regression. Cumulative Europe-scale projection at
   (PR #363, #364) collapses 13 lints into idiomatic forms with no
   behaviour change.
 
-## [Unreleased] — 2026-05-23
+### 2026-05-23
 
 ### Added
 
@@ -423,7 +418,7 @@ no query-latency regression. Cumulative Europe-scale projection at
 - `/table` with `avoid_polygons`, warm cache hit: **22 ms** (was
   366 ms before the `Arc<AvoidEntry>` return).
 
-## [Unreleased] — 2026-04-14
+### 2026-04-14
 
 ### Changed
 

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -4207,12 +4207,20 @@ fn backward_join_local_columns_len_along_time(
                 continue;
             }
             let total_time = entry.dist.saturating_add(d);
-            if total_time >= cur_time {
+            if total_time > cur_time {
                 continue;
             }
-            time_col[src] = total_time;
-            lat_col[src] = entry.lat.saturating_add(l);
-            joins += 1;
+            let total_lat = entry.lat.saturating_add(l);
+            // Lexicographic (time, lat) tie-break matches the prior
+            // packed-AtomicU64 fetch_min semantics: on equal time,
+            // smaller lat wins. Keeps /table output deterministic
+            // across runs and consistent with the pre-target-owned
+            // implementation.
+            if total_time < cur_time || total_lat < lat_col[src] {
+                time_col[src] = total_time;
+                lat_col[src] = total_lat;
+                joins += 1;
+            }
         }
 
         let edge_start = down_rev_flat.offsets[u as usize] as usize;
@@ -4312,18 +4320,23 @@ pub fn table_bucket_parallel_len_along_time(
     // ---- Backward phase: target-owned local columns (no atomics) ----
     //
     // Each target's backward Dijkstra writes its own (n_sources)-sized
-    // time + lat columns. Because every cell (src, tgt) is touched by
-    // exactly ONE target's backward run, we don't need any cross-thread
-    // synchronisation on writes — plain branch+store on a thread-local
-    // `Vec<u32>` instead of locked CAS on a shared `AtomicU64`. Codex
-    // consult flagged this as the next lever past the bound-pruned CAS.
+    // time + lat columns. Every cell (src, tgt) is touched by exactly
+    // one target's backward run, so no cross-thread synchronisation
+    // on writes is needed — plain branch+store on a local Vec<u32>
+    // instead of locked CAS on a shared AtomicU64.
     //
     // After parallel collection we gather the columns into the final
     // row-major matrices.
     let backward_start = std::time::Instant::now();
 
-    type ColumnPair = (usize, Vec<u32>, Vec<u32>, usize, usize);
-    let columns: Vec<ColumnPair> = targets
+    struct ColumnResult {
+        target_idx: usize,
+        time_col: Vec<u32>,
+        lat_col: Vec<u32>,
+        visited: usize,
+        joins: usize,
+    }
+    let columns: Vec<ColumnResult> = targets
         .par_iter()
         .enumerate()
         .filter(|&(_, target)| (*target as usize) < n_nodes)
@@ -4347,28 +4360,41 @@ pub fn table_bucket_parallel_len_along_time(
                     &mut lat_col,
                     state,
                 );
-                (target_idx, time_col, lat_col, visited, joins)
+                ColumnResult {
+                    target_idx,
+                    time_col,
+                    lat_col,
+                    visited,
+                    joins,
+                }
             })
         })
         .collect();
 
     let mut total_visited = 0usize;
     let mut total_joins = 0usize;
-    for (_, _, _, v, j) in &columns {
-        total_visited += *v;
-        total_joins += *j;
+    for c in &columns {
+        total_visited += c.visited;
+        total_joins += c.joins;
     }
     stats.backward_visited = total_visited;
     stats.join_operations = total_joins;
     stats.backward_time_ms = backward_start.elapsed().as_millis() as u64;
 
     // ---- Gather columns into row-major matrices ----
+    //
+    // Source-major outer loop, column inner loop: each iteration writes
+    // a contiguous run of n_targets cells (one full row), so the row-
+    // major output is touched in stride-1 order. This is significantly
+    // friendlier on L1/L2 than the prior target-major iteration which
+    // wrote each cell at stride `n_targets`.
     let mut time_matrix = vec![u32::MAX; n_sources * n_targets];
     let mut lat_matrix = vec![u32::MAX; n_sources * n_targets];
-    for (target_idx, time_col, lat_col, _, _) in columns {
-        for src in 0..n_sources {
-            time_matrix[src * n_targets + target_idx] = time_col[src];
-            lat_matrix[src * n_targets + target_idx] = lat_col[src];
+    for src in 0..n_sources {
+        let row_off = src * n_targets;
+        for c in &columns {
+            time_matrix[row_off + c.target_idx] = c.time_col[src];
+            lat_matrix[row_off + c.target_idx] = c.lat_col[src];
         }
     }
 


### PR DESCRIPTION
Addresses inline Copilot review on #382 (CHANGELOG) and #383 (matrix code).

## bucket_ch.rs

- **Tie-break fix**: the local-columns variant updated only on `total_time < cur_time` (strict). The prior packed-u64 `fetch_min` picked smaller `(time, lat)` lexicographically — equal time still wins on smaller lat. Restored. Without this, /table cells with multiple time-equal paths could keep the first-seen lat instead of the smallest.
- **ColumnPair → ColumnResult struct**: 5-tuple replaced with named fields.
- **Cache-friendly gather**: source-major outer loop, columns inner — each iteration now writes a contiguous run of `n_targets` cells (one row) in stride-1 order.
- **Comment cleanup**: removed tool-specific narrative ("codex consult", benchmark notes), replaced with neutral rationale.

## CHANGELOG.md

- Consolidated four sibling `## [Unreleased] — DATE` headings into one `## [Unreleased]` with `### DATE — TITLE` subsections (Keep a Changelog convention).
- Trimmed the 2026-05-27 sprint table to shipped vs reference rows.
- Refreshed /table 1000×1000 latency 459 → 379 ms after #383 landed.
- Added #383 to the PR list.

## Verification

- 598 lib tests pass
- clippy clean
- Belgium /table cell Aalst→Charleroi still 160826 m (unchanged from #383)