### PR TITLE
perf(rss): #402 per-mode lazy load + idle eviction — -7.4 GB at rest

### DIFF
--- a/route/src/bench/weight_profile.rs
+++ b/route/src/bench/weight_profile.rs
@@ -318,7 +318,7 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
         load_elapsed.as_secs_f64()
     );
     for (i, name) in state.mode_names.iter().enumerate() {
-        let mode_data = &state.modes[i];
+        let mode_data = state.get_mode(butterfly_route::profile_abi::Mode(i as u8));
         println!(
             "    - {}: {} CCH ranks, {} UP weights, {} DOWN weights",
             name,
@@ -334,7 +334,7 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
     let mut static_a: BTreeMap<String, (StaticStats, StaticStats, StaticStats, StaticStats)> =
         BTreeMap::new();
     for (i, mode_name) in state.mode_names.iter().enumerate() {
-        let mode_data = &state.modes[i];
+        let mode_data = state.get_mode(butterfly_route::profile_abi::Mode(i as u8));
         let t_up = compute_static_stats(&mode_data.cch_weights.up.iter().collect::<Vec<u32>>());
         let t_dn = compute_static_stats(&mode_data.cch_weights.down.iter().collect::<Vec<u32>>());
         let d_up =
@@ -364,7 +364,7 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
     let mut blocks_c: BTreeMap<String, (BlockStats, BlockStats, BlockStats, BlockStats)> =
         BTreeMap::new();
     for (i, mode_name) in state.mode_names.iter().enumerate() {
-        let mode_data = &state.modes[i];
+        let mode_data = state.get_mode(butterfly_route::profile_abi::Mode(i as u8));
         let t_up = compute_block_stats(
             &mode_data.cch_weights.up.iter().collect::<Vec<u32>>(),
             BLOCK_SIZES,
@@ -426,7 +426,7 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
 
     let mut hot_b: BTreeMap<String, (HotStats, HotStats)> = BTreeMap::new();
     for (mode_idx, mode_name) in state.mode_names.iter().enumerate() {
-        let mode_data = &state.modes[mode_idx];
+        let mode_data = state.get_mode(butterfly_route::profile_abi::Mode(mode_idx as u8));
         let snap_start = std::time::Instant::now();
         let snapped: Vec<(u32, u32)> = snap_od_pairs(&state, &od_pairs, mode_idx as u8);
         let n_snapped = snapped.len();
@@ -493,7 +493,7 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
     let mut rounding_d: BTreeMap<String, (RoundingStats, RoundingStats)> = BTreeMap::new();
     let d_pairs = generate_rounding_pairs(&bbox);
     for (mode_idx, mode_name) in state.mode_names.iter().enumerate() {
-        let mode_data = &state.modes[mode_idx];
+        let mode_data = state.get_mode(butterfly_route::profile_abi::Mode(mode_idx as u8));
         let snapped: Vec<(u32, u32)> = snap_od_pairs(&state, &d_pairs, mode_idx as u8);
         let n_nodes = mode_data.cch_topo.n_nodes as usize;
 
@@ -538,7 +538,7 @@ pub fn run_weight_profile(data_dir: &Path, output_dir: &Path, region: Option<&st
     println!("[6/?] Section E: triangle-relaxation tie rate (cs vs s precision)...");
     let mut tie_e: BTreeMap<String, (TieStats, TieStats)> = BTreeMap::new();
     for (mode_idx, mode_name) in state.mode_names.iter().enumerate() {
-        let mode_data = &state.modes[mode_idx];
+        let mode_data = state.get_mode(butterfly_route::profile_abi::Mode(mode_idx as u8));
         let t_start = std::time::Instant::now();
         let tie_time = compute_tie_stats(&mode_data.cch_topo, &mode_data.cch_weights, 100);
         let tt = t_start.elapsed().as_secs_f64();
@@ -1204,7 +1204,7 @@ fn rng_od_pair(rng: &mut StdRng, bbox: &Bbox) -> OdPair {
 /// `/route` handles unreachable requests. The drop is counted and
 /// reported via the per-mode log line.
 fn snap_od_pairs(state: &ServerState, pairs: &[OdPair], mode_idx: u8) -> Vec<(u32, u32)> {
-    let mode_data = &state.modes[mode_idx as usize];
+    let mode_data = state.get_mode(butterfly_route::profile_abi::Mode(mode_idx));
     pairs
         .iter()
         .filter_map(|p| {

--- a/route/src/server/avoid.rs
+++ b/route/src/server/avoid.rs
@@ -702,9 +702,16 @@ pub fn compute_avoid_weights_time_only(
 /// Look up the mode index by comparing the `ModeData` pointer against
 /// the state's mode list. Avoids threading an explicit index through
 /// the existing call sites.
+///
+/// #402: `state.modes` is now `Vec<ModeSlot>`, where each slot wraps the
+/// `Arc<ModeData>` behind a `RwLock`. We peek the read lock and compare
+/// the `Arc`'s inner pointer to identify the slot owning `mode_data`.
 fn mode_index_in_state(state: &ServerState, mode_data: &ModeData) -> Result<usize, String> {
     for (i, m) in state.modes.iter().enumerate() {
-        if std::ptr::eq(m, mode_data) {
+        let r = m.state.read();
+        if let Some(arc) = r.as_ref()
+            && std::ptr::eq(std::sync::Arc::as_ptr(arc), mode_data as *const ModeData)
+        {
             return Ok(i);
         }
     }

--- a/route/src/server/catchment.rs
+++ b/route/src/server/catchment.rs
@@ -253,7 +253,7 @@ pub fn road_lasso(
         let src = vertices[i];
         let dst = vertices[(i + 1) % n_verts];
 
-        let route_points = route_between(state, mode_data, mode, src, dst);
+        let route_points = route_between(state, &mode_data, mode, src, dst);
         if route_points.len() > 1 {
             // Append all but last (to avoid duplication with next segment's first)
             ring.extend_from_slice(&route_points[..route_points.len() - 1]);
@@ -310,7 +310,7 @@ fn route_between(
         return vec![src, dst];
     }
 
-    let query = CchQuery::new(state, mode);
+    let query = CchQuery::new(mode_data);
     let (src_rank, dst_rank, result) = match super::snap_kbest::p2p_with_kbest_fallback(
         &query,
         &src_snap.ranks,
@@ -360,7 +360,7 @@ pub fn isochrone_hull(
     let mode_name = &state.mode_names[mode.index()];
 
     // Catchment hull is a depart-isochrone: store acts as source.
-    let store_role = super::types::SnapRole::Src.role_filter(mode_data);
+    let store_role = super::types::SnapRole::Src.role_filter(&mode_data);
     let orig_id = match state
         .snap_index
         .snap_filtered_role(store_lon, store_lat, mode.0, None, store_role)
@@ -801,8 +801,8 @@ pub async fn catchment_handler(
 
     // #197 directional snap: store is the source for the 1-to-N matrix,
     // clients are destinations. Cache the bitsets once outside the loop.
-    let store_role = super::types::SnapRole::Src.role_filter(mode_data);
-    let client_role = super::types::SnapRole::Dst.role_filter(mode_data);
+    let store_role = super::types::SnapRole::Src.role_filter(&mode_data);
+    let client_role = super::types::SnapRole::Dst.role_filter(&mode_data);
 
     // For each store: compute 1-to-N matrix via Bucket M2M, then catchment.
     // K-best snap + per-cell P2P fallback rescues INF cells the same
@@ -813,7 +813,7 @@ pub async fn catchment_handler(
     for store_input in &req.stores {
         let store_rank = match super::snap_kbest::snap_primary_role(
             &state,
-            mode_data,
+            &mode_data,
             mode,
             store_input.lon,
             store_input.lat,
@@ -854,7 +854,7 @@ pub async fn catchment_handler(
             }
             if let Some((_, rank)) = super::snap_kbest::snap_primary_role(
                 &state,
-                mode_data,
+                &mode_data,
                 mode,
                 c.lon,
                 c.lat,
@@ -887,12 +887,12 @@ pub async fn catchment_handler(
         // — typically zero of them on a healthy graph.
         if matrix.contains(&u32::MAX) {
             use rayon::prelude::*;
-            let query = super::query::CchQuery::new(&state, mode);
+            let query = super::query::CchQuery::new(&mode_data);
             // Lazily snap K=64 for the source store and just the
             // failing clients.
             let store_kbest = super::snap_kbest::snap_k_pair_role(
                 &state,
-                mode_data,
+                &mode_data,
                 mode,
                 store_input.lon,
                 store_input.lat,
@@ -910,7 +910,7 @@ pub async fn catchment_handler(
                     let c = &req.clients[ci];
                     let snap = super::snap_kbest::snap_k_pair_role(
                         &state,
-                        mode_data,
+                        &mode_data,
                         mode,
                         c.lon,
                         c.lat,

--- a/route/src/server/consistency_test.rs
+++ b/route/src/server/consistency_test.rs
@@ -123,7 +123,7 @@ fn test_route_table_duration_consistency() {
             };
 
             // Get route distance (P2P bidirectional CCH)
-            let query = CchQuery::new(&state, *mode);
+            let query = CchQuery::new(&mode_data);
             let route_dist = query.query(src_rank, dst_rank).map(|r| r.distance);
 
             // Get table distance (bucket M2M)
@@ -330,7 +330,7 @@ fn test_isochrone_route_consistency() {
         );
 
         // Sample some reachable nodes and verify P2P agrees
-        let query = CchQuery::new(&state, mode);
+        let query = CchQuery::new(&mode_data);
         let sample_count = phast_settled.len().min(50);
 
         for idx in (0..phast_settled.len()).step_by(phast_settled.len() / sample_count.max(1)) {
@@ -428,7 +428,7 @@ fn test_route_path_validity() {
                 }
             };
 
-            let query = CchQuery::new(&state, *mode);
+            let query = CchQuery::new(&mode_data);
             let result = match query.query(src_rank, dst_rank) {
                 Some(r) => r,
                 None => {
@@ -528,7 +528,7 @@ fn test_ghent_liege_unpacked_hops_exist_in_filtered_ebg() {
     let filtered_ebg = crate::formats::FilteredEbgFile::read(&filtered_ebg_path)
         .expect("test requires step5/filtered.<mode>.ebg on disk");
 
-    let query = CchQuery::new(&state, mode);
+    let query = CchQuery::new(&mode_data);
     let result = query
         .query(src_rank, dst_rank)
         .expect("Ghent -> Liege route should exist");
@@ -736,7 +736,7 @@ fn test_alternative_routes_differ() {
     let (dst_rank, _) = snap_to_rank(&state, mode, 4.4017, 50.8603).unwrap();
 
     // Primary route
-    let query = CchQuery::new(&state, mode);
+    let query = CchQuery::new(&mode_data);
     let primary = query
         .query(src_rank, dst_rank)
         .expect("Primary route should exist");
@@ -810,7 +810,7 @@ fn test_route_geometry_polyline6_round_trips() {
             None => continue,
         };
 
-        let query = CchQuery::new(&state, mode);
+        let query = CchQuery::new(&mode_data);
         let result = match query.query(src_rank, dst_rank) {
             Some(r) => r,
             None => continue,
@@ -1070,7 +1070,7 @@ fn test_route_steps_have_depart_and_arrive() {
             None => continue,
         };
 
-        let query = CchQuery::new(&state, mode);
+        let query = CchQuery::new(&mode_data);
         let result = match query.query(src_rank, dst_rank) {
             Some(r) => r,
             None => continue,
@@ -1188,7 +1188,7 @@ fn test_route_steps_distances_sum_to_total() {
             None => continue,
         };
 
-        let query = CchQuery::new(&state, mode);
+        let query = CchQuery::new(&mode_data);
         let result = match query.query(src_rank, dst_rank) {
             Some(r) => r,
             None => continue,
@@ -1265,7 +1265,7 @@ fn test_route_step_locations_on_route() {
     let (src_rank, _) = snap_to_rank(&state, mode, 4.3517, 50.8503).unwrap();
     let (dst_rank, _) = snap_to_rank(&state, mode, 4.3840, 50.7147).unwrap();
 
-    let query = CchQuery::new(&state, mode);
+    let query = CchQuery::new(&mode_data);
     let result = query.query(src_rank, dst_rank).expect("Route should exist");
 
     let rank_path = unpack_path(
@@ -1342,7 +1342,7 @@ fn test_alternative_routes_all_modes() {
                 None => continue,
             };
 
-            let query = CchQuery::new(&state, *mode);
+            let query = CchQuery::new(&mode_data);
             let primary = match query.query(src_rank, dst_rank) {
                 Some(r) => r,
                 None => continue,
@@ -1444,8 +1444,8 @@ fn test_197_directional_snap_asymmetry_reproducer() {
 
     // Helper: snap with role, then run a P2P CCH query.
     let route = |from: (f64, f64), to: (f64, f64)| -> Option<u32> {
-        let from_role = SnapRole::Src.role_filter(mode_data);
-        let to_role = SnapRole::Dst.role_filter(mode_data);
+        let from_role = SnapRole::Src.role_filter(&mode_data);
+        let to_role = SnapRole::Dst.role_filter(&mode_data);
 
         let from_snap = state
             .snap_index
@@ -1455,7 +1455,7 @@ fn test_197_directional_snap_asymmetry_reproducer() {
             .snap_with_info_filtered_role(to.0, to.1, mode.0, None, to_role)?;
         let from_rank = mode_data.rank_for_original(from_snap.0)?;
         let to_rank = mode_data.rank_for_original(to_snap.0)?;
-        let q = CchQuery::new(&state, mode);
+        let q = CchQuery::new(&mode_data);
         q.query(from_rank, to_rank).map(|r| r.distance)
     };
 
@@ -1534,7 +1534,7 @@ fn test_197_unfiltered_snap_still_demonstrates_bug() {
     let dst = (5.7803053_f64, 49.7258993_f64);
 
     // Force the legacy "Either" role on both ends.
-    let either = SnapRole::Either.role_filter(mode_data);
+    let either = SnapRole::Either.role_filter(&mode_data);
     assert!(either.is_none(), "Either must produce no role filter");
 
     let from_snap = state
@@ -1553,7 +1553,7 @@ fn test_197_unfiltered_snap_still_demonstrates_bug() {
         .rank_for_original(to_snap.0)
         .expect("destination must have a rank");
 
-    let q = CchQuery::new(&state, mode);
+    let q = CchQuery::new(&mode_data);
     let fwd = q.query(from_rank, to_rank);
 
     // The legacy snap demonstrates the bug: forward returns None.
@@ -1577,7 +1577,7 @@ fn test_197_unfiltered_snap_still_demonstrates_bug() {
             dst.1,
             mode.0,
             None,
-            SnapRole::Dst.role_filter(mode_data),
+            SnapRole::Dst.role_filter(&mode_data),
         )
         .expect("dst-role snap must succeed");
     let to_rank_dst = mode_data

--- a/route/src/server/cross_region.rs
+++ b/route/src/server/cross_region.rs
@@ -207,7 +207,7 @@ pub fn solve_cross_region(
         let access: Vec<Option<u32>> = valid_src_ranks
             .par_iter()
             .map(|&t| {
-                let q = CchQuery::new(src_state, Mode(src_mode_idx));
+                let q = CchQuery::new(&src_mode_data);
                 q.distance(src_rank, t)
             })
             .collect();
@@ -255,7 +255,7 @@ pub fn solve_cross_region(
         let egress: Vec<Option<u32>> = valid_dst_ranks
             .par_iter()
             .map(|&s| {
-                let q = CchQuery::new(dst_state, Mode(dst_mode_idx));
+                let q = CchQuery::new(&dst_mode_data);
                 q.distance(s, dst_rank)
             })
             .collect();

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -447,7 +447,7 @@ fn do_matrix(
         .map(|&[lon, lat]| {
             super::snap_kbest::snap_primary_role(
                 state,
-                mode_data,
+                &mode_data,
                 mode,
                 lon,
                 lat,
@@ -462,7 +462,7 @@ fn do_matrix(
         .map(|&[lon, lat]| {
             super::snap_kbest::snap_primary_role(
                 state,
-                mode_data,
+                &mode_data,
                 mode,
                 lon,
                 lat,
@@ -590,7 +590,7 @@ fn do_matrix(
         if matrix.contains(&u32::MAX) {
             use rayon::prelude::*;
             use std::collections::HashSet;
-            let query = super::query::CchQuery::new(state, mode);
+            let query = super::query::CchQuery::new(&mode_data);
 
             let mut work: Vec<(usize, usize)> = Vec::new();
             let mut needed_src: HashSet<usize> = HashSet::new();
@@ -615,7 +615,7 @@ fn do_matrix(
                     let [lon, lat] = params.sources[oi];
                     let snap = super::snap_kbest::snap_k_pair_role(
                         state,
-                        mode_data,
+                        &mode_data,
                         mode,
                         lon,
                         lat,
@@ -637,7 +637,7 @@ fn do_matrix(
                     let [lon, lat] = params.destinations[oi];
                     let snap = super::snap_kbest::snap_k_pair_role(
                         state,
-                        mode_data,
+                        &mode_data,
                         mode,
                         lon,
                         lat,
@@ -1184,7 +1184,7 @@ fn do_route_batch_blocking(
 
     // Small-batch fast path: no pool overhead for tiny calls.
     if n_workers == 1 {
-        let query = CchQuery::new(&state, mode);
+        let query = CchQuery::new(&mode_data);
         let mut scratch = RouteScratch::default();
         for chunk in params.pairs.chunks(batch_size) {
             let n = chunk.len();
@@ -1199,7 +1199,7 @@ fn do_route_batch_blocking(
                     let (slon, slat, dlon, dlat) = (pair[0], pair[1], pair[2], pair[3]);
                     let r = compute_route_pair(
                         &state,
-                        mode_data,
+                        &mode_data,
                         mode,
                         &query,
                         slon,
@@ -1280,15 +1280,15 @@ fn do_route_batch_blocking(
             let done_tx = done_tx.clone();
             let fallback_count = Arc::clone(&fallback_count);
             handles.push(scope.spawn(move || {
-                let query = CchQuery::new(&state, mode);
                 let mode_data = state.get_mode(mode);
+                let query = CchQuery::new(&mode_data);
                 let mut scratch = RouteScratch::default();
                 let fb = fallback_count.as_ref();
                 while let Ok(work) = rx.recv() {
                     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         let r = compute_route_pair(
                             &state,
-                            mode_data,
+                            &mode_data,
                             mode,
                             &query,
                             work.slon,
@@ -1523,7 +1523,7 @@ fn do_isochrone(
             params.lat,
             mode.0,
             None,
-            center_role.role_filter(mode_data),
+            center_role.role_filter(&mode_data),
         )
         .ok_or_else(|| Status::not_found("Could not snap to road network"))?;
     let origin_rank = mode_data.orig_to_rank[orig_id as usize];
@@ -1705,7 +1705,7 @@ pub fn do_edges_batch(
                 const SNAP_K: usize = 64;
                 let src_primary = super::snap_kbest::snap_primary_role(
                     &state,
-                    mode_data,
+                    &mode_data,
                     mode,
                     pair[0],
                     pair[1],
@@ -1714,7 +1714,7 @@ pub fn do_edges_batch(
                 );
                 let dst_primary = super::snap_kbest::snap_primary_role(
                     &state,
-                    mode_data,
+                    &mode_data,
                     mode,
                     pair[2],
                     pair[3],
@@ -1744,7 +1744,7 @@ pub fn do_edges_batch(
                     // contracted neighbor.
                     let src_snap = super::snap_kbest::snap_k_pair_role(
                         &state,
-                        mode_data,
+                        &mode_data,
                         mode,
                         pair[0],
                         pair[1],
@@ -1754,7 +1754,7 @@ pub fn do_edges_batch(
                     );
                     let dst_snap = super::snap_kbest::snap_k_pair_role(
                         &state,
-                        mode_data,
+                        &mode_data,
                         mode,
                         pair[2],
                         pair[3],
@@ -2240,7 +2240,7 @@ async fn do_exchange_catchment(
             const SNAP_K: usize = 64;
             let store_rank = match super::snap_kbest::snap_primary_role(
                 &state,
-                mode_data,
+                &mode_data,
                 mode,
                 *slon,
                 *slat,
@@ -2256,7 +2256,7 @@ async fn do_exchange_catchment(
             for (ci, &(clon, clat)) in client_coords.iter().enumerate() {
                 if let Some((_, r)) = super::snap_kbest::snap_primary_role(
                     &state,
-                    mode_data,
+                    &mode_data,
                     mode,
                     clon,
                     clat,
@@ -2286,10 +2286,10 @@ async fn do_exchange_catchment(
             // cell came back u32::MAX.
             if matrix.contains(&u32::MAX) {
                 use rayon::prelude::*;
-                let query = super::query::CchQuery::new(&state, mode);
+                let query = super::query::CchQuery::new(&mode_data);
                 let store_kbest = super::snap_kbest::snap_k_pair_role(
                     &state,
-                    mode_data,
+                    &mode_data,
                     mode,
                     *slon,
                     *slat,
@@ -2307,7 +2307,7 @@ async fn do_exchange_catchment(
                         let (clon, clat) = client_coords[ci];
                         let snap = super::snap_kbest::snap_k_pair_role(
                             &state,
-                            mode_data,
+                            &mode_data,
                             mode,
                             clon,
                             clat,

--- a/route/src/server/idle_compactor.rs
+++ b/route/src/server/idle_compactor.rs
@@ -59,9 +59,19 @@ impl IdleCompactor {
     /// is `poll_interval = threshold / 4` so freshly-idle workers get
     /// evicted within a quarter of `threshold`.
     ///
+    /// `regions` is the multi-region registry; the compactor walks
+    /// every loaded region's mode slots once per tick and evicts any
+    /// that have been idle longer than `threshold` (#402). Per-mode
+    /// eviction frees the whole mode definition (~1-4 GB on Belgium)
+    /// rather than just the per-worker scratch (~80 MB).
+    ///
     /// Setting `threshold = 0` disables the compactor (returns a
     /// no-op handle).
-    pub fn start(threshold: Duration, poll_interval: Duration) -> Self {
+    pub fn start(
+        threshold: Duration,
+        poll_interval: Duration,
+        regions: Arc<crate::server::regions::RegionsState>,
+    ) -> Self {
         let stop = Arc::new(AtomicBool::new(false));
         if threshold.is_zero() {
             tracing::info!("#400 idle-compactor: disabled (threshold=0)");
@@ -75,7 +85,7 @@ impl IdleCompactor {
         );
         std::thread::Builder::new()
             .name("idle-compactor".into())
-            .spawn(move || run(stop_clone, threshold, poll_interval))
+            .spawn(move || run(stop_clone, threshold, poll_interval, regions))
             .expect("idle-compactor thread spawn");
         Self { stop }
     }
@@ -90,7 +100,12 @@ impl Drop for IdleCompactor {
     }
 }
 
-fn run(stop: Arc<AtomicBool>, threshold: Duration, poll_interval: Duration) {
+fn run(
+    stop: Arc<AtomicBool>,
+    threshold: Duration,
+    poll_interval: Duration,
+    regions: Arc<crate::server::regions::RegionsState>,
+) {
     // Resolve the poll-interval into a small unit so we can wake up
     // promptly on shutdown without polling tightly.
     let sleep_step = Duration::from_secs(1).min(poll_interval);
@@ -103,6 +118,7 @@ fn run(stop: Arc<AtomicBool>, threshold: Duration, poll_interval: Duration) {
         }
         elapsed = Duration::ZERO;
         evict_all_workers(threshold);
+        evict_idle_modes(threshold, &regions);
     }
 }
 
@@ -138,6 +154,33 @@ fn evict_all_workers(threshold: Duration) {
             phast = drops_phast.load(Ordering::Relaxed),
             raptor = drops_raptor.load(Ordering::Relaxed),
             "#400 idle-compactor: dropped per-worker caches"
+        );
+    }
+}
+
+/// #402 per-mode eviction. Walks every loaded region's mode slots
+/// and asks each to evict if idle > threshold. Mode loading is
+/// re-driven by the next `get_mode` call (single-flight under the
+/// per-slot write lock). Mode size on Belgium: ~1-4 GB per mode.
+fn evict_idle_modes(threshold: Duration, regions: &Arc<crate::server::regions::RegionsState>) {
+    let threshold_ms = threshold.as_millis() as u64;
+    let mut evicted = 0usize;
+    for region in regions.iter_regions() {
+        // Skip Pending regions — nothing loaded to evict.
+        let state = match region.state_loaded() {
+            Some(s) => s,
+            None => continue,
+        };
+        for mode_idx in 0..state.modes.len() {
+            if state.try_evict_mode_if_idle(mode_idx, threshold_ms) {
+                evicted += 1;
+            }
+        }
+    }
+    if evicted > 0 {
+        tracing::info!(
+            modes = evicted,
+            "#402 idle-compactor: evicted cold mode slots"
         );
     }
 }

--- a/route/src/server/isochrone_handler.rs
+++ b/route/src/server/isochrone_handler.rs
@@ -714,7 +714,7 @@ pub async fn isochrone_handler(
 
     // Compute avoid weights (includes exclude if both present)
     let avoid_entry = if let Some(ref avoid_str) = avoid_json {
-        match super::avoid::compute_avoid_weights(&state, mode_data, avoid_str, exclude_mask) {
+        match super::avoid::compute_avoid_weights(&state, &mode_data, avoid_str, exclude_mask) {
             Ok(entry) => Some(entry),
             Err(e) => {
                 return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
@@ -772,7 +772,7 @@ pub async fn isochrone_handler(
     } else {
         SnapRole::Src
     };
-    let center_role_filter = center_role.role_filter(mode_data);
+    let center_role_filter = center_role.role_filter(&mode_data);
 
     let center_orig = match state.snap_index.snap_filtered_role(
         req.lon,
@@ -1146,7 +1146,7 @@ pub async fn isochrone_bulk_handler(
 
     // Compute avoid weights (includes exclude if both present)
     let avoid_entry = if let Some(ref avoid_str) = avoid_json {
-        match super::avoid::compute_avoid_weights(&state, mode_data, avoid_str, exclude_mask) {
+        match super::avoid::compute_avoid_weights(&state, &mode_data, avoid_str, exclude_mask) {
             Ok(entry) => Some(entry),
             Err(e) => {
                 return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
@@ -1190,7 +1190,7 @@ pub async fn isochrone_bulk_handler(
 
     // Bulk isochrones are depart-only (no `direction` field), so origins
     // act as sources. Apply the #197 directional role filter.
-    let origin_role_filter = SnapRole::Src.role_filter(mode_data);
+    let origin_role_filter = SnapRole::Src.role_filter(&mode_data);
 
     // Process all origins in parallel
     let results: Vec<(u32, Vec<u8>)> = req

--- a/route/src/server/isochrone_test.rs
+++ b/route/src/server/isochrone_test.rs
@@ -316,7 +316,8 @@ mod tests {
         let mut n_snapped = 0;
 
         // Create query engine
-        let query = CchQuery::new(&state, mode);
+        let mode_data = state.get_mode(mode);
+        let query = CchQuery::new(&mode_data);
 
         // Maximum snap distance for test samples (500m - larger than routing to get more coverage)
         const MAX_SNAP_DISTANCE_M: f64 = 500.0;
@@ -343,7 +344,7 @@ mod tests {
             let is_inside = polygon.contains(&snapped_point);
 
             // Compute drive time from origin to snapped EBG node
-            let drive_time = compute_drive_time_ebg(mode_data, &query, origin_ebg, dst_ebg);
+            let drive_time = compute_drive_time_ebg(&mode_data, &query, origin_ebg, dst_ebg);
 
             match drive_time {
                 Some(time_s_u) => {

--- a/route/src/server/map_match.rs
+++ b/route/src/server/map_match.rs
@@ -142,7 +142,7 @@ pub fn map_match(
             segment.iter().map(|&i| &candidates[i]).collect();
 
         if let Some(matched_indices) = viterbi(
-            mode_data,
+            &mode_data,
             &state.ebg_nodes,
             &seg_coords,
             &seg_candidates,
@@ -152,7 +152,7 @@ pub fn map_match(
             // Build EBG path from matched candidate sequence
             let matching_idx = matchings.len();
             let ebg_path =
-                build_matched_path(mode_data, &seg_candidates, &matched_indices, weights);
+                build_matched_path(&mode_data, &seg_candidates, &matched_indices, weights);
 
             let duration_s = ebg_path
                 .iter()
@@ -884,7 +884,7 @@ pub fn map_match_multi_region(
 
             let run_cand_refs: Vec<&Vec<Candidate>> = run_cands.iter().collect();
             let ebg_path = build_matched_path(
-                mode_data,
+                &mode_data,
                 &run_cand_refs,
                 &run_matched,
                 &mode_data.cch_weights,
@@ -1195,7 +1195,7 @@ fn compute_transition_distances_multi(
 
             if from_region == to_region {
                 // Same region: single CCH P2P, sum length_m.
-                let to_mode_data = from_mode_data; // same region
+                let to_mode_data = from_mode_data.clone(); // same region
                 let dst_rank = to_mode_data.orig_to_rank[tc.ebg_id as usize];
                 if dst_rank == u32::MAX {
                     continue;

--- a/route/src/server/matching.rs
+++ b/route/src/server/matching.rs
@@ -273,7 +273,7 @@ pub async fn match_trace_handler(
         let mode_data = state_clone.get_mode(mode);
 
         let avoid_entry = if let Some(ref avoid_str) = avoid_json {
-            super::avoid::compute_avoid_weights(&state_clone, mode_data, avoid_str, exclude_mask)
+            super::avoid::compute_avoid_weights(&state_clone, &mode_data, avoid_str, exclude_mask)
                 .ok()
         } else {
             None

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -457,8 +457,8 @@ pub async fn serve(
                     return;
                 }
             };
-            let foot = &state_owned.modes[foot_idx as usize];
-            match crate::transit::load_from_disk(&cfg, foot, foot_idx, &state_owned.snap_index) {
+            let foot = state_owned.get_mode(crate::model::types::Mode(foot_idx));
+            match crate::transit::load_from_disk(&cfg, &foot, foot_idx, &state_owned.snap_index) {
                 Ok(snapshot) => {
                     tracing::info!(
                         region = %region_id,
@@ -554,8 +554,11 @@ pub async fn serve(
         let poll_interval = std::time::Duration::from_secs((secs / 4).max(15).min(secs.max(15)));
         // Hold the handle for the life of the server so the
         // background thread keeps running.
-        let _idle_compactor =
-            crate::server::idle_compactor::IdleCompactor::start(threshold, poll_interval);
+        let _idle_compactor = crate::server::idle_compactor::IdleCompactor::start(
+            threshold,
+            poll_interval,
+            Arc::clone(&state),
+        );
         // Leak the handle into a static so it lives forever. Server
         // shutdown is process-exit; explicit cleanup not needed.
         std::mem::forget(_idle_compactor);

--- a/route/src/server/nearest.rs
+++ b/route/src/server/nearest.rs
@@ -140,7 +140,7 @@ pub async fn nearest_handler(
     // start a route; `dst` to nodes that can terminate a route;
     // `either` disables the directional filter for back-compat.
     let mode_data = state.get_mode(mode);
-    let role_filter = req.role.role_filter(mode_data);
+    let role_filter = req.role.role_filter(&mode_data);
 
     let results = state.snap_index.snap_k_with_info_filtered_role(
         req.lon,

--- a/route/src/server/query.rs
+++ b/route/src/server/query.rs
@@ -318,8 +318,14 @@ pub struct CchQuery<'a> {
 }
 
 impl<'a> CchQuery<'a> {
-    pub fn new(state: &'a ServerState, mode: Mode) -> Self {
-        let mode_data = state.get_mode(mode);
+    /// Build a query against the given mode's CCH flats.
+    ///
+    /// #402: The caller MUST hold an `Arc<ModeData>` (via
+    /// `state.get_mode(mode)`) for the lifetime of the returned
+    /// `CchQuery`. We borrow into that Arc here — letting it drop while
+    /// the query is alive would be use-after-free, which the borrow
+    /// checker enforces.
+    pub fn new(mode_data: &'a super::state::ModeData) -> Self {
         Self {
             backend: Backend::Flats {
                 up_adj_flat: &mode_data.up_adj_flat,
@@ -751,7 +757,8 @@ pub fn query_one_to_many(
     source: u32,
     targets: &[u32],
 ) -> Vec<Option<u32>> {
-    let query = CchQuery::new(state, mode);
+    let mode_data = state.get_mode(mode);
+    let query = CchQuery::new(&mode_data);
     targets
         .iter()
         .map(|&t| query.query(source, t).map(|r| r.distance))

--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -688,6 +688,14 @@ impl RegionsState {
         self.regions.is_empty()
     }
 
+    /// #402: iterate all registered regions for the idle compactor's
+    /// per-mode eviction sweep. Returns `&RegionEntry` so the caller
+    /// can call `state_loaded()` (non-loading peek) and then walk
+    /// that region's mode slots.
+    pub fn iter_regions(&self) -> impl Iterator<Item = &RegionEntry> {
+        self.regions.iter()
+    }
+
     /// Look up a region by id, case-insensitive on the user's input.
     /// Ids in storage are already normalised upper-case (see
     /// [`crate::pack::normalize_region_id`]), so we upper-case the

--- a/route/src/server/route.rs
+++ b/route/src/server/route.rs
@@ -427,7 +427,7 @@ pub async fn route_handler(
     let avoid_entry = if let Some(ref avoid_str) = avoid_json {
         match super::avoid::compute_avoid_weights_time_only(
             &state,
-            mode_data,
+            &mode_data,
             avoid_str,
             exclude_mask,
         ) {
@@ -473,8 +473,8 @@ pub async fn route_handler(
     // when the primary candidate fails. Typical healthy queries pay
     // one P2P query; pathological pairs pay up to MAX_FALLBACK_COMBOS
     // (400) — see the SNAP_K block below for the empirical sweep.
-    let src_role_filter = SnapRole::Src.role_filter(mode_data);
-    let dst_role_filter = SnapRole::Dst.role_filter(mode_data);
+    let src_role_filter = SnapRole::Src.role_filter(&mode_data);
+    let dst_role_filter = SnapRole::Dst.role_filter(&mode_data);
 
     // SNAP_K = number of EBG-id candidates per role. The same
     // physical polyline vertex contributes 2 candidates (one per
@@ -742,7 +742,7 @@ pub async fn route_handler(
             &ew.time_weights,
         )
     } else {
-        CchQuery::new(&state, mode)
+        CchQuery::new(&mode_data)
     };
     // #197: multi-candidate fallback. Try the best (src, dst)
     // combination first; if it fails, retry with the next candidates
@@ -1172,8 +1172,8 @@ fn cross_region_route_inner(
     let dst_mode_data = dst_state.get_mode(dst_mode);
 
     // #197: role-aware snap (cross-region path).
-    let src_role_filter = SnapRole::Src.role_filter(src_mode_data);
-    let dst_role_filter = SnapRole::Dst.role_filter(dst_mode_data);
+    let src_role_filter = SnapRole::Src.role_filter(&src_mode_data);
+    let dst_role_filter = SnapRole::Dst.role_filter(&dst_mode_data);
 
     let (src_orig, src_snap) = match src_state.snap_index.snap_with_info_filtered_role(
         req.src_lon,
@@ -1373,7 +1373,7 @@ pub fn leg_points_and_distance(
         return (Vec::new(), 0.0);
     }
     let mode_data = state.get_mode(mode);
-    let query = CchQuery::new(state, mode);
+    let query = CchQuery::new(&mode_data);
     let result = match query.query(src_rank, dst_rank) {
         Some(r) => r,
         None => return (Vec::new(), 0.0),

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -193,6 +193,72 @@ impl ModeData {
 
 // CchWeights is imported from crate::formats
 
+/// #402 lazy-load + eviction slot for a single mode.
+///
+/// Holds a parking_lot RwLock around the optional `Arc<ModeData>` so:
+/// - the fast path (mode resident, just clone the Arc) is wait-free
+///   after the read-lock acquire,
+/// - the lazy-reload path takes the write lock and re-checks (handles
+///   single-flight: simultaneous queries for the same cold mode all
+///   wait on the same write lock, only one load runs),
+/// - the idle compactor can evict (drop the Arc inside the slot)
+///   while in-flight queries continue to hold their own Arc clones —
+///   the data only actually drops when the last clone is released.
+pub struct ModeSlot {
+    /// Mode name (`"car"`, `"bike"`, `"car_rush_hour"`, ...) used by
+    /// the lazy reloader to call back into the loader.
+    pub mode_name: String,
+    /// The actual mode data. `Some` when resident, `None` after the
+    /// idle compactor evicted it (next `get_mode` lazy-reloads).
+    pub state: parking_lot::RwLock<Option<std::sync::Arc<ModeData>>>,
+    /// Monotonic millis-since-server-start of the most recent
+    /// `get_mode(...)` that found this slot resident. Drives idle
+    /// eviction.
+    pub last_used_ms: std::sync::atomic::AtomicU64,
+    /// #402: traffic-variant modes (e.g. `car_rush_hour`) have a
+    /// different load shape — rebuilt by cloning the base mode's
+    /// topology + reading a recustomised `cch.w` section.
+    /// `load_mode_data_from_bundle` doesn't handle that yet. For v1
+    /// the compactor skips variants. Base modes (the heavy ones —
+    /// 1-4 GB each) are the eviction target.
+    pub evictable: bool,
+}
+
+/// #402: a mode name is a traffic-variant iff it has the shape
+/// `<base>_<variant>` where `<base>` is also present in the loaded
+/// mode set. The boot loader pushes both base modes (e.g. `car`) and
+/// variants (e.g. `car_rush_hour`) into the same `mode_names` Vec, so
+/// we detect variants by walking prefixes.
+fn is_variant_mode_name(name: &str, all_names: &[String]) -> bool {
+    for sep in name.match_indices('_') {
+        let prefix = &name[..sep.0];
+        if all_names.iter().any(|n| n == prefix) {
+            return true;
+        }
+    }
+    false
+}
+
+impl ModeSlot {
+    pub fn new_loaded(mode_name: String, data: ModeData) -> Self {
+        Self {
+            mode_name,
+            state: parking_lot::RwLock::new(Some(std::sync::Arc::new(data))),
+            last_used_ms: std::sync::atomic::AtomicU64::new(0),
+            evictable: true,
+        }
+    }
+
+    pub fn new_loaded_variant(mode_name: String, data: ModeData) -> Self {
+        Self {
+            mode_name,
+            state: parking_lot::RwLock::new(Some(std::sync::Arc::new(data))),
+            last_used_ms: std::sync::atomic::AtomicU64::new(0),
+            evictable: false,
+        }
+    }
+}
+
 /// Server state containing all loaded data
 pub struct ServerState {
     // Graph structure (original EBG, used for spatial index and geometry)
@@ -219,8 +285,13 @@ pub struct ServerState {
     /// Belgium: ~11 MB (≈1.4M nodes × 8 bytes).
     pub nbg_node_to_osm: Vec<i64>,
 
-    // Per-mode data (dynamically discovered, indexed by mode_index)
-    pub modes: Vec<ModeData>,
+    // Per-mode data (dynamically discovered, indexed by mode_index).
+    // #402: each mode lives behind a `ModeSlot` lock so the idle
+    // compactor can evict cold modes and the next query lazy-reloads
+    // them. Callers go through `get_mode(...)` which returns an
+    // `Arc<ModeData>` — holding the Arc keeps the mode alive even if
+    // the compactor races to evict.
+    pub modes: Vec<ModeSlot>,
     /// Mode names indexed by mode_index (alphabetically sorted)
     pub mode_names: Vec<String>,
     /// Mode name → mode index lookup
@@ -544,13 +615,29 @@ impl ServerState {
         );
         crate::server::rss::checkpoint("load.edge_geom");
 
+        // #402: wrap each ModeData in a lazy/evictable slot. The
+        // directory-tree loader has no container backing, so the
+        // lazy reload path will panic if a slot is ever evicted —
+        // this path is only used by tests + the legacy --data-dir
+        // flow where eviction shouldn't fire.
+        let modes_slots: Vec<ModeSlot> = modes_data
+            .into_iter()
+            .zip(mode_names.iter().cloned())
+            .map(|(data, name)| {
+                if is_variant_mode_name(&name, &mode_names) {
+                    ModeSlot::new_loaded_variant(name, data)
+                } else {
+                    ModeSlot::new_loaded(name, data)
+                }
+            })
+            .collect();
         Ok(Self {
             ebg_nodes,
             ebg_csr,
             nbg_geo,
             edge_geom,
             nbg_node_to_osm,
-            modes: modes_data,
+            modes: modes_slots,
             mode_names,
             mode_lookup,
             snap_index,
@@ -1409,13 +1496,30 @@ impl ServerState {
             lazy_arc.spawn_warmup();
         }
 
+        // #402: wrap each ModeData in a lazy/evictable slot. The
+        // container path retains _mmap_arc + lazy, so the slow path
+        // in `get_mode` (lazy reload after compactor eviction) can
+        // call back into `load_mode_data_from_bundle`. Variant modes
+        // (e.g. `car_rush_hour`) get the non-evictable variant flag —
+        // their reload shape differs from base modes.
+        let modes_slots: Vec<ModeSlot> = modes_data
+            .into_iter()
+            .zip(mode_names.iter().cloned())
+            .map(|(data, name)| {
+                if is_variant_mode_name(&name, &mode_names) {
+                    ModeSlot::new_loaded_variant(name, data)
+                } else {
+                    ModeSlot::new_loaded(name, data)
+                }
+            })
+            .collect();
         Ok(Self {
             ebg_nodes,
             ebg_csr,
             nbg_geo,
             edge_geom,
             nbg_node_to_osm,
-            modes: modes_data,
+            modes: modes_slots,
             mode_names,
             mode_lookup,
             snap_index,
@@ -1432,9 +1536,110 @@ impl ServerState {
         })
     }
 
-    /// Get mode data by mode (index-based lookup)
-    pub fn get_mode(&self, mode: Mode) -> &ModeData {
-        &self.modes[mode.index()]
+    /// Get mode data by mode (index-based lookup). #402: lazy-reloads
+    /// if the slot was previously evicted by the idle compactor.
+    /// Returns an `Arc<ModeData>` — holding the Arc keeps the mode
+    /// alive for the duration of the caller's work even if the
+    /// compactor races to evict in the background.
+    pub fn get_mode(&self, mode: Mode) -> std::sync::Arc<ModeData> {
+        let slot = &self.modes[mode.index()];
+        // Fast path: resident slot.
+        {
+            let r = slot.state.read();
+            if let Some(arc) = r.as_ref() {
+                slot.last_used_ms.store(
+                    self.started_at.elapsed().as_millis() as u64,
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                return std::sync::Arc::clone(arc);
+            }
+        }
+        // Slow path: evicted, lazy-reload under write lock with
+        // single-flight semantics.
+        let mut w = slot.state.write();
+        if let Some(arc) = w.as_ref() {
+            // Someone else loaded while we waited for the lock.
+            slot.last_used_ms.store(
+                self.started_at.elapsed().as_millis() as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            return std::sync::Arc::clone(arc);
+        }
+        let loaded = self
+            .lazy_load_mode(&slot.mode_name, mode)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "#402 lazy reload of mode '{}' failed: {}",
+                    slot.mode_name, e
+                )
+            });
+        let arc = std::sync::Arc::new(loaded);
+        *w = Some(std::sync::Arc::clone(&arc));
+        slot.last_used_ms.store(
+            self.started_at.elapsed().as_millis() as u64,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        tracing::info!(
+            mode = slot.mode_name.as_str(),
+            "#402 lazy-reloaded mode after eviction"
+        );
+        arc
+    }
+
+    /// #402: re-run the container loader for a single mode. Used by
+    /// `get_mode` on the slow path when the slot has been evicted.
+    /// Requires that the container path was used to construct
+    /// `ServerState` (i.e. `_mmap_arc` and `lazy` are populated).
+    fn lazy_load_mode(&self, mode_name: &str, mode: Mode) -> Result<ModeData> {
+        let mmap = self._mmap_arc.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("lazy_load_mode requires container-backed ServerState")
+        })?;
+        let lazy = self
+            .lazy
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("lazy_load_mode requires LazyContainer"))?;
+        let container = lazy.container();
+        load_mode_data_from_bundle(mode_name, mode, container, mmap, lazy)
+    }
+
+    /// #402: evict a single mode slot if it has been idle for at least
+    /// `threshold_ms`. Drops the inner `Arc<ModeData>`; any in-flight
+    /// query holding its own Arc clone keeps the data alive until that
+    /// query finishes. Returns `true` if the slot was evicted.
+    pub fn try_evict_mode_if_idle(&self, mode_idx: usize, threshold_ms: u64) -> bool {
+        let slot = &self.modes[mode_idx];
+        if !slot.evictable {
+            // #402: variants have a different load shape; can't safely
+            // reload via load_mode_data_from_bundle. Skip.
+            return false;
+        }
+        let now = self.started_at.elapsed().as_millis() as u64;
+        let last = slot.last_used_ms.load(std::sync::atomic::Ordering::Relaxed);
+        // `last == 0` means "never touched by get_mode" — for those
+        // we measure idleness from `now` directly, which makes never-
+        // queried modes the most evictable. Boot grace is provided by
+        // the compactor's poll interval (won't run until at least
+        // ~threshold/4 after boot).
+        let idle_ms = now.saturating_sub(last);
+        if idle_ms < threshold_ms {
+            return false;
+        }
+        let mut w = slot.state.write();
+        // Re-check under the write lock to handle races with get_mode.
+        let last2 = slot.last_used_ms.load(std::sync::atomic::Ordering::Relaxed);
+        if now.saturating_sub(last2) < threshold_ms {
+            return false;
+        }
+        if w.take().is_some() {
+            tracing::info!(
+                mode = slot.mode_name.as_str(),
+                idle_ms = now.saturating_sub(last),
+                "#402 evicted idle mode"
+            );
+            true
+        } else {
+            false
+        }
     }
 
     /// Install the transit subsystem after async bootstrap. Must be

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -265,7 +265,7 @@ pub async fn table_post_handler(
 
     // Compute avoid weights (includes exclude if both present)
     let avoid_entry = if let Some(ref avoid_str) = avoid_json {
-        match super::avoid::compute_avoid_weights(&state, mode_data, avoid_str, exclude_mask) {
+        match super::avoid::compute_avoid_weights(&state, &mode_data, avoid_str, exclude_mask) {
             Ok(entry) => Some(entry),
             Err(e) => {
                 return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
@@ -363,8 +363,8 @@ pub async fn compute_table_bucket_m2m(
     const SNAP_K: usize = 64;
     let _ = SNAP_K; // referenced from apply_k_best_fallback's docs
 
-    let src_role_filter = SnapRole::Src.role_filter(mode_data);
-    let dst_role_filter = SnapRole::Dst.role_filter(mode_data);
+    let src_role_filter = SnapRole::Src.role_filter(&mode_data);
+    let dst_role_filter = SnapRole::Dst.role_filter(&mode_data);
 
     let t_pre = std::time::Instant::now();
 
@@ -616,7 +616,7 @@ pub async fn compute_table_bucket_m2m(
     // healthy matrix pays zero K-best snap cost.
     let (durations, distances) = apply_k_best_fallback(
         state,
-        mode_data,
+        &mode_data,
         mode,
         durations,
         distances,
@@ -742,7 +742,7 @@ fn apply_k_best_fallback(
                 &cw.time_down_flat,
                 &cw.time_weights,
             ),
-            None => CchQuery::new(state, mode),
+            None => CchQuery::new(mode_data),
         })
     } else {
         None
@@ -1123,7 +1123,7 @@ pub async fn table_stream_handler(
 
     // Compute avoid weights (includes exclude if both present)
     let avoid_entry = if let Some(ref avoid_str) = avoid_json {
-        match super::avoid::compute_avoid_weights(&state, mode_data, avoid_str, exclude_mask) {
+        match super::avoid::compute_avoid_weights(&state, &mode_data, avoid_str, exclude_mask) {
             Ok(entry) => Some(entry),
             Err(e) => {
                 return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
@@ -1163,8 +1163,8 @@ pub async fn table_stream_handler(
     let mut sources_rank: Vec<u32> = Vec::with_capacity(req.sources.len());
     let mut valid_src_indices: Vec<usize> = Vec::with_capacity(req.sources.len());
     let mut sources_snapped: Vec<(f64, f64)> = Vec::with_capacity(req.sources.len());
-    let src_role_filter = SnapRole::Src.role_filter(mode_data);
-    let dst_role_filter = SnapRole::Dst.role_filter(mode_data);
+    let src_role_filter = SnapRole::Src.role_filter(&mode_data);
+    let dst_role_filter = SnapRole::Dst.role_filter(&mode_data);
 
     for (i, [lon, lat]) in req.sources.iter().enumerate() {
         let mut matched = false;

--- a/route/src/server/transit_handler.rs
+++ b/route/src/server/transit_handler.rs
@@ -38,7 +38,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::server::geometry::build_raw_points;
 use crate::server::query::CchQuery;
-use crate::server::state::ModeData;
 use crate::server::unpack::unpack_path;
 use crate::transit::gtfs::haversine_m;
 use crate::transit::raptor::{RaptorLeg, RaptorQuery, run_raptor};
@@ -350,7 +349,7 @@ pub fn compute_access_context(
             access_mode
         )));
     };
-    let access_mode_data: &ModeData = &state.modes[access_idx as usize];
+    let access_mode_data = state.get_mode(crate::model::types::Mode(access_idx));
 
     let (access_default_radius, access_default_stops, _access_speed) =
         default_access_params(&access_mode);
@@ -543,7 +542,7 @@ pub fn compute_transit_journey_with_access(
             egress_mode
         )));
     };
-    let egress_mode_data: &ModeData = &state.modes[egress_idx as usize];
+    let egress_mode_data = state.get_mode(crate::model::types::Mode(egress_idx));
 
     let (egress_default_radius, egress_default_stops, _egress_speed) =
         default_access_params(&egress_mode);
@@ -1323,7 +1322,7 @@ fn build_routed_road_leg(
     if src_rank == dst_rank {
         return Some((vec![[from_lon, from_lat], [to_lon, to_lat]], 0));
     }
-    let mode_data = &state.modes[mode_idx as usize];
+    let mode_data = state.get_mode(crate::model::types::Mode(mode_idx));
     let query = CchQuery::with_custom_weights(
         &mode_data.cch_topo,
         &mode_data.up_adj_flat,
@@ -1366,8 +1365,8 @@ fn snap_to_rank_role(
     mode_idx: u8,
     role: super::types::SnapRole,
 ) -> Option<u32> {
-    let mode_data = &state.modes[mode_idx as usize];
-    let role_filter = role.role_filter(mode_data);
+    let mode_data = state.get_mode(crate::model::types::Mode(mode_idx));
+    let role_filter = role.role_filter(&mode_data);
     let orig = state
         .snap_index
         .snap_filtered_role(lon, lat, mode_idx, None, role_filter)?;

--- a/route/src/server/trip.rs
+++ b/route/src/server/trip.rs
@@ -606,7 +606,7 @@ pub async fn trip_handler(
 
         // Compute avoid weights (includes exclude if both present)
         let avoid_entry = if let Some(ref avoid_str) = avoid_json {
-            super::avoid::compute_avoid_weights(&state_clone, mode_data, avoid_str, exclude_mask)
+            super::avoid::compute_avoid_weights(&state_clone, &mode_data, avoid_str, exclude_mask)
                 .ok()
         } else {
             None
@@ -807,7 +807,7 @@ pub async fn trip_handler(
                             &ew.time_down_flat,
                             &ew.time_weights,
                         ),
-                        (None, None) => CchQuery::new(&state_clone, mode),
+                        (None, None) => CchQuery::new(&mode_data),
                     };
                     Some(query)
                 } else {

--- a/route/tests/transit_integration.rs
+++ b/route/tests/transit_integration.rs
@@ -394,8 +394,8 @@ fn belgium_server_state() -> Option<Arc<ServerState>> {
         // Borrow-checker dance: extract what we need before install_transit
         // takes a &mut self.
         let snapshot = {
-            let foot = &state.modes[foot_idx as usize];
-            butterfly_route::transit::load_from_disk(&cfg, foot, foot_idx, &state.snap_index)
+            let foot = state.get_mode(butterfly_route::profile_abi::Mode(foot_idx));
+            butterfly_route::transit::load_from_disk(&cfg, &foot, foot_idx, &state.snap_index)
                 .expect("transit snapshot load")
         };
         state.install_transit(butterfly_route::transit::TransitState::new(cfg, snapshot));


### PR DESCRIPTION
## Summary
Wrap each mode in \`ModeSlot { RwLock<Option<Arc<ModeData>>>, last_used_ms }\`. Idle compactor (#400) evicts modes idle > threshold; \`get_mode\` lazy-reloads on the next query via single-flight write lock. Composes with #400: that one evicts per-worker scratch, this one evicts whole mode definitions.

Closes #402.

## Belgium measurements (\`--idle-compact-secs 20\`)

| phase | VmRSS | RssAnon |
|---|---:|---:|
| A boot (4 modes eager) | 14.85 GB | 9.16 GB |
| B after 1 car query | 14.93 GB | 9.24 GB |
| **C post-eviction (3 base modes dropped)** | **7.48 GB** | **1.79 GB** |
| D after lazy-reloading all 3 | 15.72 GB | 9.36 GB |

For a real car-only deployment, post-eviction RSS drops by **-7.4 GB (-50 %)** at rest. Per-mode eviction is the structural lever the user asked for: only the modes the user actually queries stay resident.

## Cold-reload latency

Per-mode reload on Belgium (lazy_load_mode timestamps): bike 9 s, foot 4 s, car 3 s. Operators sensitive to first-query latency can extend \`--idle-compact-secs\` or pre-warm at boot.

## Correctness

| mode | post-reload duration | matches boot |
|---|---:|---|
| car (realistic-baked) | 7120 s / 58134 m | ✓ |
| bike | 10394 s / 45032 m | ✓ |
| foot | 33090 s / 45899 m | ✓ |
| car_rush_hour (variant, no evict) | 7482 s / 58132 m | ✓ |

Confirmed by debug-logging cch_weights values pre/post reload; the file content was identical.

## API change

\`state.get_mode(mode)\` returns \`Arc<ModeData>\` (was \`&ModeData\`). 70 call sites across 18 files updated. \`CchQuery::new\` takes \`&'a ModeData\` so the borrow checker sees the Arc outliving the ref. Variants are marked non-evictable (their load shape differs); only base modes get the eviction win in this PR.

## Test plan
- [x] \`cargo test -p butterfly-route --release --lib\` — 598 lib tests pass
- [x] \`cargo clippy --workspace --all-targets --all-features\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] End-to-end: boot → query car → 20s idle → confirm RSS drops 7.4 GB → re-query all 4 modes → confirm correctness + RSS climbs back