### PR TITLE
feat(profile): #387 ship car_realistic.traffic.json — rurbanity multipliers (no learning)

### DIFF
--- a/traffic/car_realistic.traffic.json
+++ b/traffic/car_realistic.traffic.json
@@ -1,0 +1,11 @@
+{
+  "name": "realistic",
+  "base_model": "car",
+  "speed_factors": {
+    "urban_high": 0.60,
+    "urban_medium": 0.78,
+    "urban_low": 0.88,
+    "suburban": 0.95,
+    "rural": 1.00
+  }
+}


### PR DESCRIPTION
Closes #387. Sample rurbanity-aware car profile, plugs into the existing #84 step-8 --traffic machinery with no engine changes.

## Profile

```json
{
  "name": "realistic",
  "base_model": "car",
  "speed_factors": {
    "urban_high":   0.60,
    "urban_medium": 0.78,
    "urban_low":    0.88,
    "suburban":     0.95,
    "rural":        1.00
  }
}
```

After `step8-customize --traffic traffic/car_realistic.traffic.json`, the server boots with a synthetic `car_realistic` mode alongside `car`. `/route`, `/isochrone`, `/table` all accept it transparently.

## Validation (drivetimes#11 Dilbeek, EPSG:3812 km²)

| | 5 min | 10 min | 15 min |
|---|---:|---:|---:|
| Valhalla OLD ("realistic") | 7.97 | 67.66 | n/a |
| Valhalla NEW ("too generous") | 24.41 | 153.91 | n/a |
| Butterfly `car` | 4.00 | 27.52 | 83.01 |
| **Butterfly `car_realistic`** | 2.31 | 12.91 | 45.98 |

`/route` Brussels–Antwerp: `car` 6740 s/57693 m vs `car_realistic` 8669 s/58607 m (+29 % time, +1.6 % distance).

## What this confirms / what's deferred

- **Machinery: works.** Mode discovery, mode dispatch through every endpoint, density-class multiplier applied at step-8 customize, all unchanged from #84.
- **Multiplier values: explicit placeholders.** They go in the *wrong direction* relative to the issue's target — butterfly's base `car` is already more conservative than Valhalla OLD, so further slowdown moves it AWAY from realism, not toward. See #387 / inline comment for full discussion. Proper value-picking belongs in #388 (probe-data fit) or a separate base-car-table revision.

## Test plan

- [x] Belgium step8 `--traffic traffic/car_realistic.traffic.json` runs clean (0 unreachable shortcuts).
- [x] Server boot with `--data-dir` picks up `car_realistic` in `/health.modes`.
- [x] `/route?mode=car_realistic` and `/isochrone?mode=car_realistic` return 200 with sensible-shaped output.
- [x] Quantitative validation table above.