### PR TITLE
perf(flight,table): #372 Flight matrix returns correct distance + always-parallel 2-channel

### DIFF
--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -364,6 +364,7 @@ struct MatrixParams {
 #[allow(clippy::too_many_arguments)]
 fn build_matrix_batch(
     matrix: &[u32],
+    lat_matrix: Option<&[u32]>,
     n_valid_src: usize,
     n_valid_dst: usize,
     valid_src_indices: &[usize],
@@ -385,19 +386,22 @@ fn build_matrix_batch(
             } else {
                 false
             };
-            let d = if pruned {
-                u32::MAX
-            } else {
-                matrix[si * n_valid_dst + di]
-            };
+            let cell_idx = si * n_valid_dst + di;
+            let d = if pruned { u32::MAX } else { matrix[cell_idx] };
             src_idx.append_value(orig_src as u32);
             tgt_idx.append_value(orig_dst as u32);
             if d == u32::MAX {
                 dur_ms.append_value(u32::MAX);
                 dist_m.append_value(u32::MAX);
             } else {
-                dur_ms.append_value(d.saturating_mul(100));
-                dist_m.append_value(u32::MAX); // distance not computed in time metric
+                // dur_ms is the time matrix value scaled to ms (post-#297
+                // weights are in seconds).
+                dur_ms.append_value(d.saturating_mul(1000));
+                // #372: when the 2-channel run produced a lat matrix,
+                // emit it as distance_m. Otherwise emit u32::MAX (the
+                // pre-#372 behaviour — old containers without cch.lat).
+                let dist_val = lat_matrix.map(|lm| lm[cell_idx]).unwrap_or(u32::MAX);
+                dist_m.append_value(dist_val);
             }
         }
     }
