### PR TITLE
feat(matrix): max_minutes duration bound on /table + Flight matrix (#415)

### DIFF
--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -2350,7 +2350,7 @@ struct SearchState {
     pushes: usize,
     pops: usize,
     stale_pops: usize, // Should always be 0 with decrease-key
-    /// Early-stop bound (#412-matrix / max_minutes): `pop()` returns `None`
+    /// Early-stop bound (#415 / max_minutes): `pop()` returns `None`
     /// once the heap minimum exceeds this. `u32::MAX` = unbounded (no
     /// behavioural change). The min-heap pops in non-decreasing order, so
     /// once the minimum crosses the threshold every remaining entry does
@@ -3126,7 +3126,7 @@ pub fn forward_build_buckets(
     forward_build_buckets_bounded(n_nodes, up_adj_flat, sources, u32::MAX)
 }
 
-/// Time-bounded [`forward_build_buckets`] (#12). Stops each source's forward
+/// Time-bounded [`forward_build_buckets`] (#415). Stops each source's forward
 /// sweep once the up-distance exceeds `threshold`. `u32::MAX` = unbounded.
 pub fn forward_build_buckets_bounded(
     n_nodes: usize,
@@ -3184,7 +3184,7 @@ pub fn backward_join_with_buckets(
     backward_join_with_buckets_bounded(n_nodes, down_rev_flat, source_buckets, targets, u32::MAX)
 }
 
-/// Time-bounded [`backward_join_with_buckets`] (#12). Stops each target's
+/// Time-bounded [`backward_join_with_buckets`] (#415). Stops each target's
 /// backward sweep once the down-distance exceeds `threshold`. Pairs whose
 /// shortest time exceeds `threshold` are left as `u32::MAX` or a non-minimal
 /// value > `threshold`; the caller must treat any cell > `threshold` as
@@ -3450,7 +3450,7 @@ pub fn table_bucket_parallel(
     )
 }
 
-/// Time-bounded variant of [`table_bucket_parallel`] (max_minutes, #12).
+/// Time-bounded variant of [`table_bucket_parallel`] (max_minutes, #415).
 ///
 /// Stops every forward and backward sweep once the popped distance exceeds
 /// `threshold` (in the metric of `up_adj_flat`/`down_rev_flat` — pass the
@@ -4629,7 +4629,7 @@ pub fn table_bucket_parallel_len_along_time(
     )
 }
 
-/// Time-bounded 2-channel bucket-M2M (max_minutes, #12). `threshold` bounds
+/// Time-bounded 2-channel bucket-M2M (max_minutes, #415). `threshold` bounds
 /// the TIME channel (the ordering metric); the length-along-time channel is
 /// carried unbounded alongside. `u32::MAX` = unbounded. See
 /// [`table_bucket_parallel_bounded`] for the exactness argument — it applies
@@ -5592,7 +5592,7 @@ mod step_a_tests {
 
 #[cfg(test)]
 mod max_minutes_bound_tests {
-    //! #12 max_minutes — exactness of the time-bounded bucket-M2M.
+    //! #415 max_minutes — exactness of the time-bounded bucket-M2M.
     //!
     //! Each test builds a deterministic "broom" graph: every leaf node has a
     //! single UP edge to one apex node, and a single reverse-down edge to the

--- a/route/src/matrix/bucket_ch.rs
+++ b/route/src/matrix/bucket_ch.rs
@@ -2350,6 +2350,15 @@ struct SearchState {
     pushes: usize,
     pops: usize,
     stale_pops: usize, // Should always be 0 with decrease-key
+    /// Early-stop bound (#412-matrix / max_minutes): `pop()` returns `None`
+    /// once the heap minimum exceeds this. `u32::MAX` = unbounded (no
+    /// behavioural change). The min-heap pops in non-decreasing order, so
+    /// once the minimum crosses the threshold every remaining entry does
+    /// too — stopping here is exact for the reachable-within-threshold set.
+    /// Set per-sweep by the bounded entry points; preserved across
+    /// `start_search()` so it must be reset explicitly when reusing a
+    /// thread-local state for an unbounded query.
+    dist_threshold: u32,
 }
 
 impl SearchState {
@@ -2368,6 +2377,7 @@ impl SearchState {
             pushes: 0,
             pops: 0,
             stale_pops: 0,
+            dist_threshold: u32::MAX,
         }
     }
 
@@ -2424,6 +2434,13 @@ impl SearchState {
     #[inline]
     fn pop(&mut self) -> Option<(u32, u32)> {
         if let Some((dist, node)) = self.heap.pop(&mut self.handles) {
+            // Bounded early-stop: the popped node already had its handle
+            // cleared by `DAryHeap::pop`, so returning `None` here cleanly
+            // terminates the sweep. Every node with final distance
+            // <= dist_threshold has already been settled (min-heap order).
+            if dist > self.dist_threshold {
+                return None;
+            }
             self.pops += 1;
             // Mark as settled (handle becomes INVALID_HANDLE after pop in heapify_down)
             self.handles[node as usize] = INVALID_HANDLE;
@@ -2893,6 +2910,7 @@ impl BucketM2MEngine {
         down_rev_flat: &DownReverseAdjFlat,
         sources: &[u32],
         targets: &[u32],
+        threshold: u32,
     ) -> (Vec<u32>, BucketM2MStats) {
         let n_sources = sources.len();
         let n_targets = targets.len();
@@ -2908,6 +2926,10 @@ impl BucketM2MEngine {
             n_targets,
             ..Default::default()
         };
+
+        // max_minutes bound: stop both forward and backward sweeps once the
+        // time metric exceeds `threshold`. `u32::MAX` = unbounded.
+        self.state.dist_threshold = threshold;
 
         // Clear bucket items (reuse allocation)
         self.bucket_items.clear();
@@ -3101,6 +3123,17 @@ pub fn forward_build_buckets(
     up_adj_flat: &UpAdjFlat,
     sources: &[u32],
 ) -> SourceBuckets {
+    forward_build_buckets_bounded(n_nodes, up_adj_flat, sources, u32::MAX)
+}
+
+/// Time-bounded [`forward_build_buckets`] (#12). Stops each source's forward
+/// sweep once the up-distance exceeds `threshold`. `u32::MAX` = unbounded.
+pub fn forward_build_buckets_bounded(
+    n_nodes: usize,
+    up_adj_flat: &UpAdjFlat,
+    sources: &[u32],
+    threshold: u32,
+) -> SourceBuckets {
     let n_sources = sources.len();
 
     if n_sources == 0 {
@@ -3115,6 +3148,7 @@ pub fn forward_build_buckets(
 
     // Single reusable search state
     let mut state = SearchState::new(n_nodes, avg_visited);
+    state.dist_threshold = threshold;
 
     // Collect bucket items: (node, source_idx, dist)
     let mut bucket_items: Vec<(u32, u32, u32)> = Vec::with_capacity(n_sources * avg_visited);
@@ -3147,6 +3181,21 @@ pub fn backward_join_with_buckets(
     source_buckets: &SourceBuckets,
     targets: &[u32],
 ) -> Vec<u32> {
+    backward_join_with_buckets_bounded(n_nodes, down_rev_flat, source_buckets, targets, u32::MAX)
+}
+
+/// Time-bounded [`backward_join_with_buckets`] (#12). Stops each target's
+/// backward sweep once the down-distance exceeds `threshold`. Pairs whose
+/// shortest time exceeds `threshold` are left as `u32::MAX` or a non-minimal
+/// value > `threshold`; the caller must treat any cell > `threshold` as
+/// out-of-bound. `u32::MAX` = unbounded.
+pub fn backward_join_with_buckets_bounded(
+    n_nodes: usize,
+    down_rev_flat: &DownReverseAdjFlat,
+    source_buckets: &SourceBuckets,
+    targets: &[u32],
+    threshold: u32,
+) -> Vec<u32> {
     let n_sources = source_buckets.n_sources;
     let n_targets = targets.len();
 
@@ -3159,6 +3208,7 @@ pub fn backward_join_with_buckets(
     // Estimate for pre-allocation
     let avg_visited = (n_nodes / 400).clamp(500, 20000);
     let mut state = SearchState::new(n_nodes, avg_visited);
+    state.dist_threshold = threshold;
 
     for (target_idx, &target) in targets.iter().enumerate() {
         if target as usize >= n_nodes {
@@ -3390,6 +3440,37 @@ pub fn table_bucket_parallel(
     sources: &[u32],
     targets: &[u32],
 ) -> (Vec<u32>, BucketM2MStats) {
+    table_bucket_parallel_bounded(
+        n_nodes,
+        up_adj_flat,
+        down_rev_flat,
+        sources,
+        targets,
+        u32::MAX,
+    )
+}
+
+/// Time-bounded variant of [`table_bucket_parallel`] (max_minutes, #12).
+///
+/// Stops every forward and backward sweep once the popped distance exceeds
+/// `threshold` (in the metric of `up_adj_flat`/`down_rev_flat` — pass the
+/// TIME flats and a seconds threshold). `u32::MAX` = unbounded (identical
+/// behaviour to the wrapper above).
+///
+/// Exactness: for any pair whose shortest distance d(s→t) ≤ `threshold`, the
+/// optimal CCH meeting node m* satisfies up(s→m*) ≤ d ≤ threshold and
+/// down(m*→t) ≤ d ≤ threshold, so m* survives both bounded sweeps and the
+/// join recovers d exactly. Pairs with d(s→t) > `threshold` may be returned
+/// as `u32::MAX` or as a non-minimal value > `threshold`; callers MUST treat
+/// any cell > `threshold` as out-of-bound (the /table handler nulls them).
+pub fn table_bucket_parallel_bounded(
+    n_nodes: usize,
+    up_adj_flat: &UpAdjFlat,
+    down_rev_flat: &DownReverseAdjFlat,
+    sources: &[u32],
+    targets: &[u32],
+    threshold: u32,
+) -> (Vec<u32>, BucketM2MStats) {
     let n_sources = sources.len();
     let n_targets = targets.len();
 
@@ -3416,7 +3497,7 @@ pub fn table_bucket_parallel(
                     if engine.n_nodes != n_nodes {
                         *engine = BucketM2MEngine::new(n_nodes);
                     }
-                    engine.compute_flat(up_adj_flat, down_rev_flat, sources, targets)
+                    engine.compute_flat(up_adj_flat, down_rev_flat, sources, targets, threshold)
                 },
             )
         });
@@ -3437,6 +3518,7 @@ pub fn table_bucket_parallel(
             sources,
             targets,
             tile,
+            threshold,
         );
     }
 
@@ -3471,6 +3553,7 @@ pub fn table_bucket_parallel(
                             if state.entries.len() != n_nodes {
                                 *state = SearchState::new(n_nodes, avg_visited);
                             }
+                            state.dist_threshold = threshold;
                             items_cell.with_or_init(Vec::new, |items| {
                                 items.clear();
 
@@ -3535,6 +3618,7 @@ pub fn table_bucket_parallel(
                         if state.entries.len() != n_nodes {
                             *state = SearchState::new(n_nodes, avg_visited);
                         }
+                        state.dist_threshold = threshold;
                         backward_join_parallel_prefix(
                             down_rev_flat,
                             target,
@@ -3588,6 +3672,7 @@ fn table_bucket_parallel_l3_tiled(
     sources: &[u32],
     targets: &[u32],
     src_tile_size: usize,
+    threshold: u32,
 ) -> (Vec<u32>, BucketM2MStats) {
     use std::sync::atomic::AtomicU32;
 
@@ -3631,6 +3716,7 @@ fn table_bucket_parallel_l3_tiled(
                                 if state.entries.len() != n_nodes {
                                     *state = SearchState::new(n_nodes, avg_visited);
                                 }
+                                state.dist_threshold = threshold;
                                 items_cell.with_or_init(Vec::new, |items| {
                                     items.clear();
 
@@ -3685,6 +3771,7 @@ fn table_bucket_parallel_l3_tiled(
                             if state.entries.len() != n_nodes {
                                 *state = SearchState::new(n_nodes, avg_visited);
                             }
+                            state.dist_threshold = threshold;
                             backward_join_tile(
                                 down_rev_flat,
                                 target,
@@ -4109,6 +4196,9 @@ struct SearchState2 {
     handles: Vec<u32>,
     pushes: usize,
     pops: usize,
+    /// Early-stop bound on the ordering metric (time). See
+    /// [`SearchState::dist_threshold`]. `u32::MAX` = unbounded.
+    dist_threshold: u32,
 }
 
 impl SearchState2 {
@@ -4127,6 +4217,7 @@ impl SearchState2 {
             handles: vec![INVALID_HANDLE; n_nodes],
             pushes: 0,
             pops: 0,
+            dist_threshold: u32::MAX,
         }
     }
 
@@ -4180,6 +4271,11 @@ impl SearchState2 {
     #[inline]
     fn pop(&mut self) -> Option<(u32, u32, u32)> {
         if let Some((dist, node)) = self.heap.pop(&mut self.handles) {
+            // Bounded early-stop on the time metric (`dist`). See
+            // `SearchState::pop`.
+            if dist > self.dist_threshold {
+                return None;
+            }
             self.pops += 1;
             self.handles[node as usize] = INVALID_HANDLE;
             let lat = self.lats[node as usize];
@@ -4315,6 +4411,7 @@ pub fn table_bucket_full_flat_len_along_time(
     down_rev_flat_len_along_time: &DownReverseAdjFlat,
     sources: &[u32],
     targets: &[u32],
+    threshold: u32,
 ) -> (Vec<u32>, Vec<u32>, BucketM2MStats) {
     let n_sources = sources.len();
     let n_targets = targets.len();
@@ -4350,6 +4447,7 @@ pub fn table_bucket_full_flat_len_along_time(
                         // Reset cumulative perf counters per call.
                         state.pushes = 0;
                         state.pops = 0;
+                        state.dist_threshold = threshold;
                         buckets_cell.with_or_init(
                             || PrefixSumBuckets2::new(n_nodes),
                             |buckets| {
@@ -4519,6 +4617,37 @@ pub fn table_bucket_parallel_len_along_time(
     sources: &[u32],
     targets: &[u32],
 ) -> (Vec<u32>, Vec<u32>, BucketM2MStats) {
+    table_bucket_parallel_len_along_time_bounded(
+        n_nodes,
+        up_adj_flat,
+        down_rev_flat,
+        up_adj_flat_len_along_time,
+        down_rev_flat_len_along_time,
+        sources,
+        targets,
+        u32::MAX,
+    )
+}
+
+/// Time-bounded 2-channel bucket-M2M (max_minutes, #12). `threshold` bounds
+/// the TIME channel (the ordering metric); the length-along-time channel is
+/// carried unbounded alongside. `u32::MAX` = unbounded. See
+/// [`table_bucket_parallel_bounded`] for the exactness argument — it applies
+/// identically here because the heap orders on time. The returned `time`
+/// matrix is `u32::MAX` (or a value > threshold) for out-of-bound pairs, and
+/// the paired `lat` cell for those pairs is meaningless — the /table handler
+/// nulls both whenever the time cell exceeds the bound.
+#[allow(clippy::too_many_arguments)]
+pub fn table_bucket_parallel_len_along_time_bounded(
+    n_nodes: usize,
+    up_adj_flat: &UpAdjFlat,
+    down_rev_flat: &DownReverseAdjFlat,
+    up_adj_flat_len_along_time: &UpAdjFlat,
+    down_rev_flat_len_along_time: &DownReverseAdjFlat,
+    sources: &[u32],
+    targets: &[u32],
+    threshold: u32,
+) -> (Vec<u32>, Vec<u32>, BucketM2MStats) {
     let n_sources = sources.len();
     let n_targets = targets.len();
 
@@ -4546,6 +4675,7 @@ pub fn table_bucket_parallel_len_along_time(
             down_rev_flat_len_along_time,
             sources,
             targets,
+            threshold,
         );
     }
 
@@ -4573,6 +4703,7 @@ pub fn table_bucket_parallel_len_along_time(
                             if state.entries.len() != n_nodes {
                                 *state = SearchState2::new(n_nodes, avg_visited);
                             }
+                            state.dist_threshold = threshold;
                             items_cell.with_or_init(Vec::new, |items| {
                                 items.clear();
                                 forward_fill_buckets_flat_len_along_time(
@@ -4633,6 +4764,7 @@ pub fn table_bucket_parallel_len_along_time(
                         if state.entries.len() != n_nodes {
                             *state = SearchState2::new(n_nodes, avg_visited);
                         }
+                        state.dist_threshold = threshold;
                         let mut time_col = vec![u32::MAX; n_sources];
                         let mut lat_col = vec![u32::MAX; n_sources];
                         let (visited, joins) = backward_join_local_columns_len_along_time(
@@ -5033,24 +5165,45 @@ mod step_a_tests {
         let (mono, _) = table_bucket_parallel(n_nodes, &up_adj, &down_rev, &sources, &targets);
 
         // L3-tiled with tile=1 (one source per tile — most aggressive split).
-        let (tiled, _) =
-            table_bucket_parallel_l3_tiled(n_nodes, &up_adj, &down_rev, &sources, &targets, 1);
+        let (tiled, _) = table_bucket_parallel_l3_tiled(
+            n_nodes,
+            &up_adj,
+            &down_rev,
+            &sources,
+            &targets,
+            1,
+            u32::MAX,
+        );
         assert_eq!(
             tiled, mono,
             "L3-tiled (tile=1) must match monolithic byte-for-byte"
         );
 
         // Also exercise tile=3 (forces non-uniform last tile).
-        let (tiled3, _) =
-            table_bucket_parallel_l3_tiled(n_nodes, &up_adj, &down_rev, &sources, &targets, 3);
+        let (tiled3, _) = table_bucket_parallel_l3_tiled(
+            n_nodes,
+            &up_adj,
+            &down_rev,
+            &sources,
+            &targets,
+            3,
+            u32::MAX,
+        );
         assert_eq!(
             tiled3, mono,
             "L3-tiled (tile=3) must match monolithic byte-for-byte"
         );
 
         // And tile=8 (one tile, equivalent to monolithic shape).
-        let (tiled8, _) =
-            table_bucket_parallel_l3_tiled(n_nodes, &up_adj, &down_rev, &sources, &targets, 8);
+        let (tiled8, _) = table_bucket_parallel_l3_tiled(
+            n_nodes,
+            &up_adj,
+            &down_rev,
+            &sources,
+            &targets,
+            8,
+            u32::MAX,
+        );
         assert_eq!(
             tiled8, mono,
             "L3-tiled (tile=8 = whole problem) must match monolithic"
@@ -5434,5 +5587,194 @@ mod step_a_tests {
         let err = decode_flat_weights_bytes(&bytes).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("CRC"), "expected CRC error, got: {msg}");
+    }
+}
+
+#[cfg(test)]
+mod max_minutes_bound_tests {
+    //! #12 max_minutes — exactness of the time-bounded bucket-M2M.
+    //!
+    //! Each test builds a deterministic "broom" graph: every leaf node has a
+    //! single UP edge to one apex node, and a single reverse-down edge to the
+    //! same apex. The bucket-M2M then computes, for leaf source `s` and leaf
+    //! target `t`, exactly `d(s→t) = wu[s] + wd[t]` (and `0` on the diagonal),
+    //! via the apex meeting node. Because there is exactly one path, an
+    //! out-of-bound cell settles to `u32::MAX` — so we can assert the strict
+    //! invariant: `bounded[c] == unbounded[c]` when `unbounded[c] ≤ threshold`,
+    //! else `bounded[c] == u32::MAX`. This exercises the real `SearchState`
+    //! early-stop through the sequential (≤100 cells) and monolithic (>100)
+    //! dispatch paths, plus the 2-channel variant.
+    use super::*;
+    use crate::formats::{ArcCow, WeightArray};
+
+    /// Build a broom with `n_leaf` leaves (ids 0..n_leaf) and one apex
+    /// (id n_leaf). UP weights = (i+1)*10, reverse-down weights = (i+1).
+    /// Returns (n_nodes, up, down, wu, wd).
+    fn broom(n_leaf: usize) -> (usize, UpAdjFlat, DownReverseAdjFlat, Vec<u32>, Vec<u32>) {
+        let apex = n_leaf as u32;
+        let n_nodes = n_leaf + 1;
+        let wu: Vec<u32> = (0..n_leaf).map(|i| (i as u32 + 1) * 10).collect();
+        let wd: Vec<u32> = (0..n_leaf).map(|i| i as u32 + 1).collect();
+
+        // CSR: each leaf has 1 edge to apex; apex has 0.
+        let mut offsets: Vec<u64> = Vec::with_capacity(n_nodes + 1);
+        for i in 0..=n_nodes {
+            offsets.push(i.min(n_leaf) as u64);
+        }
+        let up_targets: Vec<u32> = vec![apex; n_leaf];
+        let dn_sources: Vec<u32> = vec![apex; n_leaf];
+
+        let up = UpAdjFlat {
+            offsets: ArcCow::from_vec(offsets.clone()),
+            targets: ArcCow::from_vec(up_targets),
+            weights: WeightArray::from_vec_u32(wu.clone()),
+            topo_edge_idx: ArcCow::from_vec(Vec::new()),
+        };
+        let down = DownReverseAdjFlat {
+            offsets: ArcCow::from_vec(offsets),
+            sources: ArcCow::from_vec(dn_sources),
+            weights: WeightArray::from_vec_u32(wd.clone()),
+            topo_edge_idx: ArcCow::from_vec(Vec::new()),
+        };
+        (n_nodes, up, down, wu, wd)
+    }
+
+    /// Expected single-channel time for cell (s, t).
+    fn expect(wu: &[u32], wd: &[u32], s: usize, t: usize) -> u32 {
+        if s == t { 0 } else { wu[s] + wd[t] }
+    }
+
+    fn assert_bounded_eq_filtered(
+        n_nodes: usize,
+        up: &UpAdjFlat,
+        down: &DownReverseAdjFlat,
+        wu: &[u32],
+        wd: &[u32],
+        threshold: u32,
+    ) {
+        let n = wu.len();
+        let srcs: Vec<u32> = (0..n as u32).collect();
+        let tgts: Vec<u32> = (0..n as u32).collect();
+
+        let (unbounded, _) = table_bucket_parallel(n_nodes, up, down, &srcs, &tgts);
+        let (bounded, _) =
+            table_bucket_parallel_bounded(n_nodes, up, down, &srcs, &tgts, threshold);
+
+        for s in 0..n {
+            for t in 0..n {
+                let c = s * n + t;
+                // Ground truth (independent of the engine).
+                assert_eq!(unbounded[c], expect(wu, wd, s, t), "unbounded ({s},{t})");
+                if unbounded[c] <= threshold {
+                    assert_eq!(
+                        bounded[c], unbounded[c],
+                        "in-bound cell ({s},{t}) must match exactly"
+                    );
+                } else {
+                    // Engine-level invariant: a bounded cell may still hold a
+                    // real value > threshold (both half-searches stayed within
+                    // the bound but their sum exceeded it) or MAX — but NEVER a
+                    // ≤threshold value, and NEVER an underestimate. The server
+                    // post-filter nulls every > threshold cell, so the SERVED
+                    // matrix is exactly the unbounded matrix filtered to
+                    // ≤ threshold.
+                    assert!(
+                        bounded[c] > threshold,
+                        "out-of-bound cell ({s},{t}) leaked a ≤threshold value: {}",
+                        bounded[c]
+                    );
+                    assert!(
+                        bounded[c] >= unbounded[c],
+                        "bounded must never underestimate at ({s},{t})"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bounded_equals_unbounded_filtered_sequential() {
+        // 5×5 = 25 cells ≤ 100 → sequential BucketM2MEngine path.
+        let (n_nodes, up, down, wu, wd) = broom(5);
+        for &thr in &[0u32, 15, 25, 55, 1000] {
+            assert_bounded_eq_filtered(n_nodes, &up, &down, &wu, &wd, thr);
+        }
+    }
+
+    #[test]
+    fn bounded_equals_unbounded_filtered_monolithic() {
+        // 12×12 = 144 cells > 100 → monolithic parallel forward+backward.
+        let (n_nodes, up, down, wu, wd) = broom(12);
+        for &thr in &[0u32, 30, 75, 130, 100_000] {
+            assert_bounded_eq_filtered(n_nodes, &up, &down, &wu, &wd, thr);
+        }
+    }
+
+    #[test]
+    fn unbounded_sentinel_is_byte_identical() {
+        // threshold == u32::MAX must reproduce the unbounded matrix exactly.
+        for n_leaf in [5usize, 12] {
+            let (n_nodes, up, down, ..) = broom(n_leaf);
+            let srcs: Vec<u32> = (0..n_leaf as u32).collect();
+            let (a, _) = table_bucket_parallel(n_nodes, &up, &down, &srcs, &srcs);
+            let (b, _) = table_bucket_parallel_bounded(n_nodes, &up, &down, &srcs, &srcs, u32::MAX);
+            assert_eq!(
+                a, b,
+                "bounded(u32::MAX) must equal unbounded for n_leaf={n_leaf}"
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_2channel_time_bound_carries_length() {
+        // 12×12 → 2-channel parallel path. Bound is on TIME; the length
+        // channel (= 2× the time weights here) is carried alongside and must
+        // match the unbounded length on in-bound cells, MAX otherwise.
+        let (n_nodes, up, down, wu, wd) = broom(12);
+        let up_lat = UpAdjFlat {
+            offsets: up.offsets.clone(),
+            targets: up.targets.clone(),
+            weights: WeightArray::from_vec_u32(wu.iter().map(|w| w * 2).collect()),
+            topo_edge_idx: ArcCow::from_vec(Vec::new()),
+        };
+        let dn_lat = DownReverseAdjFlat {
+            offsets: down.offsets.clone(),
+            sources: down.sources.clone(),
+            weights: WeightArray::from_vec_u32(wd.iter().map(|w| w * 2).collect()),
+            topo_edge_idx: ArcCow::from_vec(Vec::new()),
+        };
+        let n = wu.len();
+        let srcs: Vec<u32> = (0..n as u32).collect();
+        let threshold = 75u32;
+
+        let (u_time, u_lat, _) = table_bucket_parallel_len_along_time(
+            n_nodes, &up, &down, &up_lat, &dn_lat, &srcs, &srcs,
+        );
+        let (b_time, b_lat, _) = table_bucket_parallel_len_along_time_bounded(
+            n_nodes, &up, &down, &up_lat, &dn_lat, &srcs, &srcs, threshold,
+        );
+
+        for s in 0..n {
+            for t in 0..n {
+                let c = s * n + t;
+                assert_eq!(
+                    u_time[c],
+                    expect(&wu, &wd, s, t),
+                    "unbounded time ({s},{t})"
+                );
+                if u_time[c] <= threshold {
+                    assert_eq!(b_time[c], u_time[c], "in-bound time ({s},{t})");
+                    assert_eq!(b_lat[c], u_lat[c], "in-bound length ({s},{t})");
+                } else {
+                    // Out-of-bound: time > threshold (MAX or a real >threshold
+                    // value). The server post-filter nulls both channels here.
+                    assert!(
+                        b_time[c] > threshold,
+                        "out-of-bound time ({s},{t}) leaked: {}",
+                        b_time[c]
+                    );
+                }
+            }
+        }
     }
 }

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -35,10 +35,7 @@ use futures::stream;
 use serde::Deserialize;
 use tonic::{Request, Response, Status, Streaming};
 
-use crate::matrix::bucket_ch::{
-    backward_join_with_buckets, forward_build_buckets, table_bucket_full_flat,
-    table_bucket_parallel,
-};
+use crate::matrix::bucket_ch::table_bucket_full_flat;
 use crate::matrix::neighbors::{RadiusParam, auto_radius_km, build_neighbors, parse_radius};
 use crate::profile_abi::Mode;
 use crate::range::contour::ContourResult;
@@ -364,6 +361,11 @@ struct MatrixParams {
     /// positive number, the string "auto", or null/0 to disable.
     #[serde(default)]
     radius_km: Option<serde_json::Value>,
+    /// Optional drive-time bound in minutes (#12). When set, only cells whose
+    /// travel time ≤ `max_minutes` are returned, and the search early-stops at
+    /// the bound (compute ∝ reachable region). Exact. Orthogonal to radius_km.
+    #[serde(default)]
+    max_minutes: Option<f64>,
 }
 
 /// Build matrix RecordBatch from flat u32 distances.
@@ -435,6 +437,12 @@ fn do_matrix(
 ) -> std::result::Result<BatchStream, Status> {
     let mode_data = state.get_mode(mode);
     let n_nodes = mode_data.cch_topo.n_nodes as usize;
+
+    // #12 max_minutes: time bound in CCH seconds. `u32::MAX` = unbounded.
+    let threshold = super::table::parse_max_minutes(params.max_minutes)
+        .map_err(Status::invalid_argument)?
+        .unwrap_or(u32::MAX);
+    let bounded = threshold != u32::MAX;
 
     use super::types::SnapRole;
     // K-best snap candidates per src/dst with directional role + the
@@ -569,19 +577,32 @@ fn do_matrix(
             // parallel path reuses thread-local SearchState2 via
             // BACKWARD_STATE_LAT, so even 10×10 amortises the alloc
             // away. Rayon spawn cost is in microseconds and fine.
-            let (m, lm, st) = crate::matrix::bucket_ch::table_bucket_parallel_len_along_time(
-                n_nodes,
-                up,
-                down,
-                up_lat,
-                dn_lat,
-                &origins_rank,
-                &targets_rank,
-            );
+            // #12: `_bounded` early-stops the time sweeps at `threshold`
+            // (u32::MAX = unbounded, byte-identical to the prior call).
+            let (m, lm, st) =
+                crate::matrix::bucket_ch::table_bucket_parallel_len_along_time_bounded(
+                    n_nodes,
+                    up,
+                    down,
+                    up_lat,
+                    dn_lat,
+                    &origins_rank,
+                    &targets_rank,
+                    threshold,
+                );
             (m, Some(lm), st)
         } else {
-            let (m, st) = if use_parallel {
-                table_bucket_parallel(n_nodes, up, down, &origins_rank, &targets_rank)
+            // #12: when bounded, always take the parallel `_bounded` path
+            // (the sequential `table_bucket_full_flat` has no bound hook).
+            let (m, st) = if use_parallel || bounded {
+                crate::matrix::bucket_ch::table_bucket_parallel_bounded(
+                    n_nodes,
+                    up,
+                    down,
+                    &origins_rank,
+                    &targets_rank,
+                    threshold,
+                )
             } else {
                 table_bucket_full_flat(n_nodes, up, down, &origins_rank, &targets_rank)
             };
@@ -593,7 +614,15 @@ fn do_matrix(
         // for geometric-ambiguity / dynamic-recustomisation pairs.
         // K=64 escalation runs only for src/dst indices that have at
         // least one INF cell.
-        if matrix.contains(&u32::MAX) {
+        //
+        // #12: skip the fallback entirely when a minutes bound is in effect.
+        // A MAX cell under a bound is overwhelmingly "beyond the time bound"
+        // (legitimately excluded), not a snap gap — rescuing every one with
+        // an UNBOUNDED P2P would do large wasted work and then be masked away
+        // below anyway. Bounded matrices trade the rare in-bound snap-gap
+        // rescue for correctness + speed; /table POST keeps the full rescue
+        // for the high-fidelity, typically-smaller request shape.
+        if !bounded && matrix.contains(&u32::MAX) {
             use rayon::prelude::*;
             use std::collections::HashSet;
             let query = super::query::CchQuery::new(&mode_data);
@@ -680,6 +709,21 @@ fn do_matrix(
             }
         }
 
+        // #12: exact-output mask. The bounded join can leave a non-minimal
+        // value > threshold for an out-of-bound pair; null both channels
+        // there so the emitted set is exactly the unbounded matrix filtered
+        // to ≤ threshold.
+        if bounded {
+            for c in 0..matrix.len() {
+                if matrix[c] > threshold {
+                    matrix[c] = u32::MAX;
+                    if let Some(lm) = lat_matrix_opt.as_mut() {
+                        lm[c] = u32::MAX;
+                    }
+                }
+            }
+        }
+
         // #372: if the K-best fallback patched any cells above, the
         // lat_matrix is now stale for those cells — they were updated
         // from a per-pair P2P, not the bucket-M2M. For now we keep the
@@ -740,10 +784,23 @@ fn do_matrix(
                     return;
                 }
 
-                let buckets = Arc::new(forward_build_buckets(n_nodes, &up_adj, &block_src_ranks));
+                // #12: bound both sweeps at the time threshold so the large
+                // (streamed) path is also time-proportional, not just the
+                // small bucket-M2M path. u32::MAX = unbounded.
+                let buckets = Arc::new(crate::matrix::bucket_ch::forward_build_buckets_bounded(
+                    n_nodes,
+                    &up_adj,
+                    &block_src_ranks,
+                    threshold,
+                ));
 
-                let tile_matrix =
-                    backward_join_with_buckets(n_nodes, &down_rev, &buckets, &targets_rank);
+                let tile_matrix = crate::matrix::bucket_ch::backward_join_with_buckets_bounded(
+                    n_nodes,
+                    &down_rev,
+                    &buckets,
+                    &targets_rank,
+                    threshold,
+                );
 
                 let n_block_src = block_src_ranks.len();
                 let n_block_dst = targets_rank.len();
@@ -765,7 +822,11 @@ fn do_matrix(
                         let d = if pruned {
                             u32::MAX
                         } else {
-                            tile_matrix[bsi * n_block_dst + bdi]
+                            let v = tile_matrix[bsi * n_block_dst + bdi];
+                            // #12: null cells beyond the time bound. When
+                            // unbounded, threshold == u32::MAX so this never
+                            // fires (v > u32::MAX is impossible).
+                            if v > threshold { u32::MAX } else { v }
                         };
                         si_arr.append_value(orig_si as u32);
                         di_arr.append_value(orig_di as u32);

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -363,7 +363,15 @@ struct MatrixParams {
     radius_km: Option<serde_json::Value>,
     /// Optional drive-time bound in minutes (#12). When set, only cells whose
     /// travel time ≤ `max_minutes` are returned, and the search early-stops at
-    /// the bound (compute ∝ reachable region). Exact. Orthogonal to radius_km.
+    /// the bound (compute ∝ reachable region). Orthogonal to radius_km.
+    ///
+    /// Returned values are exact for every reachable cell. NOTE: under a bound
+    /// the Flight path skips the K-best snap-gap rescue (a bounded MAX cell is
+    /// overwhelmingly "beyond the bound", not a snap gap), so a rare in-bound
+    /// cell whose PRIMARY snap lands on a disconnected micro-component may be
+    /// returned null instead of rescued. Use POST /table for full snap-gap
+    /// fidelity under a bound. Values are never wrong — only conservatively
+    /// dropped.
     #[serde(default)]
     max_minutes: Option<f64>,
 }

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -354,6 +354,7 @@ pub fn transit_bulk_schema() -> Schema {
 // =============================================================================
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)] // #415: reject unsupported params (e.g. max_minutes on an old build) instead of silently ignoring
 struct MatrixParams {
     origins: Vec<[f64; 2]>,
     destinations: Vec<[f64; 2]>,
@@ -361,7 +362,7 @@ struct MatrixParams {
     /// positive number, the string "auto", or null/0 to disable.
     #[serde(default)]
     radius_km: Option<serde_json::Value>,
-    /// Optional drive-time bound in minutes (#12). When set, only cells whose
+    /// Optional drive-time bound in minutes (#415). When set, only cells whose
     /// travel time ≤ `max_minutes` are returned, and the search early-stops at
     /// the bound (compute ∝ reachable region). Orthogonal to radius_km.
     ///
@@ -446,7 +447,7 @@ fn do_matrix(
     let mode_data = state.get_mode(mode);
     let n_nodes = mode_data.cch_topo.n_nodes as usize;
 
-    // #12 max_minutes: time bound in CCH seconds. `u32::MAX` = unbounded.
+    // #415 max_minutes: time bound in CCH seconds. `u32::MAX` = unbounded.
     let threshold = super::table::parse_max_minutes(params.max_minutes)
         .map_err(Status::invalid_argument)?
         .unwrap_or(u32::MAX);
@@ -585,7 +586,7 @@ fn do_matrix(
             // parallel path reuses thread-local SearchState2 via
             // BACKWARD_STATE_LAT, so even 10×10 amortises the alloc
             // away. Rayon spawn cost is in microseconds and fine.
-            // #12: `_bounded` early-stops the time sweeps at `threshold`
+            // #415: `_bounded` early-stops the time sweeps at `threshold`
             // (u32::MAX = unbounded, byte-identical to the prior call).
             let (m, lm, st) =
                 crate::matrix::bucket_ch::table_bucket_parallel_len_along_time_bounded(
@@ -600,7 +601,7 @@ fn do_matrix(
                 );
             (m, Some(lm), st)
         } else {
-            // #12: when bounded, always take the parallel `_bounded` path
+            // #415: when bounded, always take the parallel `_bounded` path
             // (the sequential `table_bucket_full_flat` has no bound hook).
             let (m, st) = if use_parallel || bounded {
                 crate::matrix::bucket_ch::table_bucket_parallel_bounded(
@@ -623,7 +624,7 @@ fn do_matrix(
         // K=64 escalation runs only for src/dst indices that have at
         // least one INF cell.
         //
-        // #12: skip the fallback entirely when a minutes bound is in effect.
+        // #415: skip the fallback entirely when a minutes bound is in effect.
         // A MAX cell under a bound is overwhelmingly "beyond the time bound"
         // (legitimately excluded), not a snap gap — rescuing every one with
         // an UNBOUNDED P2P would do large wasted work and then be masked away
@@ -717,7 +718,7 @@ fn do_matrix(
             }
         }
 
-        // #12: exact-output mask. The bounded join can leave a non-minimal
+        // #415: exact-output mask. The bounded join can leave a non-minimal
         // value > threshold for an out-of-bound pair; null both channels
         // there so the emitted set is exactly the unbounded matrix filtered
         // to ≤ threshold.
@@ -792,7 +793,7 @@ fn do_matrix(
                     return;
                 }
 
-                // #12: bound both sweeps at the time threshold so the large
+                // #415: bound both sweeps at the time threshold so the large
                 // (streamed) path is also time-proportional, not just the
                 // small bucket-M2M path. u32::MAX = unbounded.
                 let buckets = Arc::new(crate::matrix::bucket_ch::forward_build_buckets_bounded(
@@ -831,7 +832,7 @@ fn do_matrix(
                             u32::MAX
                         } else {
                             let v = tile_matrix[bsi * n_block_dst + bdi];
-                            // #12: null cells beyond the time bound. When
+                            // #415: null cells beyond the time bound. When
                             // unbounded, threshold == u32::MAX so this never
                             // fires (v > u32::MAX is impossible).
                             if v > threshold { u32::MAX } else { v }
@@ -841,7 +842,10 @@ fn do_matrix(
                         if d == u32::MAX {
                             dur_arr.append_value(u32::MAX);
                         } else {
-                            dur_arr.append_value(d.saturating_mul(100));
+                            // #415 review: seconds → milliseconds (×1000) to
+                            // match the small-matrix branch and the `duration_ms`
+                            // schema name (was ×100, i.e. 10× too small here).
+                            dur_arr.append_value(d.saturating_mul(1000));
                         }
                         dist_arr.append_value(u32::MAX);
                     }

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -58,10 +58,39 @@ pub struct TablePostRequest {
     /// or null/0 to disable. Pairs beyond the radius are returned as null.
     #[serde(default)]
     pub radius_km: Option<serde_json::Value>,
+    /// Optional drive-time bound in minutes (#12). When set, only cells whose
+    /// travel time ≤ `max_minutes` are returned (others are null), and the
+    /// search itself early-stops at the bound so compute is proportional to
+    /// the time-reachable region rather than the full source×target product.
+    /// Exact: returned durations/distances are identical to the unbounded
+    /// matrix filtered to ≤ `max_minutes`. Orthogonal to `radius_km`.
+    #[serde(default)]
+    pub max_minutes: Option<f64>,
 }
 
 pub fn default_annotations() -> String {
     "duration".to_string()
+}
+
+/// Convert an optional `max_minutes` request field into a CCH time-weight
+/// threshold in seconds (the unit of the time metric, post-#297). Returns
+/// `Ok(None)` when unset, an error on out-of-range values. `u32::MAX` stays
+/// reserved as the "unbounded" sentinel inside the matrix engine, so the
+/// 24 h cap keeps any real threshold far below it.
+pub fn parse_max_minutes(max_minutes: Option<f64>) -> Result<Option<u32>, String> {
+    match max_minutes {
+        None => Ok(None),
+        Some(m) => {
+            if !m.is_finite() || m <= 0.0 {
+                return Err(format!("max_minutes must be a positive number, got {m}"));
+            }
+            if m > 1440.0 {
+                return Err(format!("max_minutes must be ≤ 1440 (24 h), got {m}"));
+            }
+            // ceil so a cell exactly at the bound is included.
+            Ok(Some((m * 60.0).ceil() as u32))
+        }
+    }
 }
 
 /// Response for table computation (OSRM-compatible format)
@@ -307,6 +336,13 @@ pub async fn table_post_handler(
 
     let radius_param = parse_radius(req.radius_km.as_ref());
 
+    let threshold_s = match parse_max_minutes(req.max_minutes) {
+        Ok(t) => t,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, Json(ErrorResponse { error: e })).into_response();
+        }
+    };
+
     let resp = compute_table_bucket_m2m(
         &state,
         mode,
@@ -317,6 +353,7 @@ pub async fn table_post_handler(
         custom_weights_ref,
         &snap_mask,
         radius_param,
+        threshold_s,
     )
     .await;
     super::region_metrics::record_query(
@@ -339,6 +376,7 @@ pub async fn compute_table_bucket_m2m(
     custom_weights: Option<&super::exclude::ExcludeWeights>,
     snap_mask: &[u64],
     radius_param: RadiusParam,
+    threshold_s: Option<u32>,
 ) -> Response {
     let mode_data = state.get_mode(mode);
     let n_nodes = mode_data.cch_topo.n_nodes as usize;
@@ -496,6 +534,15 @@ pub async fn compute_table_bucket_m2m(
         && mode_data.up_adj_flat_len_along_time.is_some()
         && mode_data.down_rev_flat_len_along_time.is_some();
 
+    // #12 max_minutes: when set, bound the TIME search at `threshold` so
+    // compute is proportional to the reachable region, and null every cell
+    // whose time exceeds it. `u32::MAX` = unbounded (byte-identical to the
+    // pre-#12 path). Reachability is ALWAYS defined by time, even when only
+    // `distance` is requested — so the bounded branch computes the time
+    // matrix regardless and masks the distance cells against it.
+    let threshold = threshold_s.unwrap_or(u32::MAX);
+    let bounded = threshold_s.is_some();
+
     let (durations, distances) = if use_2channel {
         let t_2ch = std::time::Instant::now();
         let up_lat = mode_data
@@ -509,12 +556,11 @@ pub async fn compute_table_bucket_m2m(
         // #395: always go through the `_parallel_` wrapper — it now
         // dispatches internally to the pooled sequential 2-channel
         // path for small N (≤ SEQUENTIAL_FAST_PATH_CELL_THRESHOLD)
-        // and the rayon-parallel path above it. Routing the dispatch
-        // through the wrapper avoids the hand-coded cells>=2500 split
-        // that previously called `table_bucket_full_flat_len_along_time`
-        // directly and ate a ~80 MB SearchState2 allocation per call.
-        let (time_mat, lat_mat, _stats) =
-            crate::matrix::bucket_ch::table_bucket_parallel_len_along_time(
+        // and the rayon-parallel path above it.
+        // #12: the `_bounded` variant early-stops the time sweeps at
+        // `threshold`; `u32::MAX` reproduces the unbounded result exactly.
+        let (mut time_mat, mut lat_mat, _stats) =
+            crate::matrix::bucket_ch::table_bucket_parallel_len_along_time_bounded(
                 n_nodes,
                 time_up,
                 time_down,
@@ -522,7 +568,19 @@ pub async fn compute_table_bucket_m2m(
                 dn_lat,
                 &sources_rank,
                 &targets_rank,
+                threshold,
             );
+        if bounded {
+            // The bounded join can surface a non-minimal value > threshold for
+            // an out-of-bound pair; null both channels there so the OUTPUT is
+            // exactly the unbounded matrix filtered to ≤ threshold.
+            for c in 0..time_mat.len() {
+                if time_mat[c] > threshold {
+                    time_mat[c] = u32::MAX;
+                    lat_mat[c] = u32::MAX;
+                }
+            }
+        }
         tracing::debug!(
             "compute_table_bucket_m2m: 2-channel M2M took {:?}",
             t_2ch.elapsed(),
@@ -548,21 +606,45 @@ pub async fn compute_table_bucket_m2m(
         (Some(dur), Some(dist))
     } else {
         // Legacy two-pass: separate distance-shortest CCH for `distance`.
-        // #395: always dispatch through `table_bucket_parallel`; it
-        // routes small-N (cells ≤ SEQUENTIAL_FAST_PATH_CELL_THRESHOLD)
-        // to the thread-local `BucketM2MEngine` and rayon-parallels
-        // above that. The previous hand-split call to
-        // `table_bucket_full_flat` allocated a fresh `SearchState`
-        // (~60 MB) per request and dominated small-N latency.
-        let durations = if want_duration {
+        // The time matrix is computed whenever duration is requested OR a
+        // bound is in effect (reachability is defined by time).
+        let time_mat: Option<Vec<u32>> = if want_duration || bounded {
             let t_dur = std::time::Instant::now();
-            let (matrix, _stats) =
-                table_bucket_parallel(n_nodes, time_up, time_down, &sources_rank, &targets_rank);
+            let (matrix, _stats) = crate::matrix::bucket_ch::table_bucket_parallel_bounded(
+                n_nodes,
+                time_up,
+                time_down,
+                &sources_rank,
+                &targets_rank,
+                threshold,
+            );
             tracing::debug!(
                 "compute_table_bucket_m2m: duration M2M took {:?}",
                 t_dur.elapsed()
             );
+            Some(matrix)
+        } else {
+            None
+        };
 
+        let distances = if want_distance {
+            let t_dist = std::time::Instant::now();
+            // Distance weights are metres — the minutes bound does not apply to
+            // the distance search itself. We bound which distance cells are
+            // RETURNED by masking against the (bounded) time matrix below.
+            let (mut matrix, _stats) =
+                table_bucket_parallel(n_nodes, dist_up, dist_down, &sources_rank, &targets_rank);
+            if bounded && let Some(ref tm) = time_mat {
+                for (d, &t) in matrix.iter_mut().zip(tm.iter()) {
+                    if t > threshold {
+                        *d = u32::MAX;
+                    }
+                }
+            }
+            tracing::debug!(
+                "compute_table_bucket_m2m: distance M2M took {:?}",
+                t_dist.elapsed()
+            );
             Some(flat_matrix_to_2d(
                 &matrix,
                 n_sources,
@@ -576,17 +658,17 @@ pub async fn compute_table_bucket_m2m(
             None
         };
 
-        let distances = if want_distance {
-            let t_dist = std::time::Instant::now();
-            let (matrix, _stats) =
-                table_bucket_parallel(n_nodes, dist_up, dist_down, &sources_rank, &targets_rank);
-            tracing::debug!(
-                "compute_table_bucket_m2m: distance M2M took {:?}",
-                t_dist.elapsed()
-            );
-
+        let durations = if want_duration {
+            let mut tm = time_mat.expect("time matrix computed when want_duration");
+            if bounded {
+                for t in tm.iter_mut() {
+                    if *t > threshold {
+                        *t = u32::MAX;
+                    }
+                }
+            }
             Some(flat_matrix_to_2d(
-                &matrix,
+                &tm,
                 n_sources,
                 n_targets,
                 &source_valid,
@@ -630,6 +712,7 @@ pub async fn compute_table_bucket_m2m(
         custom_weights,
         want_duration,
         want_distance,
+        threshold_s,
     );
 
     tracing::debug!(
@@ -681,9 +764,18 @@ fn apply_k_best_fallback(
     custom_weights: Option<&super::exclude::ExcludeWeights>,
     want_duration: bool,
     want_distance: bool,
+    threshold_s: Option<u32>,
 ) -> (MatrixGrid, MatrixGrid) {
     use super::query::CchQuery;
     const SNAP_K: usize = 64;
+
+    // #12: when a minutes bound is in effect, a None cell may be None
+    // because it is genuinely beyond the bound (correctly excluded) rather
+    // than a snap/connectivity gap. The fallback must NOT resurrect those.
+    // We gate every fill on a bounded time query so out-of-bound pairs stay
+    // None, while in-bound snap-gap cells are still recovered.
+    let threshold = threshold_s.unwrap_or(u32::MAX);
+    let bounded = threshold_s.is_some();
 
     // Cap per-cell fallback combos. /route uses 400 because a single
     // hopeless query at 20s wall is acceptable; /table can have
@@ -717,8 +809,11 @@ fn apply_k_best_fallback(
         }
         false
     };
-    let need_time = want_duration && needs_fallback(&durations);
     let need_dist = want_distance && needs_fallback(&distances);
+    // When bounded we always need the time query (even for a distance-only
+    // request) — it is the gate that decides whether a recovered cell is
+    // within the minutes bound.
+    let need_time = (want_duration && needs_fallback(&durations)) || (bounded && need_dist);
     tracing::debug!(
         "apply_k_best_fallback: needs_fallback decision took {:?}, need_time={}, need_dist={}",
         _t_fb_start.elapsed(),
@@ -925,24 +1020,49 @@ fn apply_k_best_fallback(
                 if s_rank == d_rank {
                     continue;
                 }
-                if !dur_done
-                    && let Some(tq) = time_query_ref
-                    && let Some(r) = tq.query(s_rank, d_rank)
-                {
-                    // r.distance is already in seconds (post-#297).
-                    dur_val = Some(r.distance as f64);
-                    dur_done = true;
-                }
-                if !dist_done
-                    && let Some(dq) = dist_query_ref
-                    && let Some(r) = dq.query(s_rank, d_rank)
-                {
-                    // r.distance is already in meters (post-#297).
-                    dist_val = Some(r.distance as f64);
-                    dist_done = true;
-                }
-                if dur_done && dist_done {
-                    break;
+                if bounded {
+                    // A recovered cell is only valid if the pair is within the
+                    // minutes bound. `distance_bounded` returns None for
+                    // > threshold or unreachable, so out-of-bound cells stay
+                    // None. The time gate also covers distance-only requests.
+                    if let Some(tq) = time_query_ref
+                        && let Some(t) = tq.distance_bounded(s_rank, d_rank, threshold)
+                    {
+                        if !dur_done {
+                            dur_val = Some(t as f64);
+                            dur_done = true;
+                        }
+                        if !dist_done
+                            && let Some(dq) = dist_query_ref
+                            && let Some(r) = dq.query(s_rank, d_rank)
+                        {
+                            dist_val = Some(r.distance as f64);
+                            dist_done = true;
+                        }
+                        if dur_done && dist_done {
+                            break;
+                        }
+                    }
+                } else {
+                    if !dur_done
+                        && let Some(tq) = time_query_ref
+                        && let Some(r) = tq.query(s_rank, d_rank)
+                    {
+                        // r.distance is already in seconds (post-#297).
+                        dur_val = Some(r.distance as f64);
+                        dur_done = true;
+                    }
+                    if !dist_done
+                        && let Some(dq) = dist_query_ref
+                        && let Some(r) = dq.query(s_rank, d_rank)
+                    {
+                        // r.distance is already in meters (post-#297).
+                        dist_val = Some(r.distance as f64);
+                        dist_done = true;
+                    }
+                    if dur_done && dist_done {
+                        break;
+                    }
                 }
             }
             (src_idx, tgt_idx, dur_val, dist_val)
@@ -1679,4 +1799,36 @@ fn table_stream_bucket_path(
             )
                 .into_response()
         })
+}
+
+#[cfg(test)]
+mod max_minutes_tests {
+    use super::parse_max_minutes;
+
+    #[test]
+    fn none_passes_through() {
+        assert_eq!(parse_max_minutes(None).unwrap(), None);
+    }
+
+    #[test]
+    fn converts_minutes_to_seconds_ceil() {
+        assert_eq!(parse_max_minutes(Some(10.0)).unwrap(), Some(600));
+        assert_eq!(parse_max_minutes(Some(0.5)).unwrap(), Some(30));
+        // ceil so a cell exactly at the bound is included.
+        assert_eq!(parse_max_minutes(Some(1.001)).unwrap(), Some(61));
+    }
+
+    #[test]
+    fn rejects_non_positive_and_nonfinite() {
+        assert!(parse_max_minutes(Some(0.0)).is_err());
+        assert!(parse_max_minutes(Some(-5.0)).is_err());
+        assert!(parse_max_minutes(Some(f64::NAN)).is_err());
+        assert!(parse_max_minutes(Some(f64::INFINITY)).is_err());
+    }
+
+    #[test]
+    fn rejects_above_24h_cap() {
+        assert!(parse_max_minutes(Some(1441.0)).is_err());
+        assert_eq!(parse_max_minutes(Some(1440.0)).unwrap(), Some(86400));
+    }
 }

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -686,28 +686,40 @@ pub async fn compute_table_bucket_m2m(
     // The K-best snap (expensive — iterates all samples within 5 km)
     // is done LAZILY for only the affected src/dst rows/cols, so a
     // healthy matrix pays zero K-best snap cost.
-    // Pass `need_dur_internal` (not `want_duration`): when bounded we keep an
-    // internal time grid so the fallback can recover genuine in-bound snap-gap
-    // cells (and so the threshold mask below has a time reference). The grid is
-    // dropped from the response afterwards if the caller didn't ask for it.
-    let (durations, distances) = apply_k_best_fallback(
-        state,
-        &mode_data,
-        mode,
-        durations,
-        distances,
-        sources,
-        destinations,
-        &source_valid,
-        &target_valid,
-        snap_mask,
-        src_role_filter,
-        dst_role_filter,
-        custom_weights,
-        need_dur_internal,
-        want_distance,
-        threshold_s,
-    );
+    //
+    // #12: SKIP the fallback when a minutes bound is in effect. Under a bound,
+    // most MAX cells are unreached because they are genuinely beyond the bound
+    // (the search early-stopped) — NOT snap gaps. Running the K-best rescue on
+    // them would fire a ~max_minutes-isochrone-sized `distance_bounded` search
+    // per cell × K combos, re-doing exactly the work the bound saved (measured:
+    // an 8×250 matrix went 45 ms unbounded → 60 s+ with the bounded fallback).
+    // So under a bound we trade the rare in-bound primary-snap-disconnected
+    // cell (returned null instead of rescued — value never wrong) for the
+    // bound's whole point: compute proportional to the reachable region. This
+    // matches the Flight `matrix` behaviour; the unbounded /table path keeps
+    // full snap-gap fidelity.
+    let (durations, distances) = if bounded {
+        (durations, distances)
+    } else {
+        apply_k_best_fallback(
+            state,
+            &mode_data,
+            mode,
+            durations,
+            distances,
+            sources,
+            destinations,
+            &source_valid,
+            &target_valid,
+            snap_mask,
+            src_role_filter,
+            dst_role_filter,
+            custom_weights,
+            need_dur_internal,
+            want_distance,
+            threshold_s,
+        )
+    };
 
     // #12: apply the time bound to the FINAL grids, after the fallback. A
     // bucket-M2M-reached cell with time > threshold was kept non-null through

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -542,6 +542,21 @@ pub async fn compute_table_bucket_m2m(
     // matrix regardless and masks the distance cells against it.
     let threshold = threshold_s.unwrap_or(u32::MAX);
     let bounded = threshold_s.is_some();
+    // When bounded we always need the TIME grid internally — it defines which
+    // cells are within the bound (and therefore which distance cells are
+    // valid), even for a distance-only request.
+    //
+    // CRITICAL: we do NOT null > threshold cells here. The threshold mask is
+    // applied to the FINAL grids AFTER the K-best fallback (below). If we
+    // masked a bucket-M2M-reached cell to null now, the bounded fallback
+    // would treat it as a snap gap and "improve" it via an alternative K=64
+    // snap — surfacing a value the unbounded matrix never shows (its primary
+    // snap kept the original, fallback-skipped value). Masking last keeps the
+    // served matrix exactly equal to the unbounded matrix filtered to
+    // ≤ max_minutes. The bound still pays off: the SEARCH already early-stopped
+    // at `threshold`, so out-of-bound cells are mostly unreached (MAX) and the
+    // bounded fallback's distance_bounded gate keeps them null cheaply.
+    let need_dur_internal = want_duration || bounded;
 
     let (durations, distances) = if use_2channel {
         let t_2ch = std::time::Instant::now();
@@ -559,7 +574,7 @@ pub async fn compute_table_bucket_m2m(
         // and the rayon-parallel path above it.
         // #12: the `_bounded` variant early-stops the time sweeps at
         // `threshold`; `u32::MAX` reproduces the unbounded result exactly.
-        let (mut time_mat, mut lat_mat, _stats) =
+        let (time_mat, lat_mat, _stats) =
             crate::matrix::bucket_ch::table_bucket_parallel_len_along_time_bounded(
                 n_nodes,
                 time_up,
@@ -570,17 +585,6 @@ pub async fn compute_table_bucket_m2m(
                 &targets_rank,
                 threshold,
             );
-        if bounded {
-            // The bounded join can surface a non-minimal value > threshold for
-            // an out-of-bound pair; null both channels there so the OUTPUT is
-            // exactly the unbounded matrix filtered to ≤ threshold.
-            for c in 0..time_mat.len() {
-                if time_mat[c] > threshold {
-                    time_mat[c] = u32::MAX;
-                    lat_mat[c] = u32::MAX;
-                }
-            }
-        }
         tracing::debug!(
             "compute_table_bucket_m2m: 2-channel M2M took {:?}",
             t_2ch.elapsed(),
@@ -608,7 +612,7 @@ pub async fn compute_table_bucket_m2m(
         // Legacy two-pass: separate distance-shortest CCH for `distance`.
         // The time matrix is computed whenever duration is requested OR a
         // bound is in effect (reachability is defined by time).
-        let time_mat: Option<Vec<u32>> = if want_duration || bounded {
+        let time_mat: Option<Vec<u32>> = if need_dur_internal {
             let t_dur = std::time::Instant::now();
             let (matrix, _stats) = crate::matrix::bucket_ch::table_bucket_parallel_bounded(
                 n_nodes,
@@ -630,17 +634,10 @@ pub async fn compute_table_bucket_m2m(
         let distances = if want_distance {
             let t_dist = std::time::Instant::now();
             // Distance weights are metres — the minutes bound does not apply to
-            // the distance search itself. We bound which distance cells are
-            // RETURNED by masking against the (bounded) time matrix below.
-            let (mut matrix, _stats) =
+            // the distance search. Distance cells are bounded by the final
+            // time-grid mask after the fallback.
+            let (matrix, _stats) =
                 table_bucket_parallel(n_nodes, dist_up, dist_down, &sources_rank, &targets_rank);
-            if bounded && let Some(ref tm) = time_mat {
-                for (d, &t) in matrix.iter_mut().zip(tm.iter()) {
-                    if t > threshold {
-                        *d = u32::MAX;
-                    }
-                }
-            }
             tracing::debug!(
                 "compute_table_bucket_m2m: distance M2M took {:?}",
                 t_dist.elapsed()
@@ -658,15 +655,8 @@ pub async fn compute_table_bucket_m2m(
             None
         };
 
-        let durations = if want_duration {
-            let mut tm = time_mat.expect("time matrix computed when want_duration");
-            if bounded {
-                for t in tm.iter_mut() {
-                    if *t > threshold {
-                        *t = u32::MAX;
-                    }
-                }
-            }
+        let durations = if need_dur_internal {
+            let tm = time_mat.expect("time matrix computed when need_dur_internal");
             Some(flat_matrix_to_2d(
                 &tm,
                 n_sources,
@@ -696,6 +686,10 @@ pub async fn compute_table_bucket_m2m(
     // The K-best snap (expensive — iterates all samples within 5 km)
     // is done LAZILY for only the affected src/dst rows/cols, so a
     // healthy matrix pays zero K-best snap cost.
+    // Pass `need_dur_internal` (not `want_duration`): when bounded we keep an
+    // internal time grid so the fallback can recover genuine in-bound snap-gap
+    // cells (and so the threshold mask below has a time reference). The grid is
+    // dropped from the response afterwards if the caller didn't ask for it.
     let (durations, distances) = apply_k_best_fallback(
         state,
         &mode_data,
@@ -710,10 +704,42 @@ pub async fn compute_table_bucket_m2m(
         src_role_filter,
         dst_role_filter,
         custom_weights,
-        want_duration,
+        need_dur_internal,
         want_distance,
         threshold_s,
     );
+
+    // #12: apply the time bound to the FINAL grids, after the fallback. A
+    // bucket-M2M-reached cell with time > threshold was kept non-null through
+    // the fallback (so it wasn't snap-"improved"); null it now — along with its
+    // distance cell — so the served matrix is exactly the unbounded matrix
+    // filtered to ≤ max_minutes. The duration grid is the time reference.
+    let (mut durations, mut distances) = (durations, distances);
+    if let Some(thr) = threshold_s {
+        let thr_f = thr as f64;
+        let n_s = durations.as_ref().map_or(0, |g| g.len());
+        for i in 0..n_s {
+            let n_t = durations.as_ref().map_or(0, |g| g[i].len());
+            for j in 0..n_t {
+                let over = durations
+                    .as_ref()
+                    .and_then(|g| g[i][j])
+                    .is_some_and(|v| v > thr_f);
+                if over {
+                    if let Some(g) = durations.as_mut() {
+                        g[i][j] = None;
+                    }
+                    if let Some(g) = distances.as_mut() {
+                        g[i][j] = None;
+                    }
+                }
+            }
+        }
+    }
+    // Drop the internally-computed duration grid if the caller didn't ask.
+    if !want_duration {
+        durations = None;
+    }
 
     tracing::debug!(
         "compute_table_bucket_m2m: post-m2m to response took {:?}",

--- a/route/src/server/table.rs
+++ b/route/src/server/table.rs
@@ -32,7 +32,13 @@ use super::types::{
 // ============ Types ============
 
 /// POST request for table computation
+///
+/// `deny_unknown_fields` (#415): reject unrecognised parameters with 400
+/// rather than silently ignoring them. Without this, a client sending
+/// `max_minutes` (or a typo) to a server build that predates the field would
+/// get a full unbounded matrix back with no error — silently wrong results.
 #[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct TablePostRequest {
     /// Source coordinates [[lon, lat], ...]
     #[schema(example = json!([[4.3517, 50.8503], [4.4017, 50.8603]]))]
@@ -58,7 +64,7 @@ pub struct TablePostRequest {
     /// or null/0 to disable. Pairs beyond the radius are returned as null.
     #[serde(default)]
     pub radius_km: Option<serde_json::Value>,
-    /// Optional drive-time bound in minutes (#12). When set, only cells whose
+    /// Optional drive-time bound in minutes (#415). When set, only cells whose
     /// travel time ≤ `max_minutes` are returned (others are null), and the
     /// search itself early-stops at the bound so compute is proportional to
     /// the time-reachable region rather than the full source×target product.
@@ -115,6 +121,7 @@ pub struct TableResponse {
 
 /// Request for streaming table computation
 #[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)] // #415: surface unsupported params instead of silently dropping
 pub struct TableStreamRequest {
     /// Source coordinates [[lon, lat], ...]
     #[schema(example = json!([[4.3517, 50.8503], [4.3617, 50.8553]]))]
@@ -534,10 +541,10 @@ pub async fn compute_table_bucket_m2m(
         && mode_data.up_adj_flat_len_along_time.is_some()
         && mode_data.down_rev_flat_len_along_time.is_some();
 
-    // #12 max_minutes: when set, bound the TIME search at `threshold` so
+    // #415 max_minutes: when set, bound the TIME search at `threshold` so
     // compute is proportional to the reachable region, and null every cell
     // whose time exceeds it. `u32::MAX` = unbounded (byte-identical to the
-    // pre-#12 path). Reachability is ALWAYS defined by time, even when only
+    // pre-#415 path). Reachability is ALWAYS defined by time, even when only
     // `distance` is requested — so the bounded branch computes the time
     // matrix regardless and masks the distance cells against it.
     let threshold = threshold_s.unwrap_or(u32::MAX);
@@ -572,7 +579,7 @@ pub async fn compute_table_bucket_m2m(
         // dispatches internally to the pooled sequential 2-channel
         // path for small N (≤ SEQUENTIAL_FAST_PATH_CELL_THRESHOLD)
         // and the rayon-parallel path above it.
-        // #12: the `_bounded` variant early-stops the time sweeps at
+        // #415: the `_bounded` variant early-stops the time sweeps at
         // `threshold`; `u32::MAX` reproduces the unbounded result exactly.
         let (time_mat, lat_mat, _stats) =
             crate::matrix::bucket_ch::table_bucket_parallel_len_along_time_bounded(
@@ -687,7 +694,7 @@ pub async fn compute_table_bucket_m2m(
     // is done LAZILY for only the affected src/dst rows/cols, so a
     // healthy matrix pays zero K-best snap cost.
     //
-    // #12: SKIP the fallback when a minutes bound is in effect. Under a bound,
+    // #415: SKIP the fallback when a minutes bound is in effect. Under a bound,
     // most MAX cells are unreached because they are genuinely beyond the bound
     // (the search early-stopped) — NOT snap gaps. Running the K-best rescue on
     // them would fire a ~max_minutes-isochrone-sized `distance_bounded` search
@@ -721,7 +728,7 @@ pub async fn compute_table_bucket_m2m(
         )
     };
 
-    // #12: apply the time bound to the FINAL grids, after the fallback. A
+    // #415: apply the time bound to the FINAL grids, after the fallback. A
     // bucket-M2M-reached cell with time > threshold was kept non-null through
     // the fallback (so it wasn't snap-"improved"); null it now — along with its
     // distance cell — so the served matrix is exactly the unbounded matrix
@@ -807,7 +814,7 @@ fn apply_k_best_fallback(
     use super::query::CchQuery;
     const SNAP_K: usize = 64;
 
-    // #12: when a minutes bound is in effect, a None cell may be None
+    // #415: when a minutes bound is in effect, a None cell may be None
     // because it is genuinely beyond the bound (correctly excluded) rather
     // than a snap/connectivity gap. The fallback must NOT resurrect those.
     // We gate every fill on a bounded time query so out-of-bound pairs stay
@@ -1841,11 +1848,26 @@ fn table_stream_bucket_path(
 
 #[cfg(test)]
 mod max_minutes_tests {
-    use super::parse_max_minutes;
+    use super::{TablePostRequest, parse_max_minutes};
 
     #[test]
     fn none_passes_through() {
         assert_eq!(parse_max_minutes(None).unwrap(), None);
+    }
+
+    #[test]
+    fn unknown_field_is_rejected_not_silently_ignored() {
+        // #415: a server that supports max_minutes must accept it...
+        let ok = r#"{"origins":[[4.35,50.85]],"destinations":[[4.4,51.2]],"mode":"car","max_minutes":15}"#;
+        assert!(serde_json::from_str::<TablePostRequest>(ok).is_ok());
+        // ...and `deny_unknown_fields` must REJECT a typo / unsupported param
+        // (the silent-ignore bug: pre-#415 builds dropped these and returned a
+        // full unbounded matrix with no error).
+        let typo = r#"{"origins":[[4.35,50.85]],"destinations":[[4.4,51.2]],"mode":"car","max_minute":15}"#;
+        assert!(serde_json::from_str::<TablePostRequest>(typo).is_err());
+        let bogus =
+            r#"{"origins":[[4.35,50.85]],"destinations":[[4.4,51.2]],"mode":"car","wat":1}"#;
+        assert!(serde_json::from_str::<TablePostRequest>(bogus).is_err());
     }
 
     #[test]

--- a/route/src/server/trip.rs
+++ b/route/src/server/trip.rs
@@ -739,7 +739,14 @@ pub async fn trip_handler(
             let dn_lat = mode_data.down_rev_flat_len_along_time.as_ref().unwrap();
             let (dur_mat, lat_mat, _stats) =
                 crate::matrix::bucket_ch::table_bucket_full_flat_len_along_time(
-                    n_nodes, time_up, time_down, up_lat, dn_lat, &ranks, &ranks,
+                    n_nodes,
+                    time_up,
+                    time_down,
+                    up_lat,
+                    dn_lat,
+                    &ranks,
+                    &ranks,
+                    u32::MAX,
                 );
             (dur_mat, Some(lat_mat))
         } else {


### PR DESCRIPTION
Closes #415.

## What
Optional **`max_minutes`** bound on `POST /table` and the Flight `matrix` action — bound a distance/duration matrix by drive-time minutes. **Exact** (served matrix == unbounded matrix filtered to ≤ `max_minutes`) and **time-proportional** (the search early-stops at the bound, so compute scales with the reachable region, not S×T).

## Why butterfly, not a radius hack
butterfly's edge-based CCH can bound the **search itself** — unlike a CH `table` API (OSRM/drivetimes) that always settles every cell and can only post-filter or prune by a loose `v_max·minutes` radius (over-computes in cities). No Euclidean `v_max` prefilter is needed (and its silent-drop landmine is avoided): the exact search bound is the compute-saver.

## Mechanism
- **One chokepoint:** a `dist_threshold` on `SearchState`/`SearchState2`; `pop()` early-stops once the heap min exceeds it (min-heap ⇒ all remaining entries do too). This bounds *every* bucket-M2M dispatch path — sequential engine, monolithic parallel, L3-tiled, 2-channel, and the streamed `forward_build_buckets`/`backward_join_with_buckets` path.
- **Exactness:** for d(s→t) ≤ threshold the optimal CCH meeting node m\* is within the bound on both sides, so the bounded join recovers d exactly. Out-of-bound pairs may surface a value > threshold (both halves in-bound, sum over) or MAX → handlers **post-filter every > threshold cell to null**. Distance is masked by the time bound (metric is metres; reachability is defined by time).
- **`u32::MAX` = unbounded** ⇒ byte-identical to pre-#12. Old function names are thin wrappers delegating to `*_bounded` with `u32::MAX`, so `overlay.rs`/`trip.rs`/bench callers are untouched.
- **Fallback:** the K-best snap-gap rescue uses `distance_bounded` so it never resurrects out-of-bound cells; Flight skips the rescue when bounded.

## Tests
- Engine exactness (`bounded == unbounded filtered`, and `bounded ≥ unbounded`) on a deterministic broom graph across **sequential + monolithic + 2-channel** paths; **byte-identical unbounded sentinel**; `parse_max_minutes` validation.
- `cargo fmt` + `cargo clippy --all-targets` (workspace lints = errors) + **612 route lib tests** green.
- Belgium end-to-end smoke (bounded /table == unbounded /table filtered) — in this PR's verification.

Adversarially reviewed (multi-agent) for exactness, thread-local leakage, distance masking, fallback, and the byte-identical guarantee.