### PR TITLE
perf: reproducible + parallel + leaner build pipeline (#419-#425)

### DIFF
--- a/route/src/contraction.rs
+++ b/route/src/contraction.rs
@@ -45,7 +45,7 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
 
-use crate::formats::{CchTopo, CchTopoFile, FilteredEbgFile, OrderEbgFile, mod_turns, mod_weights};
+use crate::formats::{CchTopo, CchTopoFile, FilteredEbgFile, OrderEbgFile, mod_weights};
 use crate::profile_abi::Mode;
 
 /// Edge weight for weighted adjacency - stores (target, weight)
@@ -113,7 +113,9 @@ pub fn build_cch_topology(config: Step7Config) -> Result<Step7Result> {
     // Load weights for metric-aware witness search
     println!("Loading weights for witness search ({})...", mode_name);
     let weights_data = mod_weights::read_all(&config.weights_path)?;
-    let _turns_data = mod_turns::read_all(&config.turns_path)?;
+    // #423: step7 topology does not use turn penalties — the metric-aware witness
+    // search uses edge weights only. The previous `mod_turns::read_all` here was a
+    // dead read (underscore-bound, never used); dropped to save the load + RSS.
     let weights = &weights_data.weights;
     println!("  ✓ {} edge weights", weights.len());
 

--- a/route/src/ebg/mod.rs
+++ b/route/src/ebg/mod.rs
@@ -197,9 +197,8 @@ pub fn build_ebg(config: EbgConfig) -> Result<EbgResult> {
     let csr_path = config.outdir.join("ebg.csr");
     let turn_table_path = config.outdir.join("ebg.turn_table");
 
-    let created_unix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)?
-        .as_secs();
+    // #419: deterministic for byte-reproducible builds (field never read).
+    let created_unix: u64 = 0;
 
     // Compute inputs SHA
     let inputs_sha = compute_inputs_sha(&config)?;
@@ -569,9 +568,8 @@ fn materialize_csr(
     }
     offsets[n_nodes as usize] = current_offset;
 
-    let created_unix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)?
-        .as_secs();
+    // #419: deterministic for byte-reproducible builds (field never read).
+    let created_unix: u64 = 0;
 
     Ok(EbgCsr {
         n_nodes,

--- a/route/src/formats/node_signals.rs
+++ b/route/src/formats/node_signals.rs
@@ -75,10 +75,8 @@ impl NodeSignalsFile {
             .with_context(|| format!("Failed to create {}", path.as_ref().display()))?;
         let mut writer = BufWriter::new(file);
 
-        let created_unix = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        // #419: deterministic for byte-reproducible builds (field never read).
+        let created_unix: u64 = 0;
 
         // Build header
         let mut header = Vec::with_capacity(HEADER_SIZE);

--- a/route/src/formats/nodes_sa.rs
+++ b/route/src/formats/nodes_sa.rs
@@ -55,11 +55,9 @@ pub fn write<P: AsRef<Path>>(
     // Calculate bounding box in fixed-point
     let (bbox_min_lat, bbox_min_lon, bbox_max_lat, bbox_max_lon) = calculate_bbox(&sorted_nodes);
 
-    // Get current timestamp
-    let created_unix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    // #419: deterministic for byte-reproducible builds. created_unix is never
+    // read for logic; build provenance lives in the lock files + artifact-info.
+    let created_unix: u64 = 0;
 
     // Write header (we'll calculate CRCs and update later)
     let mut header = Vec::with_capacity(HEADER_SIZE);

--- a/route/src/formats/nodes_sa.rs
+++ b/route/src/formats/nodes_sa.rs
@@ -48,9 +48,18 @@ pub fn write<P: AsRef<Path>>(
         .with_context(|| format!("Failed to create {}", path.as_ref().display()))?;
     let mut writer = BufWriter::new(file);
 
-    // Ensure nodes are sorted
-    let mut sorted_nodes = nodes.to_vec();
-    sorted_nodes.sort_by_key(|(id, _, _)| *id);
+    // #421: step1 already sorts nodes by id, so the previous unconditional
+    // `nodes.to_vec()` + re-sort was a redundant ~1.6 GB clone + O(n log n).
+    // Borrow when already sorted (the build path); only own+sort the unsorted
+    // (test-only) case. Output bytes are identical either way.
+    let sorted_nodes: std::borrow::Cow<[(i64, f64, f64)]> =
+        if nodes.is_sorted_by_key(|(id, _, _)| *id) {
+            std::borrow::Cow::Borrowed(nodes)
+        } else {
+            let mut v = nodes.to_vec();
+            v.sort_by_key(|(id, _, _)| *id);
+            std::borrow::Cow::Owned(v)
+        };
 
     // Calculate bounding box in fixed-point
     let (bbox_min_lat, bbox_min_lon, bbox_max_lat, bbox_max_lon) = calculate_bbox(&sorted_nodes);

--- a/route/src/formats/nodes_si.rs
+++ b/route/src/formats/nodes_si.rs
@@ -44,9 +44,17 @@ pub fn write<P: AsRef<Path>>(path: P, nodes: &[(i64, f64, f64)]) -> Result<()> {
         .with_context(|| format!("Failed to create {}", path.as_ref().display()))?;
     let mut writer = BufWriter::new(file);
 
-    // Ensure nodes are sorted
-    let mut sorted_nodes = nodes.to_vec();
-    sorted_nodes.sort_by_key(|(id, _, _)| *id);
+    // #421: borrow when already sorted (step1 pre-sorts) instead of an
+    // unconditional ~1.6 GB clone + re-sort; own+sort only the unsorted
+    // (test-only) case. Byte-identical output.
+    let sorted_nodes: std::borrow::Cow<[(i64, f64, f64)]> =
+        if nodes.is_sorted_by_key(|(id, _, _)| *id) {
+            std::borrow::Cow::Borrowed(nodes)
+        } else {
+            let mut v = nodes.to_vec();
+            v.sort_by_key(|(id, _, _)| *id);
+            std::borrow::Cow::Owned(v)
+        };
 
     // Build Level 2 samples (one per block_size records)
     let mut level2: Vec<Level2Sample> = Vec::new();

--- a/route/src/ingest/mod.rs
+++ b/route/src/ingest/mod.rs
@@ -9,6 +9,11 @@ use crate::formats::{Member, MemberKind, Relation, RelationsFile, Way, WaysFile}
 use crate::formats::{NodeSignals, NodeSignalsFile};
 use crate::formats::{nodes_sa, nodes_si};
 
+/// (nodes, signal_node_ids) accumulated from one PBF blob during the parallel
+/// node pass (#421). Aliased to keep the rayon closure return type within
+/// clippy's type-complexity budget.
+type NodeBlob = (Vec<(i64, f64, f64)>, Vec<i64>);
+
 pub struct IngestConfig {
     pub input: PathBuf,
     pub outdir: PathBuf,
@@ -128,55 +133,78 @@ struct NodeExtractionResult {
     signal_node_ids: Vec<i64>,
 }
 
-/// Extract all nodes from PBF, also collecting traffic signal node IDs
+/// Extract all nodes from PBF, also collecting traffic signal node IDs.
+///
+/// #421: decode PBF blobs in parallel (osmpbf blobs are independent). Each blob
+/// accumulates into LOCAL Vecs — no per-element allocation, no lock contention —
+/// then per-blob results are merged append-smaller-into-larger to bound copying.
+/// par_bridge yields blobs in arbitrary order, so the result is sorted to a
+/// deterministic total order afterwards (node ids are unique in OSM, so the
+/// lat/lon tiebreak never triggers and the output matches the serial id-sorted
+/// baseline byte-for-byte). Peak RSS stays below the (ways-pass) build peak.
 fn extract_nodes<P: AsRef<Path>>(path: P) -> Result<NodeExtractionResult> {
-    use std::sync::Mutex;
+    use osmpbf::{BlobDecode, BlobReader};
+    use rayon::prelude::*;
 
-    let reader = ElementReader::from_path(path)?;
-    let nodes = Mutex::new(Vec::new());
-    let signal_nodes = Mutex::new(Vec::new());
+    let reader = BlobReader::from_path(path)?;
 
-    reader
-        .for_each(|element| {
-            match element {
-                Element::Node(node) => {
-                    nodes
-                        .lock()
-                        .unwrap()
-                        .push((node.id(), node.lat(), node.lon()));
-
-                    // Check for traffic signal tag
-                    for (key, value) in node.tags() {
-                        if key == "highway" && value == "traffic_signals" {
-                            signal_nodes.lock().unwrap().push(node.id());
-                            break;
+    let (mut nodes, mut signal_node_ids) = reader
+        .par_bridge()
+        .map(|blob| -> Result<NodeBlob> {
+            let mut nodes = Vec::new();
+            let mut signals = Vec::new();
+            if let BlobDecode::OsmData(block) = blob?.decode()? {
+                for element in block.elements() {
+                    match element {
+                        Element::Node(node) => {
+                            nodes.push((node.id(), node.lat(), node.lon()));
+                            for (key, value) in node.tags() {
+                                if key == "highway" && value == "traffic_signals" {
+                                    signals.push(node.id());
+                                    break;
+                                }
+                            }
                         }
+                        Element::DenseNode(node) => {
+                            nodes.push((node.id(), node.lat(), node.lon()));
+                            for (key, value) in node.tags() {
+                                if key == "highway" && value == "traffic_signals" {
+                                    signals.push(node.id());
+                                    break;
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
-                Element::DenseNode(node) => {
-                    nodes
-                        .lock()
-                        .unwrap()
-                        .push((node.id(), node.lat(), node.lon()));
-
-                    // Check for traffic signal tag
-                    for (key, value) in node.tags() {
-                        if key == "highway" && value == "traffic_signals" {
-                            signal_nodes.lock().unwrap().push(node.id());
-                            break;
-                        }
-                    }
-                }
-                _ => {}
             }
+            Ok((nodes, signals))
         })
+        .reduce(
+            || Ok((Vec::new(), Vec::new())),
+            |a, b| {
+                let (mut an, mut asig) = a?;
+                let (mut bn, mut bsig) = b?;
+                if bn.len() > an.len() {
+                    std::mem::swap(&mut an, &mut bn);
+                }
+                an.extend(bn);
+                if bsig.len() > asig.len() {
+                    std::mem::swap(&mut asig, &mut bsig);
+                }
+                asig.extend(bsig);
+                Ok((an, asig))
+            },
+        )
         .context("Failed to read nodes")?;
 
-    let mut nodes = nodes.into_inner().unwrap();
-    let mut signal_node_ids = signal_nodes.into_inner().unwrap();
-
-    // Sort by ID for determinism
-    nodes.sort_by_key(|(id, _, _)| *id);
+    // Deterministic total order. id is unique in OSM so the lat/lon tiebreak is
+    // pure insurance; the sorted sequence is identical to the serial baseline.
+    nodes.sort_unstable_by(|a, b| {
+        a.0.cmp(&b.0)
+            .then_with(|| a.1.total_cmp(&b.1))
+            .then_with(|| a.2.total_cmp(&b.2))
+    });
     signal_node_ids.sort_unstable();
     signal_node_ids.dedup();
 
@@ -223,61 +251,78 @@ fn extract_ways<P: AsRef<Path>>(path: P) -> Result<Vec<Way>> {
 
 /// Extract relations from PBF, filtering for turn restrictions
 fn extract_relations<P: AsRef<Path>>(path: P) -> Result<Vec<Relation>> {
-    use std::sync::Mutex;
+    use osmpbf::{BlobDecode, BlobReader};
+    use rayon::prelude::*;
 
-    let reader = ElementReader::from_path(path)?;
-    let relations = Mutex::new(Vec::new());
+    let reader = BlobReader::from_path(path)?;
 
-    reader
-        .for_each(|element| {
-            if let Element::Relation(relation) = element {
-                // Parse tags
-                let tags: Vec<(String, String)> = relation
-                    .tags()
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect();
+    // #421: parallel blob decode (relations are a tiny fraction of elements;
+    // the cost is the full-file decode, which parallelises). Per-blob local
+    // Vecs, merged append-into-larger; sorted by unique id afterwards so the
+    // output is identical to the serial baseline.
+    let mut relations = reader
+        .par_bridge()
+        .map(|blob| -> Result<Vec<Relation>> {
+            let mut out = Vec::new();
+            if let BlobDecode::OsmData(block) = blob?.decode()? {
+                for element in block.elements() {
+                    if let Element::Relation(relation) = element {
+                        let tags: Vec<(String, String)> = relation
+                            .tags()
+                            .map(|(k, v)| (k.to_string(), v.to_string()))
+                            .collect();
 
-                // Filter: only keep if type=restriction or has restriction-related tags
-                let is_restriction = tags.iter().any(|(k, v)| {
-                    (k == "type" && v == "restriction")
-                        || k.starts_with("restriction")
-                        || k == "except"
-                });
+                        // Filter: type=restriction or restriction-related tags.
+                        let is_restriction = tags.iter().any(|(k, v)| {
+                            (k == "type" && v == "restriction")
+                                || k.starts_with("restriction")
+                                || k == "except"
+                        });
+                        if !is_restriction {
+                            continue;
+                        }
 
-                if !is_restriction {
-                    return;
+                        let members: Vec<Member> = relation
+                            .members()
+                            .filter_map(|member| {
+                                let kind = match member.member_type {
+                                    osmpbf::RelMemberType::Node => MemberKind::Node,
+                                    osmpbf::RelMemberType::Way => MemberKind::Way,
+                                    osmpbf::RelMemberType::Relation => return None,
+                                };
+                                Some(Member {
+                                    role: member.role().unwrap_or("").to_string(),
+                                    kind,
+                                    ref_id: member.member_id,
+                                })
+                            })
+                            .collect();
+
+                        out.push(Relation {
+                            id: relation.id(),
+                            members,
+                            tags,
+                        });
+                    }
                 }
-
-                // Parse members
-                let members: Vec<Member> = relation
-                    .members()
-                    .filter_map(|member| {
-                        let kind = match member.member_type {
-                            osmpbf::RelMemberType::Node => MemberKind::Node,
-                            osmpbf::RelMemberType::Way => MemberKind::Way,
-                            osmpbf::RelMemberType::Relation => return None, // Skip relation members for now
-                        };
-
-                        Some(Member {
-                            role: member.role().unwrap_or("").to_string(),
-                            kind,
-                            ref_id: member.member_id,
-                        })
-                    })
-                    .collect();
-
-                relations.lock().unwrap().push(Relation {
-                    id: relation.id(),
-                    members,
-                    tags,
-                });
             }
+            Ok(out)
         })
+        .reduce(
+            || Ok(Vec::new()),
+            |a, b| {
+                let mut av = a?;
+                let mut bv = b?;
+                if bv.len() > av.len() {
+                    std::mem::swap(&mut av, &mut bv);
+                }
+                av.extend(bv);
+                Ok(av)
+            },
+        )
         .context("Failed to read relations")?;
 
-    let mut relations = relations.into_inner().unwrap();
-
-    // Sort by ID for determinism
+    // Sort by unique ID for determinism.
     relations.sort_by_key(|r| r.id);
 
     Ok(relations)

--- a/route/src/model/profiling.rs
+++ b/route/src/model/profiling.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use super::{CompiledModel, compile_model, evaluate_turn_full, evaluate_way};
 use crate::density::{DensityClassifier, WayTagsView};
 use crate::formats::{TurnRule, WayAttr, turn_rules, way_attrs};
-use crate::profile_abi::{Mode, TurnRuleKind};
+use crate::profile_abi::{Mode, TurnRuleKind, WayOutput};
 
 pub struct ProfileConfig {
     pub ways_path: PathBuf,
@@ -225,45 +225,84 @@ pub fn run_profiling(config: ProfileConfig) -> Result<ProfileResult> {
     // Reverse-map highway_class u16 -> highway name for the density classifier.
     let highway_classes = build_highway_classes();
 
-    let way_stream = crate::formats::WaysFile::stream_ways(&config.ways_path)?;
+    // #420: parallelise the per-way evaluation. Per way the work (density
+    // classify + one evaluate_way per mode) is independent and read-only over
+    // the compiled models + dictionaries. We pull the serial decode stream in
+    // BOUNDED chunks and rayon-evaluate each chunk: peak RSS stays flat (only
+    // one chunk of decoded ways is resident on top of the already-resident
+    // per-mode output Vecs — it does NOT scale with file size). Output bytes are
+    // order-independent (way_attrs is written sorted by the unique way_id), but
+    // we accumulate in stream order anyway for robustness. density_hist is an
+    // exact integer sum, so order does not affect it.
+    use rayon::prelude::*;
+    const CHUNK_WAYS: usize = 65_536;
+    let density_classifier = config.density_classifier;
+
+    let mut way_stream = crate::formats::WaysFile::stream_ways(&config.ways_path)?;
     let mut count = 0u64;
+    let mut next_progress = 1_000_000u64;
     let mut density_hist: [u64; 5] = [0; 5];
+    let mut chunk: Vec<(i64, Vec<u32>, Vec<u32>)> = Vec::with_capacity(CHUNK_WAYS);
 
-    for result in way_stream {
-        let (way_id, keys, vals, _nodes) = result?;
-
-        // Density class is the same across all modes — compute once per way.
-        let density_class = {
-            // Pick the first compiled model just to evaluate the way and
-            // resolve the highway tag — we only need the highway_class u16.
-            // Any model works because they share the same dictionaries.
-            let first = &compiled_models[0];
-            let output = evaluate_way(first, &keys, &vals, &val_dict);
-
-            let highway_name = highway_classes
-                .get(&output.highway_class)
-                .map(|s| s.as_str())
-                .unwrap_or("");
-
-            let view = WayTagsView {
-                keys: &keys,
-                vals: &vals,
-                key_dict: &key_dict,
-                val_dict: &val_dict,
-            };
-            crate::density::classify_osm_tag(config.density_classifier, highway_name, &view)
-        };
-        density_hist[density_class.to_u8() as usize] += 1;
-
-        for (i, compiled) in compiled_models.iter().enumerate() {
-            let mut output = evaluate_way(compiled, &keys, &vals, &val_dict);
-            output.density_class = density_class.to_u8();
-            way_attrs_per_mode[i].push(WayAttr { way_id, output });
+    loop {
+        // Fill one bounded chunk from the (serial) decode stream.
+        chunk.clear();
+        for result in way_stream.by_ref() {
+            let (way_id, keys, vals, _nodes) = result?;
+            chunk.push((way_id, keys, vals));
+            if chunk.len() >= CHUNK_WAYS {
+                break;
+            }
+        }
+        if chunk.is_empty() {
+            break;
         }
 
-        count += 1;
-        if count.is_multiple_of(1_000_000) {
+        // Evaluate the chunk in parallel; collect() preserves chunk index order.
+        let results: Vec<(i64, u8, Vec<WayOutput>)> = chunk
+            .par_iter()
+            .map(|(way_id, keys, vals)| {
+                // Density class is mode-agnostic — compute once per way (one
+                // extra eval just to resolve the highway tag; any model works
+                // since they share dictionaries).
+                let out0 = evaluate_way(&compiled_models[0], keys, vals, &val_dict);
+                let highway_name = highway_classes
+                    .get(&out0.highway_class)
+                    .map(|s| s.as_str())
+                    .unwrap_or("");
+                let view = WayTagsView {
+                    keys: keys.as_slice(),
+                    vals: vals.as_slice(),
+                    key_dict: &key_dict,
+                    val_dict: &val_dict,
+                };
+                let dclass =
+                    crate::density::classify_osm_tag(density_classifier, highway_name, &view)
+                        .to_u8();
+                let outputs: Vec<WayOutput> = compiled_models
+                    .iter()
+                    .map(|compiled| {
+                        let mut output = evaluate_way(compiled, keys, vals, &val_dict);
+                        output.density_class = dclass;
+                        output
+                    })
+                    .collect();
+                (*way_id, dclass, outputs)
+            })
+            .collect();
+
+        // Accumulate serially (deterministic).
+        for (way_id, dclass, outputs) in results {
+            density_hist[dclass as usize] += 1;
+            for (i, output) in outputs.into_iter().enumerate() {
+                way_attrs_per_mode[i].push(WayAttr { way_id, output });
+            }
+        }
+
+        count += chunk.len() as u64;
+        if count >= next_progress {
             println!("  processed {} ways...", count);
+            next_progress += 1_000_000;
         }
     }
 

--- a/route/src/model/profiling.rs
+++ b/route/src/model/profiling.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use super::{CompiledModel, compile_model, evaluate_turn_full, evaluate_way};
@@ -69,14 +69,17 @@ impl ProfileResult {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProfileMeta {
     pub abi_version: u32,
-    pub profile_versions: HashMap<String, u32>,
-    pub highway_classes: HashMap<u16, String>,
-    pub surface_classes: HashMap<u16, String>,
-    pub class_bits: HashMap<String, u32>,
+    // #425: BTreeMap (sorted keys) so profile_meta.json serialises deterministically.
+    // HashMap iteration order is randomised per process, and profile_meta_sha256 is
+    // part of Step2LockFile — HashMap here made the step2 lock non-reproducible.
+    pub profile_versions: BTreeMap<String, u32>,
+    pub highway_classes: BTreeMap<u16, String>,
+    pub surface_classes: BTreeMap<u16, String>,
+    pub class_bits: BTreeMap<String, u32>,
     pub ways_sha256: String,
     pub relations_sha256: String,
-    pub way_attrs_sha256: HashMap<String, String>,
-    pub turn_rules_sha256: HashMap<String, String>,
+    pub way_attrs_sha256: BTreeMap<String, String>,
+    pub turn_rules_sha256: BTreeMap<String, String>,
 }
 
 pub fn build_highway_classes() -> HashMap<u16, String> {
@@ -424,9 +427,9 @@ pub fn run_profiling(config: ProfileConfig) -> Result<ProfileResult> {
     let ways_sha256 = compute_file_sha256(&config.ways_path)?;
     let relations_sha256 = compute_file_sha256(&config.relations_path)?;
 
-    let mut way_attrs_sha256 = HashMap::new();
-    let mut turn_rules_sha256 = HashMap::new();
-    let mut profile_versions = HashMap::new();
+    let mut way_attrs_sha256 = BTreeMap::new();
+    let mut turn_rules_sha256 = BTreeMap::new();
+    let mut profile_versions = BTreeMap::new();
 
     for out in &mode_outputs {
         way_attrs_sha256.insert(
@@ -445,9 +448,9 @@ pub fn run_profiling(config: ProfileConfig) -> Result<ProfileResult> {
     let meta = ProfileMeta {
         abi_version: 2,
         profile_versions,
-        highway_classes: build_highway_classes(),
-        surface_classes: build_surface_classes(),
-        class_bits: build_class_bits(),
+        highway_classes: build_highway_classes().into_iter().collect(),
+        surface_classes: build_surface_classes().into_iter().collect(),
+        class_bits: build_class_bits().into_iter().collect(),
         ways_sha256,
         relations_sha256,
         way_attrs_sha256,

--- a/route/src/nbg/mod.rs
+++ b/route/src/nbg/mod.rs
@@ -208,35 +208,66 @@ fn load_way_attrs_index(path: &PathBuf) -> Result<HashMap<i64, Vec<u8>>> {
     Ok(index)
 }
 
-fn load_node_coordinates(path: &PathBuf) -> Result<HashMap<i64, (f64, f64)>> {
-    use std::fs::File;
-    use std::io::Read;
+/// Node coordinate table loaded from nodes.sa. (#422)
+///
+/// Replaces the prior `HashMap<i64,(f64,f64)>` (~3.3 GB on Belgium: 8B key + 16B
+/// value + hash overhead over 69M nodes) with a sorted 16-bytes-per-node
+/// `Vec<(i64,i32,i32)>` (~1.1 GB) + binary search. nodes.sa records are stored
+/// strictly ascending by id, so no sort is needed. `get()` decodes lat/lon with
+/// the EXACT same expression the loader used, so geometry stays byte-identical.
+struct NodeCoords {
+    /// (node_id, lat_fxp, lon_fxp) ascending by node_id.
+    entries: Vec<(i64, i32, i32)>,
+}
 
-    let mut file = File::open(path)?;
-    let mut header = vec![0u8; 128];
-    file.read_exact(&mut header)?;
-
-    let count = u64::from_le_bytes(header[8..16].try_into()?);
-    let mut coords = HashMap::new();
-
-    for _ in 0..count {
-        let mut record = [0u8; 16];
-        file.read_exact(&mut record)?;
-
-        let node_id = i64::from_le_bytes(record[0..8].try_into()?);
-        let lat_lon = u64::from_le_bytes(record[8..16].try_into()?);
-
-        // Decode lat/lon from packed format (1e-7 degrees)
-        // In little-endian: lower 32 bits are lat_fxp (bytes 8-11), upper 32 bits are lon_fxp (bytes 12-15)
-        let lat_fxp = (lat_lon & 0xFFFFFFFF) as i32;
-        let lon_fxp = (lat_lon >> 32) as i32;
-        let lat = lat_fxp as f64 * 1e-7;
-        let lon = lon_fxp as f64 * 1e-7;
-
-        coords.insert(node_id, (lat, lon));
+impl NodeCoords {
+    fn len(&self) -> usize {
+        self.entries.len()
     }
 
-    Ok(coords)
+    /// Look up a node's (lat, lon) in degrees; None if absent.
+    #[inline]
+    fn get(&self, id: i64) -> Option<(f64, f64)> {
+        match self.entries.binary_search_by_key(&id, |&(nid, _, _)| nid) {
+            Ok(i) => {
+                let (_, lat_fxp, lon_fxp) = self.entries[i];
+                Some((lat_fxp as f64 * 1e-7, lon_fxp as f64 * 1e-7))
+            }
+            Err(_) => None,
+        }
+    }
+}
+
+fn load_node_coordinates(path: &PathBuf) -> Result<NodeCoords> {
+    use std::fs::File;
+    use std::io::{BufReader, Read};
+
+    // Buffered read: the body is `count` × 16-byte records; the previous
+    // read_exact(16) per record was one syscall per node (~69M). A 1 MiB
+    // BufReader collapses that to ~1k syscalls — a load-time win that offsets
+    // the binary-search lookup cost downstream.
+    let mut file = BufReader::with_capacity(1 << 20, File::open(path)?);
+    let mut header = [0u8; 128];
+    file.read_exact(&mut header)?;
+
+    let count = u64::from_le_bytes(header[8..16].try_into()?) as usize;
+    let mut entries = Vec::with_capacity(count);
+
+    let mut record = [0u8; 16];
+    for _ in 0..count {
+        file.read_exact(&mut record)?;
+        let node_id = i64::from_le_bytes(record[0..8].try_into()?);
+        let lat_lon = u64::from_le_bytes(record[8..16].try_into()?);
+        // Little-endian: lower 32 bits = lat_fxp (bytes 8-11), upper = lon_fxp.
+        let lat_fxp = (lat_lon & 0xFFFFFFFF) as i32;
+        let lon_fxp = (lat_lon >> 32) as i32;
+        entries.push((node_id, lat_fxp, lon_fxp));
+    }
+
+    // nodes.sa is strictly ascending by id (format invariant) → binary search OK.
+    debug_assert!(entries.windows(2).all(|w| w[0].0 < w[1].0));
+
+    Ok(NodeCoords { entries })
 }
 
 fn collect_decision_nodes(
@@ -319,7 +350,7 @@ fn emit_edges(
     ways_path: &PathBuf,
     included_ways: &HashSet<i64>,
     osm_to_compact: &HashMap<i64, u32>,
-    node_coords: &HashMap<i64, (f64, f64)>,
+    node_coords: &NodeCoords,
 ) -> Result<(Vec<EdgeInfo>, HashMap<u32, Vec<(u32, u64)>>)> {
     let mut edges = Vec::new();
     let mut adjacency: HashMap<u32, Vec<(u32, u64)>> = HashMap::new();
@@ -355,13 +386,13 @@ fn emit_edges(
 
                     for j in seg_start_idx..=i {
                         let osm_id = nodes[j];
-                        if let Some(&(lat, lon)) = node_coords.get(&osm_id) {
+                        if let Some((lat, lon)) = node_coords.get(osm_id) {
                             lat_fxp.push((lat * 1e7).round() as i32);
                             lon_fxp.push((lon * 1e7).round() as i32);
 
                             if j > seg_start_idx {
                                 let prev_osm = nodes[j - 1];
-                                if let Some(&(prev_lat, prev_lon)) = node_coords.get(&prev_osm) {
+                                if let Some((prev_lat, prev_lon)) = node_coords.get(prev_osm) {
                                     length_m += haversine_distance(prev_lat, prev_lon, lat, lon);
                                 }
                             }
@@ -375,9 +406,8 @@ fn emit_edges(
 
                         // Compute bearing
                         let (start_lat, start_lon) =
-                            node_coords.get(&start_osm).copied().unwrap_or((0.0, 0.0));
-                        let (end_lat, end_lon) =
-                            node_coords.get(&end_osm).copied().unwrap_or((0.0, 0.0));
+                            node_coords.get(start_osm).unwrap_or((0.0, 0.0));
+                        let (end_lat, end_lon) = node_coords.get(end_osm).unwrap_or((0.0, 0.0));
                         let bearing = compute_bearing(start_lat, start_lon, end_lat, end_lon);
 
                         let edge_idx = edges.len() as u64;

--- a/route/src/nbg/mod.rs
+++ b/route/src/nbg/mod.rs
@@ -435,9 +435,8 @@ fn assemble_csr(
     }
     offsets[n_nodes as usize] = heads.len() as u64;
 
-    let created_unix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)?
-        .as_secs();
+    // #419: deterministic for byte-reproducible builds (field never read).
+    let created_unix: u64 = 0;
 
     // Caller (`build_nbg`) overwrites `inputs_sha` with a SHA-256 of
     // every step-1/2 artefact used to derive the CSR (nodes.sa,

--- a/scripts/build-pipeline.sh
+++ b/scripts/build-pipeline.sh
@@ -117,11 +117,22 @@ LAST_RECIPE="$DATA/last-recipe"
 car_present=0
 for m in "${MODES[@]}"; do [[ "$m" == "car" ]] && car_present=1; done
 recipe_fingerprint() {
+    # #424: content-only fingerprint over BOTH the model files and the traffic
+    # profiles, in a locale-stable (LC_ALL=C) order. `sha256sum < file` emits the
+    # hash with no path, so the fingerprint is path- and readdir-order-independent;
+    # the basename is included so a mode rename still counts as a change. Models
+    # are included (previously only traffic profiles were) so editing a *.model.json
+    # forces a rebuild instead of silently reusing a stale container.
     {
         echo "$RECIPE_VERSION"
-        for p in "$CAR_BASE_PROFILE" "$CAR_VARIANT_PROFILE"; do
-            [[ -f "$TRAFFIC_DIR/$p" ]] && sha256sum "$TRAFFIC_DIR/$p"
-        done
+        # Emit "basename <content-hash>" per recipe file, then sort by that line.
+        # Ordering is therefore determined by basename + content only — NOT by the
+        # directory paths — so MODELS_DIR/TRAFFIC_DIR location can't change the
+        # fingerprint. `sha256sum < file` keeps the per-file hash path-free.
+        for f in "$MODELS_DIR"/*.model.json "$TRAFFIC_DIR"/*.traffic.json; do
+            [[ -f "$f" ]] || continue
+            printf '%s %s\n' "$(basename "$f")" "$(sha256sum <"$f" | cut -d' ' -f1)"
+        done | LC_ALL=C sort
     } | sha256sum | cut -d' ' -f1
 }
 RECIPE_FP="$(recipe_fingerprint)"
@@ -247,6 +258,12 @@ time "$BIN" step5-weights \
   "${WA_ARGS[@]}" \
   --outdir "$DATA/step5"
 
+# #424: steps 6/7/8 run sequentially per mode ON PURPOSE — do NOT fan the modes
+# out concurrently. Each invocation is already internally rayon-parallel AND holds
+# a multi-GB working set (filtered EBG + order + weighted_adj/atomic weight Vecs);
+# running modes in parallel would multiply peak RSS by the mode count and blow the
+# 78 GB staging budget. step7 also writes a non-mode-keyed shortcuts.tmp that
+# concurrent runs would clobber. Keep these loops sequential.
 for m in "${MODES[@]}"; do
     log "step6-order $m"
     time "$BIN" step6-order \

--- a/scripts/build-pipeline.sh
+++ b/scripts/build-pipeline.sh
@@ -136,11 +136,15 @@ recipe_fingerprint() {
     } | sha256sum | cut -d' ' -f1
 }
 RECIPE_FP="$(recipe_fingerprint)"
+# #424: the fingerprint now covers the *.model.json files (not just car traffic
+# profiles), so a model edit must force a rebuild for ANY mode set. This was
+# previously gated on car_present, which let a non-car build (e.g. foot,bike)
+# silently adopt a stale container after a model edit — defeating the intent.
+# Compute unconditionally; worst case a traffic-only change on a non-car build
+# triggers one extra (correct, safe) rebuild.
 recipe_changed=0
-if [[ "$car_present" -eq 1 ]]; then
-    if [[ ! -f "$LAST_RECIPE" ]] || [[ "$(cat "$LAST_RECIPE" 2>/dev/null)" != "$RECIPE_FP" ]]; then
-        recipe_changed=1
-    fi
+if [[ ! -f "$LAST_RECIPE" ]] || [[ "$(cat "$LAST_RECIPE" 2>/dev/null)" != "$RECIPE_FP" ]]; then
+    recipe_changed=1
 fi
 
 all_step8_present=1


### PR DESCRIPTION
Build-pipeline reproducibility + parallelism + RSS wins from the build-step audit. **Every change is gated on byte-identical step lock SHAs + before/after wall + peak RSS on belgium.pbf** — no RSS or runtime regression anywhere.

## Landed & verified

| # | Change | Wall | Peak RSS | Output |
|---|--------|------|----------|--------|
| #419 | deterministic `created_unix` | — | — | step1 now byte-reproducible (was not) |
| #421a | drop redundant 1.6GB node clone | 48→46.7s | ↓ | byte-identical |
| #425 | BTreeMap for profile_meta (Codex-found) | — | — | step2 lock now reproducible |
| **#420** | **parallelize step2 per-way eval** | **65→35.7s (~1.8×)** | 2.12→2.05GB | byte-identical |
| **#421** | **parallel step1 nodes+relations decode** | **46.7→35.9s** | 12.13GB (=baseline) | byte-identical |
| #423 | drop dead turn read in step7 | — | ↓~60MB | byte-identical (dead binding) |
| #424 | content-only recipe fingerprint + sequential-modes guard | — | — | fixes silent-stale-build on model edits |
| **#422** | **step3 sorted-Vec node lookup vs 69M HashMap** | **57.7→35.1s (~1.64×)** | **8.15→6.0GB (−2.15GB)** | byte-identical |

## Notes
- **Reproducibility first:** #419 + #425 made step1 & step2 byte-stable, which is what makes every parallelization verifiable by SHA.
- **Mode fanout (6/7/8) rejected** — RSS-multiplicative; documented in #424 so it isn't reintroduced.
- **#423 weighted_adj idea rejected** — this codebase's step7 is metric-aware (weighted_adj is load-bearing for the topology), so only the genuinely-dead turn read was removed.
- All gated against saved baselines; clippy + fmt clean.