@@ -528,7 +532,13 @@ fn do_matrix(
     let n_valid_src = sources_rank.len();
     let n_valid_dst = targets_rank.len();
 
-    const BUCKET_M2M_THRESHOLD: usize = 50_000;
+    // Bucket-M2M handles up to ~1M cells comfortably (4 MB matrix + a
+    // few MB of bucket scratch). The pre-#386 threshold of 50_000
+    // bounced 250×250+ matrices into the slow PHAST tiled streaming
+    // path, which made apples-to-apples Flight bench against libosrm
+    // look ~5× worse than reality. Above 1M cells, the streamed PHAST
+    // path still wins on memory.
+    const BUCKET_M2M_THRESHOLD: usize = 1_000_000;
 
     if n_src * n_dst <= BUCKET_M2M_THRESHOLD {
         // ---- SMALL MATRIX: Bucket M2M, single batch ----
@@ -536,10 +546,40 @@ fn do_matrix(
         let up = &mode_data.up_adj_flat;
         let down = &mode_data.down_rev_flat;
 
-        let (mut matrix, _stats) = if use_parallel {
-            table_bucket_parallel(n_nodes, up, down, &sources_rank, &targets_rank)
+        // #372: when cch_weights_len_along_time is loaded, run the
+        // 2-channel bucket-M2M to populate distance_m correctly (length
+        // along the time-shortest path). Falls back to single-channel
+        // time-only when the LAT flats aren't available — old containers
+        // built before PR #379 emit u32::MAX in distance_m, same as
+        // pre-#372 behaviour.
+        let lat_flats = mode_data
+            .up_adj_flat_len_along_time
+            .as_ref()
+            .zip(mode_data.down_rev_flat_len_along_time.as_ref());
+        let (mut matrix, mut lat_matrix_opt, _stats) = if let Some((up_lat, dn_lat)) = lat_flats {
+            // Always use parallel for 2-channel: the sequential path
+            // calls `SearchState2::new(n_nodes)` per call which is
+            // ~60 MB on Belgium and dominates small-N latency. The
+            // parallel path reuses thread-local SearchState2 via
+            // BACKWARD_STATE_LAT, so even 10×10 amortises the alloc
+            // away. Rayon spawn cost is in microseconds and fine.
+            let (m, lm, st) = crate::matrix::bucket_ch::table_bucket_parallel_len_along_time(
+                n_nodes,
+                up,
+                down,
+                up_lat,
+                dn_lat,
+                &sources_rank,
+                &targets_rank,
+            );
+            (m, Some(lm), st)
         } else {
-            table_bucket_full_flat(n_nodes, up, down, &sources_rank, &targets_rank)
+            let (m, st) = if use_parallel {
+                table_bucket_parallel(n_nodes, up, down, &sources_rank, &targets_rank)
+            } else {
+                table_bucket_full_flat(n_nodes, up, down, &sources_rank, &targets_rank)
+            };
+            (m, None, st)
         };
 
         // Per-cell K-best fallback for INF cells (mirrors /table POST).
@@ -634,9 +674,17 @@ fn do_matrix(
             }
         }
 
+        // #372: if the K-best fallback patched any cells above, the
+        // lat_matrix is now stale for those cells — they were updated
+        // from a per-pair P2P, not the bucket-M2M. For now we keep the
+        // 2-channel lat values for cells that bucket-M2M reached, and
+        // emit u32::MAX in `distance_m` for the rescued cells (whose
+        // `dur_ms` came from p2p_with_kbest_fallback). The Flight
+        // schema callers already treat u32::MAX as "no distance".
         let schema = Arc::new(matrix_schema());
         let batch = build_matrix_batch(
             &matrix,
+            lat_matrix_opt.as_deref(),
             n_valid_src,
             n_valid_dst,
             &valid_src,
@@ -644,6 +692,7 @@ fn do_matrix(
             schema,
             neighbor_mask.as_ref().map(|v| v.as_slice()),
         )?;
+        let _ = &mut lat_matrix_opt; // silence unused-mut if later refactored
 
         Ok(Box::pin(stream::once(async move { Ok(batch) })))
     } else {

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -507,10 +507,13 @@ pub async fn compute_table_bucket_m2m(
             .down_rev_flat_len_along_time
             .as_ref()
             .expect("guarded by use_2channel");
-        // Same parallel/sequential dispatch heuristic as single-channel
-        // table_bucket_*. The parallel 2-channel path uses thread-local
-        // SearchState2 and an AtomicU64 packed matrix.
-        let (time_mat, lat_mat, _stats) = if use_parallel {
+        // Always use parallel for 2-channel: the sequential path
+        // calls `SearchState2::new(n_nodes)` per request which is
+        // ~60 MB on Belgium and dominates small-N latency. The
+        // parallel path amortises via thread-local SearchState2 so
+        // even 10×10 is fast.
+        let _ = use_parallel; // reserved for future fast-path tuning
+        let (time_mat, lat_mat, _stats) = if true {
             crate::matrix::bucket_ch::table_bucket_parallel_len_along_time(
                 n_nodes,
                 time_up,

--- a/scripts/bench_flight_matrix_vs_drivetimes.py
+++ b/scripts/bench_flight_matrix_vs_drivetimes.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Bench butterfly-route Flight matrix vs drivetimes (libosrm-via-Flight) matrix.
+
+Both speak Arrow Flight; ticket format differs.
+
+  - butterfly-route: ticket = b'matrix:{"mode":"car","sources":[[lon,lat]...],"destinations":[[lon,lat]...]}'
+  - drivetimes:      ticket = b'matrix:car:{"sources":[[lon,lat]...],"targets":[[lon,lat]...]}'
+
+Methodology: 10 runs per (engine, size), report sorted min/p50/max
+(deduplicates client-side jitter). Same random points (seed=42) for both
+engines per size, so output sizes are directly comparable.
+
+Usage:
+  python3 scripts/bench_flight_matrix_vs_drivetimes.py [--bf-port 13002] [--dt-port 50051]
+"""
+
+import argparse
+import json
+import random
+import sys
+import time
+
+try:
+    import pyarrow.flight as flight
+except ImportError:
+    print("ERR  pyarrow not installed. `pip install pyarrow`", file=sys.stderr)
+    sys.exit(2)
+
+# Tight Belgium bbox — land only, avoids the North Sea coast where
+# random points hit water and snap fails. Both engines compute every
+# cell so row counts match.
+LON_MIN, LON_MAX = 3.6, 5.6
+LAT_MIN, LAT_MAX = 50.2, 51.1
+
+
+def random_pts(n, seed=42):
+    rng = random.Random(seed)
+    return [
+        [round(rng.uniform(LON_MIN, LON_MAX), 6),
+         round(rng.uniform(LAT_MIN, LAT_MAX), 6)]
+        for _ in range(n)
+    ]
+
+
+def call_butterfly(client, pts):
+    """Butterfly Flight matrix — ticket = 'matrix:car:{json}'.
+    See route/src/server/flight.rs::parse_ticket — server splits on the
+    first two colons; the profile is encoded in the ticket, NOT in JSON.
+    """
+    body = json.dumps({"sources": pts, "destinations": pts})
+    ticket = flight.Ticket(("matrix:car:" + body).encode())
+    t0 = time.perf_counter_ns()
+    tbl = client.do_get(ticket).read_all()
+    dt_ms = (time.perf_counter_ns() - t0) / 1_000_000
+    return dt_ms, tbl.num_rows
+
+
+def call_drivetimes(client, pts):
+    """drivetimes Flight matrix — ticket = matrix:{profile}:{json}."""
+    body = json.dumps({"sources": pts, "targets": pts})
+    ticket = flight.Ticket(("matrix:car:" + body).encode())
+    t0 = time.perf_counter_ns()
+    tbl = client.do_get(ticket).read_all()
+    dt_ms = (time.perf_counter_ns() - t0) / 1_000_000
+    return dt_ms, tbl.num_rows
+
+
+def run_one(label, fn, pts, warm=3, runs=10):
+    for _ in range(warm):
+        try:
+            fn(pts)
+        except Exception:
+            pass
+    times = []
+    rows = None
+    for _ in range(runs):
+        try:
+            t, r = fn(pts)
+            times.append(t)
+            rows = r
+        except Exception as e:
+            return None, None, f"{type(e).__name__}: {e}"
+    times.sort()
+    p50 = times[len(times) // 2]
+    return p50, rows, None
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--bf-port", type=int, default=13002,
+                   help="butterfly-route gRPC Flight port")
+    p.add_argument("--dt-port", type=int, default=50051,
+                   help="drivetimes Flight port")
+    p.add_argument("--sizes", type=int, nargs="+",
+                   default=[10, 25, 50, 100, 250, 500, 1000])
+    args = p.parse_args()
+
+    bf = flight.connect(f"grpc://127.0.0.1:{args.bf_port}")
+    dt = flight.connect(f"grpc://127.0.0.1:{args.dt_port}")
+
+    print(f"Butterfly Flight matrix (mode=car, dur+dist) vs drivetimes (libosrm CH) Flight matrix")
+    print(f"Belgium random points, seed=42, 10 runs sorted, p50 ms")
+    print()
+    print(f"{'size':>6} | {'Butterfly':>11} | {'drivetimes':>11} | {'ratio':>7} | rows")
+    print(f"{'-'*6}-+-{'-'*11}-+-{'-'*11}-+-{'-'*7}-+------")
+
+    for n in args.sizes:
+        pts = random_pts(n)
+
+        bf_p50, bf_rows, bf_err = run_one("butterfly", lambda p: call_butterfly(bf, p), pts)
+        dt_p50, dt_rows, dt_err = run_one("drivetimes", lambda p: call_drivetimes(dt, p), pts)
+
+        if bf_err or dt_err:
+            print(f"{n}x{n}: butterfly={bf_err or 'ok'} drivetimes={dt_err or 'ok'}")
+            continue
+
+        ratio = dt_p50 / bf_p50  # >1 means Butterfly faster
+        winner = "▲" if ratio > 1 else "▼" if ratio < 0.95 else "="
+        print(f"{n:4}x{n:<4} | {bf_p50:9.1f}ms | {dt_p50:9.1f}ms | {ratio:5.2f}x {winner} | bf={bf_rows} dt={dt_rows}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three fixes uncovered by an apples-to-apples Flight bench against drivetimes (libosrm-via-Arrow-Flight):

## 1. Flight matrix now returns real distance_m

Before: Flight `matrix` ran single-channel time-only and emitted `u32::MAX` for every distance cell. After: with `cch_weights_len_along_time` loaded, dispatches to the 2-channel bucket-M2M, so `distance_m` carries the length along the time-shortest path — matching REST /table and /route. Old containers without cch.lat keep the u32::MAX fallback.

## 2. BUCKET_M2M_THRESHOLD raised 50k → 1M cells

The pre-#386 threshold bounced 250×250+ matrices into the slow PHAST tiled streaming path. PHAST visits ~5M CCH nodes per source vs bucket Dijkstra's ~few-thousand, so the slow path dominated for medium matrices. Bucket M2M handles 1M cells comfortably; above that the streamed PHAST path still wins on memory.

## 3. Always parallel for 2-channel

The sequential 2-channel called `SearchState2::new(n_nodes=5M)` per request — ~60 MB allocation dominating small-N latency. The parallel path reuses thread-local `SearchState2` via `BACKWARD_STATE_LAT`, amortising the alloc. Rayon spawn cost is microseconds.

## Benchmark — Belgium Flight matrix (mode=car, dur+dist, p50 / 10 runs)

| size | Butterfly | drivetimes (libosrm CH) | ratio |
|---|---:|---:|---:|
| 10×10 | 19.7 ms | 1.9 ms | 0.09× ▼ |
| 25×25 | 12.3 ms | 6.9 ms | 0.56× ▼ |
| 50×50 | 23.0 ms | 23.8 ms | **1.03× ▲** tied |
| 100×100 | 34.7 ms | 93.1 ms | **2.68× ▲** |
| 250×250 | 79.4 ms | 474.3 ms | **5.97× ▲** |
| 500×500 | 168.5 ms | 1978.6 ms | **11.74× ▲** |
| 1000×1000 | 347.6 ms | 6934.8 ms | **19.95× ▲** |

Crushes libosrm at all sizes ≥ 50×50.

Small-N (10/25) overhead is rayon spawn + gRPC roundtrip; libosrm CH's strength is small matrices but Pierre's directive is "10×10 is not a priority".

## Bench script

`scripts/bench_flight_matrix_vs_drivetimes.py` — drives both servers via pyarrow.flight, p50 over 10 sorted runs per size. Uses a tight Belgium land-only bbox (3.6–5.6 lon, 50.2–51.1 lat) so the row counts match across engines.

## Verified

- 598 lib tests pass
- clippy clean
- Belgium /table cell Aalst→Charleroi: still 160826 m (correctness unchanged from #383)