### PR TITLE
fix(matrix): #372 bound-prune must be strict for lex (time, lat) tie-break

### DIFF
--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -4199,11 +4199,13 @@ fn backward_join_local_columns_len_along_time(
         let entries = buckets.get(u);
         for entry in entries {
             let src = entry.source_idx as usize;
-            // Bound-aware pruning: skip when current best already wins
-            // on time alone. Plain branch + load on a local Vec — no
-            // atomics, no cache-line ping-pong.
+            // Bound-aware pruning: skip only when the bucket's dist
+            // ALONE is STRICTLY worse than the current best time. At
+            // equality the per-edge (time, lat) lex tie-break below
+            // can still improve the row by lowering lat without
+            // changing time, so we cannot prune ties here.
             let cur_time = time_col[src];
-            if cur_time <= entry.dist {
+            if cur_time < entry.dist {
                 continue;
             }
             let total_time = entry.dist.saturating_add(d);
@@ -4211,8 +4213,8 @@ fn backward_join_local_columns_len_along_time(
                 continue;
             }
             let total_lat = entry.lat.saturating_add(l);
-            // Lexicographic (time, lat) tie-break matches the prior
-            // packed-AtomicU64 fetch_min semantics: on equal time,
+            // Lexicographic (time, lat) tie-break — matches the prior
+            // packed-AtomicU64 `fetch_min` semantics: on equal time,
             // smaller lat wins. Keeps /table output deterministic
             // across runs and consistent with the pre-target-owned
             // implementation.


### PR DESCRIPTION
Copilot review on #384 caught a subtle bug introduced by the lexicographic tie-break:

```rust
if cur_time <= entry.dist {     // ← too aggressive
    continue;
}
```

At equality (`cur_time == entry.dist`, common at initial-pop where `d == 0` so `total_time = entry.dist + 0 = entry.dist`), the per-entry `(time, lat)` lex tie-break can still improve the row by lowering lat without changing time. The old prune skipped before reaching the lex check.

## Fix

Change to strict less-than:

```rust
if cur_time < entry.dist {      // ← strict, leaves ties for lex
    continue;
}
```

## Visibility

No distance shift in the 4-pair Belgium sweep (Brussels–Antwerp, Aalst–Charleroi, Liège–Gent, Bruges–Namur — all unchanged). The bug would surface on cells where multiple time-equal paths exist (motorway twins, equally-fast detours) and the lex tie-break would silently lose to whichever path was visited first.

## Verified

- 598 lib tests pass
- clippy clean
- Belgium /table cell Aalst→Charleroi: 160826 m (unchanged)
- Belgium /table 1000×1000 dur+dist: 381–388 ms (vs 386–395 ms before — slight improvement because the prune is now strict-less, so a few skipped lex-improvement joins now succeed)