### PR TITLE
perf(rss): #400 lean-at-rest — per-worker idle eviction + jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3650,6 +3651,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/route/Cargo.toml
+++ b/route/Cargo.toml
@@ -40,6 +40,16 @@ memmap2 = "0.9"
 # adjacencies in steps A–C kept the only remaining readers cold).
 libc = "0.2"
 
+# Global allocator (#400). glibc's default arena keeps freed allocations
+# in process — even after the bucket-M2M thread-local SearchStates are
+# dropped, VmRSS stays high because glibc holds the pages in its arena.
+# jemalloc returns memory aggressively via `madvise(DONTNEED)` once
+# heap regions go cold, which is the lean-at-rest behaviour the idle
+# compactor needs. Picked over mimalloc for the longer production
+# track record on long-running multi-thread servers (Firefox, Redis,
+# TiKV, ripgrep, Rustup all use jemalloc).
+tikv-jemallocator = "0.6"
+
 # Safe POD slice reinterpretation for zero-copy mmap views (#147).
 # `bytemuck::cast_slice` performs alignment + size checks at runtime and
 # wraps the only `unsafe` (slice-of-u8 → slice-of-u32) in its own well-

--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -731,6 +731,22 @@ pub enum Commands {
         #[arg(long)]
         rss_budget_gb: Option<f64>,
 
+        /// #400 — lean-at-rest: idle threshold in seconds for the
+        /// per-worker thread-local cache compactor. After a heavy
+        /// /table or /isochrone query, each rayon worker retains
+        /// 80-140 MB of `SearchState` / `PhastState` for the rest of
+        /// the process lifetime. The compactor wakes every
+        /// `secs / 4` and drops caches on workers that have not
+        /// served a query in `secs`. Default 300 (5 min). Set to 0
+        /// to disable. Env override: `BUTTERFLY_IDLE_COMPACT_SECS=…`.
+        ///
+        /// First query after eviction pays a one-time re-alloc cost
+        /// (~10 ms / worker on Belgium). Lazy region eviction
+        /// (--rss-budget-gb) is orthogonal — that handles whole
+        /// regions, this handles per-worker scratch.
+        #[arg(long)]
+        idle_compact_secs: Option<u64>,
+
         /// Log format: "text" (default) or "json"
         #[arg(long, default_value = "text")]
         log_format: String,
@@ -1945,6 +1961,7 @@ impl Cli {
                 regions,
                 eager_regions,
                 rss_budget_gb,
+                idle_compact_secs,
                 log_format,
                 rss_checkpoints,
                 eager_verify,
@@ -1972,6 +1989,11 @@ impl Cli {
                 // `BUTTERFLY_RSS_BUDGET_GB=…` is also honoured.
                 if let Some(gib) = rss_budget_gb {
                     crate::server::set_rss_budget_override(gib);
+                }
+                // #400: stash --idle-compact-secs in a process-wide OnceLock
+                // so the compactor reads it without growing serve()'s sig.
+                if let Some(secs) = idle_compact_secs {
+                    crate::server::set_idle_compact_secs(secs);
                 }
 
                 let transport_mode = server::Transport::parse(&transport)?;

--- a/route/src/main.rs
+++ b/route/src/main.rs
@@ -3,6 +3,37 @@ use clap::Parser;
 
 use butterfly_route::cli::{Cli, Commands};
 
+// #400 — lean-at-rest: use jemalloc as the global allocator. glibc's
+// default arena keeps freed allocations in process, so the idle
+// compactor's `drop(SearchState)` doesn't actually return RAM to the
+// OS (VmRSS stays put even after the Vec body is freed). jemalloc
+// aggressively unmaps cold heap regions via `madvise(DONTNEED)`,
+// which is precisely the behaviour the lean-at-rest path needs.
+//
+// Picked over mimalloc for the longer production track record on
+// long-running multi-thread Rust servers (Firefox, Redis, TiKV,
+// ripgrep, Rustup all use jemalloc). The `#[global_allocator]`
+// declaration is plain safe Rust; the unsafe FFI lives inside the
+// `tikv-jemallocator` crate, behind the same encapsulation as
+// `libc::madvise` and `bytemuck`.
+//
+// Set for ALL binaries built from this crate (serve, step CLIs,
+// bench). Pipeline steps benefit incidentally: large transient
+// allocations (e.g. step8 customise) return to the OS instead of
+// staying pinned in arena.
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+// Note: jemalloc's default purge cadence is ~10s for dirty pages.
+// That means RSS after the idle compactor fires takes ~10s to drop —
+// acceptable for a "lean at rest" tool. Operators who want faster
+// purging can set the standard jemalloc env var, e.g.:
+//   MALLOC_CONF=background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000
+// We don't bake this into the binary because the `malloc_conf` symbol
+// requires `#[unsafe(no_mangle)]`, and the project rule forbids any
+// unsafe attribute in OUR code (jemalloc's internal unsafe is fine —
+// it lives inside `tikv-jemallocator`, like `libc`).
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
 

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -54,6 +54,60 @@ thread_local! {
     // dwarfs the actual routing work, so we skip the parallel path
     // entirely and run sequentially in a single thread-cached engine.
     static SEQUENTIAL_ENGINE: RefCell<Option<BucketM2MEngine>> = const { RefCell::new(None) };
+
+    // #400: per-worker last-touched timestamp for the lean-at-rest
+    // background eviction. Updated at the entry of each bucket-M2M
+    // forward/backward function via `touch_idle_marker()`; checked by
+    // `try_drop_idle_state()` running on each worker via
+    // `rayon::broadcast` from the idle-compactor thread.
+    static LAST_TOUCH: std::cell::Cell<Option<std::time::Instant>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// #400: mark this worker as recently active. Cheap (~30 ns / call) —
+/// called once at the entry of each bucket-M2M function. The idle
+/// compactor uses this to decide whether to drop the per-worker
+/// thread-local caches.
+#[inline]
+fn touch_idle_marker() {
+    LAST_TOUCH.with(|c| c.set(Some(std::time::Instant::now())));
+}
+
+/// #400: drop the per-worker bucket-M2M caches if this thread has not
+/// touched them in `threshold`. Called from `rayon::broadcast` by the
+/// idle-compactor thread. Releases ~80 MB per worker (forward +
+/// backward SearchStates + bucket items vec) plus the 2-channel
+/// equivalents. Subsequent queries pay one re-alloc (~10 ms / worker).
+pub fn try_drop_idle_state(threshold: std::time::Duration) -> bool {
+    let stale = LAST_TOUCH.with(|c| match c.get() {
+        Some(last) => last.elapsed() > threshold,
+        None => false, // never touched — nothing to drop
+    });
+    if !stale {
+        return false;
+    }
+    FORWARD_STATE.with(|c| *c.borrow_mut() = None);
+    BACKWARD_STATE.with(|c| *c.borrow_mut() = None);
+    FORWARD_BUCKET_ITEMS.with(|c| {
+        c.borrow_mut().shrink_to_fit();
+        *c.borrow_mut() = Vec::new();
+    });
+    FORWARD_STATE_LAT.with(|c| *c.borrow_mut() = None);
+    BACKWARD_STATE_LAT.with(|c| *c.borrow_mut() = None);
+    FORWARD_BUCKET_ITEMS_LAT.with(|c| {
+        c.borrow_mut().shrink_to_fit();
+        *c.borrow_mut() = Vec::new();
+    });
+    SEQ_STATE_LAT.with(|c| *c.borrow_mut() = None);
+    SEQ_BUCKETS_LAT.with(|c| *c.borrow_mut() = None);
+    SEQ_BUCKET_ITEMS_LAT.with(|c| {
+        c.borrow_mut().shrink_to_fit();
+        *c.borrow_mut() = Vec::new();
+    });
+    SEQUENTIAL_ENGINE.with(|c| *c.borrow_mut() = None);
+    // Reset the marker so we don't keep dropping on every poll.
+    LAST_TOUCH.with(|c| c.set(None));
+    true
 }
 
 /// Cell-count threshold below which `table_bucket_parallel` dispatches
@@ -3185,6 +3239,7 @@ fn forward_fill_buckets_flat(
     state: &mut SearchState,
     bucket_items: &mut Vec<(u32, u32, u32)>,
 ) {
+    touch_idle_marker();
     state.start_search();
     state.relax(source, 0);
 
@@ -3718,6 +3773,7 @@ fn backward_join_tile(
 ) -> (usize, usize) {
     use std::sync::atomic::Ordering;
 
+    touch_idle_marker();
     state.start_search();
     state.relax(target, 0);
 
@@ -3835,6 +3891,7 @@ fn backward_join_parallel_prefix(
 ) -> (usize, usize) {
     use std::sync::atomic::Ordering;
 
+    touch_idle_marker();
     state.start_search();
     state.relax(target, 0);
 
@@ -4180,6 +4237,7 @@ fn forward_fill_buckets_flat_len_along_time(
     state: &mut SearchState2,
     bucket_items: &mut Vec<(u32, u32, u32, u32)>,
 ) {
+    touch_idle_marker();
     state.start_search();
     state.relax(source, 0, 0);
 
@@ -4412,6 +4470,7 @@ fn backward_join_local_columns_len_along_time(
     lat_col: &mut [u32],
     state: &mut SearchState2,
 ) -> (usize, usize) {
+    touch_idle_marker();
     state.start_search();
     state.relax(target, 0, 0);
 

--- a/route/src/server/idle_compactor.rs
+++ b/route/src/server/idle_compactor.rs
@@ -1,0 +1,143 @@
+//! #400 — lean-at-rest: drop per-worker thread-local caches when idle.
+//!
+//! After a heavy /table or /isochrone query, every active rayon worker
+//! retains its per-thread state (`SearchState`, `PhastState`, etc.) —
+//! tens to hundreds of MB per worker, never released for the rest of
+//! the process lifetime. The user wants the server lean at rest so the
+//! OS can give the RAM to other processes during idle periods.
+//!
+//! ## Mechanism
+//!
+//! A background thread sleeps `poll_interval`, then issues a
+//! `rayon::broadcast` so a closure runs on every rayon worker. Each
+//! worker checks its own thread-local `LAST_TOUCH` timestamp and, if
+//! it hasn't been touched in `threshold`, drops its caches.
+//!
+//! Workers update `LAST_TOUCH` at the entry of every routing function
+//! they execute (see e.g.
+//! `crate::matrix::bucket_ch::touch_idle_marker`). The check is
+//! cheap (one thread-local read + one timestamp compare) and only
+//! fires when the compactor wakes up — not on every query.
+//!
+//! The drop side per module:
+//! - `matrix::bucket_ch::try_drop_idle_state` — bucket-M2M
+//!   SearchStates + bucket-items Vecs + 2-channel equivalents
+//!   (~80 MB / worker on Belgium)
+//! - `server::query::try_drop_idle_state` — /route CchQueryState
+//!   (~60 MB / worker)
+//! - `server::isochrone_handler::try_drop_idle_phast` — PHAST
+//!   forward + reverse states per mode (~30-60 MB / worker per
+//!   mode populated)
+//! - `transit::raptor::try_drop_idle_state` — RAPTOR scratch
+//!   (small relative to others)
+//!
+//! ## Out of scope (still RAM after compact)
+//!
+//! - `SEQ_STATE_LAT` / `SEQUENTIAL_ENGINE` (small-N fast-path
+//!   thread-locals on the handler thread, not on rayon workers).
+//!   `rayon::broadcast` reaches rayon workers only; handler-thread
+//!   eviction would need a separate mechanism. ~60 MB total —
+//!   accepted for v1.
+//! - Container mmap pages — kernel evicts those itself under
+//!   memory pressure; nothing to do here.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+/// Sentinel — running compactor handle. Holding a clone keeps the
+/// background thread alive; dropping all clones signals shutdown.
+#[derive(Clone)]
+pub struct IdleCompactor {
+    stop: Arc<AtomicBool>,
+}
+
+impl IdleCompactor {
+    /// Spawn the background thread. `threshold` is how long a worker
+    /// must be idle before its caches are dropped; `poll_interval` is
+    /// how often the compactor wakes up to check. A reasonable choice
+    /// is `poll_interval = threshold / 4` so freshly-idle workers get
+    /// evicted within a quarter of `threshold`.
+    ///
+    /// Setting `threshold = 0` disables the compactor (returns a
+    /// no-op handle).
+    pub fn start(threshold: Duration, poll_interval: Duration) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        if threshold.is_zero() {
+            tracing::info!("#400 idle-compactor: disabled (threshold=0)");
+            return Self { stop };
+        }
+        let stop_clone = Arc::clone(&stop);
+        tracing::info!(
+            threshold_secs = threshold.as_secs(),
+            poll_interval_secs = poll_interval.as_secs(),
+            "#400 idle-compactor: spawning background poller"
+        );
+        std::thread::Builder::new()
+            .name("idle-compactor".into())
+            .spawn(move || run(stop_clone, threshold, poll_interval))
+            .expect("idle-compactor thread spawn");
+        Self { stop }
+    }
+}
+
+impl Drop for IdleCompactor {
+    fn drop(&mut self) {
+        // Only the last Arc drop signals shutdown.
+        if Arc::strong_count(&self.stop) == 1 {
+            self.stop.store(true, Ordering::Relaxed);
+        }
+    }
+}
+
+fn run(stop: Arc<AtomicBool>, threshold: Duration, poll_interval: Duration) {
+    // Resolve the poll-interval into a small unit so we can wake up
+    // promptly on shutdown without polling tightly.
+    let sleep_step = Duration::from_secs(1).min(poll_interval);
+    let mut elapsed = Duration::ZERO;
+    while !stop.load(Ordering::Relaxed) {
+        std::thread::sleep(sleep_step);
+        elapsed += sleep_step;
+        if elapsed < poll_interval {
+            continue;
+        }
+        elapsed = Duration::ZERO;
+        evict_all_workers(threshold);
+    }
+}
+
+fn evict_all_workers(threshold: Duration) {
+    // `rayon::broadcast` runs `op` once on every worker thread in the
+    // global rayon pool. The closure must be `Sync + Fn(BroadcastContext) -> R`.
+    let drops_bucket = std::sync::atomic::AtomicUsize::new(0);
+    let drops_query = std::sync::atomic::AtomicUsize::new(0);
+    let drops_phast = std::sync::atomic::AtomicUsize::new(0);
+    let drops_raptor = std::sync::atomic::AtomicUsize::new(0);
+    rayon::broadcast(|_| {
+        if crate::matrix::bucket_ch::try_drop_idle_state(threshold) {
+            drops_bucket.fetch_add(1, Ordering::Relaxed);
+        }
+        if crate::server::query::try_drop_idle_state(threshold) {
+            drops_query.fetch_add(1, Ordering::Relaxed);
+        }
+        if crate::server::isochrone_handler::try_drop_idle_phast(threshold) {
+            drops_phast.fetch_add(1, Ordering::Relaxed);
+        }
+        if crate::transit::raptor::try_drop_idle_state(threshold) {
+            drops_raptor.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    let total = drops_bucket.load(Ordering::Relaxed)
+        + drops_query.load(Ordering::Relaxed)
+        + drops_phast.load(Ordering::Relaxed)
+        + drops_raptor.load(Ordering::Relaxed);
+    if total > 0 {
+        tracing::info!(
+            bucket = drops_bucket.load(Ordering::Relaxed),
+            query = drops_query.load(Ordering::Relaxed),
+            phast = drops_phast.load(Ordering::Relaxed),
+            raptor = drops_raptor.load(Ordering::Relaxed),
+            "#400 idle-compactor: dropped per-worker caches"
+        );
+    }
+}

--- a/route/src/server/isochrone_handler.rs
+++ b/route/src/server/isochrone_handler.rs
@@ -195,6 +195,41 @@ thread_local! {
         None, None, None, None,
         None, None, None, None,
     ]) };
+
+    /// #400: per-thread last-touched timestamp for lean-at-rest eviction.
+    static PHAST_LAST_TOUCH: std::cell::Cell<Option<std::time::Instant>> =
+        const { std::cell::Cell::new(None) };
+}
+
+#[inline]
+fn touch_phast_idle_marker() {
+    PHAST_LAST_TOUCH.with(|c| c.set(Some(std::time::Instant::now())));
+}
+
+/// #400: drop both forward and reverse PHAST states on this thread if
+/// idle > threshold. Releases up to MAX_MODES × 2 × ~30 MB per worker
+/// when fully populated (Belgium uses 4 car modes + bike + foot ≈
+/// ~720 MB per worker upper bound).
+pub fn try_drop_idle_phast(threshold: std::time::Duration) -> bool {
+    let stale = PHAST_LAST_TOUCH.with(|c| match c.get() {
+        Some(last) => last.elapsed() > threshold,
+        None => false,
+    });
+    if !stale {
+        return false;
+    }
+    PHAST_STATES.with(|c| {
+        for slot in c.borrow_mut().iter_mut() {
+            *slot = None;
+        }
+    });
+    PHAST_STATES_REV.with(|c| {
+        for slot in c.borrow_mut().iter_mut() {
+            *slot = None;
+        }
+    });
+    PHAST_LAST_TOUCH.with(|c| c.set(None));
+    true
 }
 
 /// Run PHAST bounded query using thread-local state.
@@ -216,6 +251,7 @@ pub fn run_phast_bounded_fast(
 ) -> Vec<(u32, u32)> {
     use std::cmp::Reverse;
 
+    touch_phast_idle_marker();
     let total_start = std::time::Instant::now();
     let n_nodes = up_adj_flat.offsets.len() - 1;
     let mode_idx = mode.index();
@@ -373,6 +409,7 @@ pub fn run_phast_bounded_fast_reverse(
 ) -> Vec<(u32, u32)> {
     use std::cmp::Reverse;
 
+    touch_phast_idle_marker();
     let total_start = std::time::Instant::now();
     let n_nodes = up_adj_flat.offsets.len() - 1;
     let mode_idx = mode.index();

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -46,6 +46,7 @@ pub mod flight;
 pub mod geometry;
 pub mod health_handler;
 pub mod height_handler;
+pub mod idle_compactor;
 pub mod isochrone_handler;
 pub mod map_match;
 pub mod matching;
@@ -126,6 +127,27 @@ pub fn find_free_port(start: u16) -> Result<u16> {
 /// once and lets the eviction poller read it without needing to grow
 /// the `serve()` signature.
 static RSS_BUDGET_OVERRIDE_GIB: std::sync::OnceLock<f64> = std::sync::OnceLock::new();
+
+/// #400: idle-compact threshold (seconds). 0 disables the compactor.
+/// Set once via CLI (`--idle-compact-secs`); default 300 (5 min) when
+/// the CLI didn't pass a value.
+static IDLE_COMPACT_SECS_OVERRIDE: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+
+pub fn set_idle_compact_secs(secs: u64) {
+    let _ = IDLE_COMPACT_SECS_OVERRIDE.set(secs);
+}
+
+fn idle_compact_secs() -> u64 {
+    if let Some(&v) = IDLE_COMPACT_SECS_OVERRIDE.get() {
+        return v;
+    }
+    if let Ok(s) = std::env::var("BUTTERFLY_IDLE_COMPACT_SECS")
+        && let Ok(v) = s.parse::<u64>()
+    {
+        return v;
+    }
+    300
+}
 
 /// Set the process-wide RSS budget override (in GiB). Called once by
 /// the CLI before `serve()` runs; later sets are ignored (OnceLock
@@ -518,6 +540,26 @@ pub async fn serve(
     // the steady-state baseline #153/#154/#155 will measure against,
     // captured prior to observable readiness on `/health`.
     crate::server::rss::checkpoint("boot.complete");
+
+    // #400 — lean-at-rest: spawn the idle compactor. Periodically
+    // issues `rayon::broadcast` so each worker drops its per-thread
+    // routing state (~80 MB bucket-M2M + ~60 MB query state +
+    // PHAST per mode) when it hasn't served a query in
+    // `idle_compact_secs`. Disabled with `--idle-compact-secs 0`.
+    {
+        let secs = idle_compact_secs();
+        let threshold = std::time::Duration::from_secs(secs);
+        // Poll quarter as often as the threshold so freshly-idle
+        // workers get evicted within ~threshold/4.
+        let poll_interval = std::time::Duration::from_secs((secs / 4).max(15).min(secs.max(15)));
+        // Hold the handle for the life of the server so the
+        // background thread keeps running.
+        let _idle_compactor =
+            crate::server::idle_compactor::IdleCompactor::start(threshold, poll_interval);
+        // Leak the handle into a static so it lives forever. Server
+        // shutdown is process-exit; explicit cleanup not needed.
+        std::mem::forget(_idle_compactor);
+    }
 
     // #292 Phase 6: spawn the LRU eviction poller. Reads VmRSS once
     // per `EVICT_POLL_SECS` and, if over budget, evicts the oldest

--- a/route/src/server/query.rs
+++ b/route/src/server/query.rs
@@ -218,6 +218,32 @@ impl CchQueryState {
 thread_local! {
     /// Single thread-local CCH query state. Re-initializes when n_nodes changes.
     static CCH_QUERY_STATE: RefCell<Option<CchQueryState>> = const { RefCell::new(None) };
+
+    /// #400: per-thread last-touched timestamp for lean-at-rest eviction.
+    static LAST_TOUCH: std::cell::Cell<Option<std::time::Instant>> =
+        const { std::cell::Cell::new(None) };
+}
+
+#[inline]
+fn touch_idle_marker() {
+    LAST_TOUCH.with(|c| c.set(Some(std::time::Instant::now())));
+}
+
+/// #400: drop `CCH_QUERY_STATE` on this thread if it has not been
+/// touched in `threshold`. Called via `rayon::broadcast` from the
+/// idle-compactor thread. Releases ~60 MB per thread (dist_fwd +
+/// dist_bwd + parent + gen arrays sized to n_nodes).
+pub fn try_drop_idle_state(threshold: std::time::Duration) -> bool {
+    let stale = LAST_TOUCH.with(|c| match c.get() {
+        Some(last) => last.elapsed() > threshold,
+        None => false,
+    });
+    if !stale {
+        return false;
+    }
+    CCH_QUERY_STATE.with(|c| *c.borrow_mut() = None);
+    LAST_TOUCH.with(|c| c.set(None));
+    true
 }
 
 /// Reconstruct path from generation-stamped parent arrays
@@ -486,6 +512,7 @@ impl<'a> CchQuery<'a> {
             });
         }
 
+        touch_idle_marker();
         let n = self.n_nodes;
 
         CCH_QUERY_STATE.with(|cell| {

--- a/route/src/transit/raptor.rs
+++ b/route/src/transit/raptor.rs
@@ -205,6 +205,31 @@ impl RaptorState {
 thread_local! {
     /// One RAPTOR state per thread, reused across queries. See #104.
     static RAPTOR_STATE: RefCell<RaptorState> = RefCell::new(RaptorState::new());
+
+    /// #400: per-thread last-touched timestamp for lean-at-rest eviction.
+    static LAST_TOUCH: std::cell::Cell<Option<std::time::Instant>> =
+        const { std::cell::Cell::new(None) };
+}
+
+#[inline]
+fn touch_idle_marker() {
+    LAST_TOUCH.with(|c| c.set(Some(std::time::Instant::now())));
+}
+
+/// #400: drop the per-thread RAPTOR state if idle > threshold.
+/// Replaces it with a fresh (empty) RaptorState rather than `None`
+/// since RAPTOR_STATE is `RefCell<RaptorState>` (not `Option<...>`).
+pub fn try_drop_idle_state(threshold: std::time::Duration) -> bool {
+    let stale = LAST_TOUCH.with(|c| match c.get() {
+        Some(last) => last.elapsed() > threshold,
+        None => false,
+    });
+    if !stale {
+        return false;
+    }
+    RAPTOR_STATE.with(|c| *c.borrow_mut() = RaptorState::new());
+    LAST_TOUCH.with(|c| c.set(None));
+    true
 }
 
 /// A single leg of a RAPTOR journey.
@@ -306,6 +331,7 @@ pub fn run_raptor(
         return None;
     }
 
+    touch_idle_marker();
     RAPTOR_STATE.with(|cell| {
         let mut st = cell.borrow_mut();
         st.start(n_stops, n_routes);


### PR DESCRIPTION
## Summary
Background thread issues \`rayon::broadcast\` periodically; each worker drops its thread-local routing scratch if it hasn't served a query in \`--idle-compact-secs\` (default 300, 0 = off). Switched global allocator to jemalloc so the freed RAM actually returns to the OS (glibc holds in arena).

Closes #400.

## Verified (Belgium /table car)

| phase | VmRSS | RssAnon |
|---|---:|---:|
| post-boot idle | 14.85 GB | 9.16 GB |
| post 1000×1000 query | 16.10 GB | 10.42 GB |
| post-eviction (30 s threshold) | **14.91 GB** | **9.22 GB** |
| per-query state recovered | **-1.2 GB** | **-1.2 GB** |

Eviction log: \`#400 idle-compactor: dropped per-worker caches bucket=20\` — all 20 rayon workers had cache, all 20 dropped, jemalloc returned ~1.2 GB to OS within ~5 s. Brussels→Antwerp /route preserved: 7120 s / 58134 m.

## Modules instrumented
| module | drops | rough size / worker |
|---|---|---|
| \`matrix::bucket_ch\` | FORWARD_STATE, BACKWARD_STATE, _LAT, bucket Vecs | ~80 MB |
| \`server::query\` | CCH_QUERY_STATE | ~60 MB |
| \`server::isochrone_handler\` | PHAST_STATES (fwd + rev × MAX_MODES) | up to ~480 MB |
| \`transit::raptor\` | RAPTOR_STATE | small |

## jemalloc rationale
glibc keeps freed allocations in arena → eviction logs fired but VmRSS stayed put. jemalloc returns cold heap via \`madvise(DONTNEED)\`. Picked over mimalloc for longer production track record on long-running Rust servers (Firefox, Redis, TiKV, ripgrep, Rustup). Our \`#[global_allocator]\` declaration is safe Rust; unsafe FFI is inside the \`tikv-jemallocator\` crate.

## Out of scope (filed as #402)
9.2 GB structural at-rest footprint remains — cost of eagerly loading all 4 Belgium modes. #402 implements per-mode lazy load + idle eviction; composes cleanly (this PR evicts per-worker scratch, #402 evicts whole modes).

## Test plan
- [x] \`cargo test -p butterfly-route --release --lib\` — 598 lib tests pass
- [x] \`cargo clippy --workspace --all-targets --all-features\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] End-to-end: boot → 1000×1000 query → wait 30s → confirm RSS drops by query's contribution
- [x] /route correctness preserved post-eviction