### PR TITLE
fix(traffic): tighten lenient sample profiles (#430)

### DIFF
--- a/traffic/car_realistic.traffic.json
+++ b/traffic/car_realistic.traffic.json
@@ -5,7 +5,7 @@
     "urban_high": 0.60,
     "urban_medium": 0.78,
     "urban_low": 0.88,
-    "suburban": 0.95,
-    "rural": 1.00
+    "suburban": 0.90,
+    "rural": 0.90
   }
 }

--- a/traffic/rush_hour.traffic.json
+++ b/traffic/rush_hour.traffic.json
@@ -2,10 +2,10 @@
   "name": "rush_hour",
   "base_model": "car",
   "speed_factors": {
-    "urban_high": 0.55,
-    "urban_medium": 0.70,
-    "urban_low": 0.85,
-    "suburban": 0.90,
-    "rural": 0.95
+    "urban_high": 0.35,
+    "urban_medium": 0.50,
+    "urban_low": 0.68,
+    "suburban": 0.82,
+    "rural": 0.88
   }
 }


### PR DESCRIPTION
#430: rush_hour isochrones too lenient. Diagnosed as the bundled near-free-flow sample profiles (rush_hour ≈ realistic; Brussels→Antwerp car 37min vs rush 40min, +6%).

- **rush_hour** → 0.35/0.50/0.68/0.82/0.88 (real urban congestion).
- **realistic** → capped at 0.90 max (suburban 0.95→0.90, rural 1.00→0.90); urban unchanged.
- rush_hour ≤ realistic per class; all in [0.1,1.5].

Stopgap until butterfly-speeds observed-data calibration. Residual ~0.8%-radius isochrone-geometry over-extension tracked in #431.