### PR TITLE
perf(flight): edges_batch source-grouping + per-source predecessor PHAST tree (#438)

### DIFF
--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -4686,7 +4686,9 @@ fn run_edges_batch_bench(
     seed: u64,
 ) -> anyhow::Result<()> {
     use butterfly_route::model::types::Mode;
-    use butterfly_route::server::flight::{compute_edges_flat, compute_edges_grouped};
+    use butterfly_route::server::flight::{
+        compute_edges_flat, compute_edges_grouped, compute_edges_tree,
+    };
     use butterfly_route::server::state::{LoadOptions, ServerState};
     use std::time::Instant;
 
@@ -4720,17 +4722,33 @@ fn run_edges_batch_bench(
     let mode = Mode(mode_idx);
     let mode_data = state.get_mode(mode);
 
-    // Build a source-sharing workload: each source has `targets_per_source`
-    // random Belgium-bbox targets (mirrors origin→nearby-PoIs). Sources are
-    // random too; the K=1 snap groups pairs by resolved source rank.
+    // Build a source-sharing workload mirroring traffic-flow's shape:
+    // sources jittered around real Belgian cities (street sections are always
+    // on-network — pure random bbox points land in the sea / outside the
+    // Belgium graph and skew the run toward unreachable-escalation cost),
+    // targets near the source (origin→top-k-nearest-PoIs).
+    const CITIES: [[f64; 2]; 12] = [
+        [4.3517, 50.8503],
+        [4.4025, 51.2194],
+        [3.7250, 51.0500],
+        [5.5667, 50.6333],
+        [3.2200, 50.4100],
+        [4.0300, 50.4500],
+        [4.4400, 50.4100],
+        [5.3400, 50.2700],
+        [4.8700, 50.4700],
+        [4.3600, 50.8200],
+        [3.7500, 50.3200],
+        [4.0000, 51.0000],
+    ];
     let mut rng = StdRng::seed_from_u64(seed);
     let mut pairs: Vec<[f64; 4]> = Vec::with_capacity(n_pairs);
-    for _ in 0..n_sources {
-        let slon = rng.random_range(2.55..6.40);
-        let slat = rng.random_range(49.50..51.50);
+    for k in 0..n_sources {
+        let c = CITIES[k % CITIES.len()];
+        let slon = (c[0] + rng.random_range(-0.15_f64..0.15)).clamp(2.55, 6.40);
+        let slat = (c[1] + rng.random_range(-0.15_f64..0.15)).clamp(49.50, 51.50);
         for _ in 0..targets_per_source {
-            // Targets NEAR the source (±~25 km), mirroring traffic-flow's
-            // origin→top-k-nearest-PoIs shape — keeps reachability realistic.
+            // Targets NEAR the source (±~25 km).
             let dlon = (slon + rng.random_range(-0.30_f64..0.30)).clamp(2.55, 6.40);
             let dlat = (slat + rng.random_range(-0.30_f64..0.30)).clamp(49.50, 51.50);
             pairs.push([slon, slat, dlon, dlat]);
@@ -4795,6 +4813,46 @@ fn run_edges_batch_bench(
     );
     println!("    ✓ reachability + total-duration IDENTICAL (correctness verified)");
 
+    // ---- TREE variant (#438 Phase 1) oracle ----
+    let tree = compute_edges_tree(&state, &mode_data, mode, &pairs, true);
+    assert_eq!(tree.len(), flat.len(), "tree pair count mismatch");
+    let mut t_reach_mismatch = 0usize;
+    let mut t_dur_mismatch = 0usize;
+    let mut t_byte_identical = 0usize;
+    for (f, g) in flat.iter().zip(tree.iter()) {
+        assert_eq!(f.query_idx, g.query_idx, "tree query_idx order mismatch");
+        if f.rows.is_empty() != g.rows.is_empty() {
+            t_reach_mismatch += 1;
+        }
+        let f_dur: u64 = f.rows.iter().map(|r| r.dur_ms as u64).sum();
+        let g_dur: u64 = g.rows.iter().map(|r| r.dur_ms as u64).sum();
+        if f_dur != g_dur {
+            t_dur_mismatch += 1;
+        }
+        let same = f.rows.len() == g.rows.len()
+            && f.rows.iter().zip(g.rows.iter()).all(|(a, b)| {
+                a.edge_seq == b.edge_seq
+                    && a.osm_from == b.osm_from
+                    && a.osm_to == b.osm_to
+                    && a.dur_ms == b.dur_ms
+                    && a.dist_m == b.dist_m
+            });
+        if same {
+            t_byte_identical += 1;
+        }
+    }
+    println!(
+        "  TREE EQUIVALENCE: reach mismatches {} | duration mismatches {} | byte-identical {}/{} ({:.2}%)",
+        t_reach_mismatch,
+        t_dur_mismatch,
+        t_byte_identical,
+        n_pairs,
+        100.0 * t_byte_identical as f64 / n_pairs.max(1) as f64
+    );
+    assert_eq!(t_reach_mismatch, 0, "TREE changed reachability");
+    assert_eq!(t_dur_mismatch, 0, "TREE changed total duration");
+    println!("    ✓ TREE reachability + total-duration IDENTICAL");
+
     // ---- Throughput (best of 2, after a warm run) ----
     let _ = compute_edges_flat(&state, &mode_data, mode, &pairs, true);
     let mut flat_dt = f64::MAX;
@@ -4821,7 +4879,23 @@ fn run_edges_batch_bench(
         grouped_dt,
         n_pairs as f64 / grouped_dt
     );
-    println!("    speedup: {:.2}×", flat_dt / grouped_dt);
+    let mut tree_dt = f64::MAX;
+    for _ in 0..2 {
+        let t0 = Instant::now();
+        let _ = compute_edges_tree(&state, &mode_data, mode, &pairs, true);
+        tree_dt = tree_dt.min(t0.elapsed().as_secs_f64());
+    }
+    println!(
+        "    TREE    {:.3}s  {:.0} pairs/s",
+        tree_dt,
+        n_pairs as f64 / tree_dt
+    );
+    println!(
+        "    speedup: grouped {:.2}× | tree {:.2}× (vs flat), tree {:.2}× (vs grouped)",
+        flat_dt / grouped_dt,
+        flat_dt / tree_dt,
+        grouped_dt / tree_dt
+    );
     println!("═══════════════════════════════════════════════════════════════");
     Ok(())
 }

--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -517,6 +517,30 @@ enum Commands {
         #[arg(long, default_value_t = 200)]
         max_combos: usize,
     },
+
+    /// #438: edges_batch FLAT (per-pair) vs source-GROUPED throughput +
+    /// equivalence, on a `.butterfly` container. Builds a source-sharing
+    /// workload (n_sources sources × targets_per_source nearby targets,
+    /// mirroring traffic-flow's origin→PoIs shape), runs BOTH paths, asserts
+    /// they are equivalent (same reachability + same per-pair total duration),
+    /// reports the byte-identity rate, and times flat vs grouped. Server-free.
+    EdgesBatch {
+        /// Path to a `.butterfly` container.
+        #[arg(long)]
+        data: PathBuf,
+        /// Transport mode (car, bike, foot).
+        #[arg(long, default_value = "car")]
+        mode: String,
+        /// Number of distinct sources.
+        #[arg(long, default_value_t = 200)]
+        n_sources: usize,
+        /// Targets per source (the source-sharing factor).
+        #[arg(long, default_value_t = 30)]
+        targets_per_source: usize,
+        /// Random seed.
+        #[arg(long, default_value_t = 42)]
+        seed: u64,
+    },
 }
 
 /// Aggregated statistics across multiple runs
@@ -764,6 +788,14 @@ fn main() -> anyhow::Result<()> {
             cities,
             max_combos,
         } => run_p2p_bench(&data, &mode, n, seed, parallel, cities, max_combos),
+
+        Commands::EdgesBatch {
+            data,
+            mode,
+            n_sources,
+            targets_per_source,
+            seed,
+        } => run_edges_batch_bench(&data, &mode, n_sources, targets_per_source, seed),
     }
 }
 
@@ -4636,6 +4668,160 @@ fn run_p2p_bench(
         pairs.len(),
         dt * 1000.0 / pairs.len() as f64
     );
+    println!("═══════════════════════════════════════════════════════════════");
+    Ok(())
+}
+
+/// #438: edges_batch FLAT (per-pair) vs source-GROUPED — throughput + the
+/// equivalence oracle. Builds n_sources × targets_per_source pairs (the
+/// source-sharing shape of the real traffic-flow workload), runs both
+/// `compute_edges_flat` and `compute_edges_grouped` in-process, asserts they
+/// agree (reachability + per-pair total duration), reports byte-identity, and
+/// times them. The grouped path shares one forward CCH search per source.
+fn run_edges_batch_bench(
+    data: &Path,
+    mode_name: &str,
+    n_sources: usize,
+    targets_per_source: usize,
+    seed: u64,
+) -> anyhow::Result<()> {
+    use butterfly_route::model::types::Mode;
+    use butterfly_route::server::flight::{compute_edges_flat, compute_edges_grouped};
+    use butterfly_route::server::state::{LoadOptions, ServerState};
+    use std::time::Instant;
+
+    let n_pairs = n_sources * targets_per_source;
+    println!("═══════════════════════════════════════════════════════════════");
+    println!("  EDGES_BATCH FLAT vs SOURCE-GROUPED (#438)");
+    println!("═══════════════════════════════════════════════════════════════");
+    println!(
+        "  container: {}\n  mode: {}  sources: {}  targets/source: {}  pairs: {}",
+        data.display(),
+        mode_name,
+        n_sources,
+        targets_per_source,
+        n_pairs
+    );
+
+    let t = Instant::now();
+    let state = ServerState::load_from_container_with_options(
+        data,
+        Some(&[mode_name.to_string()]),
+        &LoadOptions {
+            eager_verify: false,
+            warmup_on_boot: false,
+        },
+    )?;
+    println!("  loaded container in {:.1}s", t.elapsed().as_secs_f64());
+    let mode_idx = *state
+        .mode_lookup
+        .get(mode_name)
+        .ok_or_else(|| anyhow::anyhow!("mode '{}' not loaded", mode_name))?;
+    let mode = Mode(mode_idx);
+    let mode_data = state.get_mode(mode);
+
+    // Build a source-sharing workload: each source has `targets_per_source`
+    // random Belgium-bbox targets (mirrors origin→nearby-PoIs). Sources are
+    // random too; the K=1 snap groups pairs by resolved source rank.
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut pairs: Vec<[f64; 4]> = Vec::with_capacity(n_pairs);
+    for _ in 0..n_sources {
+        let slon = rng.random_range(2.55..6.40);
+        let slat = rng.random_range(49.50..51.50);
+        for _ in 0..targets_per_source {
+            // Targets NEAR the source (±~25 km), mirroring traffic-flow's
+            // origin→top-k-nearest-PoIs shape — keeps reachability realistic.
+            let dlon = (slon + rng.random_range(-0.30_f64..0.30)).clamp(2.55, 6.40);
+            let dlat = (slat + rng.random_range(-0.30_f64..0.30)).clamp(49.50, 51.50);
+            pairs.push([slon, slat, dlon, dlat]);
+        }
+    }
+
+    // ---- Equivalence oracle ----
+    let flat = compute_edges_flat(&state, &mode_data, mode, &pairs, true);
+    let grouped = compute_edges_grouped(&state, &mode_data, mode, &pairs, true);
+    assert_eq!(flat.len(), grouped.len(), "pair count mismatch");
+    let mut reach_mismatch = 0usize;
+    let mut dur_mismatch = 0usize;
+    let mut byte_identical = 0usize;
+    let mut reachable = 0usize;
+    for (f, g) in flat.iter().zip(grouped.iter()) {
+        assert_eq!(f.query_idx, g.query_idx, "query_idx order mismatch");
+        let f_reach = !f.rows.is_empty();
+        let g_reach = !g.rows.is_empty();
+        if f_reach {
+            reachable += 1;
+        }
+        if f_reach != g_reach {
+            reach_mismatch += 1;
+        }
+        let f_dur: u64 = f.rows.iter().map(|r| r.dur_ms as u64).sum();
+        let g_dur: u64 = g.rows.iter().map(|r| r.dur_ms as u64).sum();
+        if f_dur != g_dur {
+            dur_mismatch += 1;
+        }
+        // Byte-identity: same edge rows (seq, osm ids, dur, dist).
+        let same = f.rows.len() == g.rows.len()
+            && f.rows.iter().zip(g.rows.iter()).all(|(a, b)| {
+                a.edge_seq == b.edge_seq
+                    && a.osm_from == b.osm_from
+                    && a.osm_to == b.osm_to
+                    && a.dur_ms == b.dur_ms
+                    && a.dist_m == b.dist_m
+            });
+        if same {
+            byte_identical += 1;
+        }
+    }
+    println!();
+    println!("  EQUIVALENCE:");
+    println!(
+        "    reachable {}/{}  | reachability mismatches: {}  | total-duration mismatches: {}",
+        reachable, n_pairs, reach_mismatch, dur_mismatch
+    );
+    println!(
+        "    byte-identical pairs: {}/{} ({:.2}%)  [equal-cost ties may differ]",
+        byte_identical,
+        n_pairs,
+        100.0 * byte_identical as f64 / n_pairs.max(1) as f64
+    );
+    assert_eq!(
+        reach_mismatch, 0,
+        "CORRECTNESS: grouped path changed reachability for {reach_mismatch} pairs"
+    );
+    assert_eq!(
+        dur_mismatch, 0,
+        "CORRECTNESS: grouped path changed total duration for {dur_mismatch} pairs"
+    );
+    println!("    ✓ reachability + total-duration IDENTICAL (correctness verified)");
+
+    // ---- Throughput (best of 2, after a warm run) ----
+    let _ = compute_edges_flat(&state, &mode_data, mode, &pairs, true);
+    let mut flat_dt = f64::MAX;
+    for _ in 0..2 {
+        let t0 = Instant::now();
+        let _ = compute_edges_flat(&state, &mode_data, mode, &pairs, true);
+        flat_dt = flat_dt.min(t0.elapsed().as_secs_f64());
+    }
+    let mut grouped_dt = f64::MAX;
+    for _ in 0..2 {
+        let t0 = Instant::now();
+        let _ = compute_edges_grouped(&state, &mode_data, mode, &pairs, true);
+        grouped_dt = grouped_dt.min(t0.elapsed().as_secs_f64());
+    }
+    println!();
+    println!("  THROUGHPUT (parallel, best of 2):");
+    println!(
+        "    FLAT    {:.3}s  {:.0} pairs/s",
+        flat_dt,
+        n_pairs as f64 / flat_dt
+    );
+    println!(
+        "    GROUPED {:.3}s  {:.0} pairs/s",
+        grouped_dt,
+        n_pairs as f64 / grouped_dt
+    );
+    println!("    speedup: {:.2}×", flat_dt / grouped_dt);
     println!("═══════════════════════════════════════════════════════════════");
     Ok(())
 }

--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -4639,6 +4639,9 @@ fn run_p2p_bench(
         false
     };
 
+    if pairs.is_empty() {
+        anyhow::bail!("p2p bench: no pairs to run (check --n)");
+    }
     // Warm one query (pages in hot sections so the timing is steady-state).
     let _ = run_pair(&pairs[0]);
 
@@ -4852,6 +4855,21 @@ fn run_edges_batch_bench(
     assert_eq!(t_reach_mismatch, 0, "TREE changed reachability");
     assert_eq!(t_dur_mismatch, 0, "TREE changed total duration");
     println!("    ✓ TREE reachability + total-duration IDENTICAL");
+
+    // Codex audit: row-chain continuity (osm_to[i] == osm_from[i+1]) on every
+    // variant — a malformed but duration-equal path must not slip through.
+    for (label, set) in [("flat", &flat), ("grouped", &grouped), ("tree", &tree)] {
+        for p in set.iter() {
+            for w in p.rows.windows(2) {
+                assert_eq!(
+                    w[0].osm_to, w[1].osm_from,
+                    "{label}: continuity break in query_idx {}",
+                    p.query_idx
+                );
+            }
+        }
+    }
+    println!("    ✓ row-chain continuity holds on all variants");
 
     // ---- Throughput (best of 2, after a warm run) ----
     let _ = compute_edges_flat(&state, &mode_data, mode, &pairs, true);

--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -486,6 +486,37 @@ enum Commands {
         #[arg(long)]
         region: Option<String>,
     },
+
+    /// #438: P2P edges_batch-style query benchmark against a `.butterfly`
+    /// container (snap + bidirectional CCH query) — the OSRM-gap loop. Runs
+    /// in-process (no server), so it's reliable where a background serve isn't.
+    P2p {
+        /// Path to a `.butterfly` container.
+        #[arg(long)]
+        data: PathBuf,
+        /// Transport mode (car, bike, foot).
+        #[arg(long, default_value = "car")]
+        mode: String,
+        /// Number of pairs to run.
+        #[arg(long, default_value_t = 5000)]
+        n: usize,
+        /// Random seed (random-coord mode).
+        #[arg(long, default_value_t = 42)]
+        seed: u64,
+        /// Fan pairs across rayon (matches the serve). Else sequential —
+        /// isolates per-query CPU cost.
+        #[arg(long, default_value_t = false)]
+        parallel: bool,
+        /// Use the 12-city OSRM-parity workload (132 ordered pairs tiled to
+        /// `n`) instead of random Belgium-bbox coords.
+        #[arg(long, default_value_t = false)]
+        cities: bool,
+        /// Max snap-combo fallback attempts for the escalation path (#438:
+        /// unreachable pairs exhaust this many failed CCH queries). Default
+        /// mirrors the engine's DEFAULT_MAX_FALLBACK_COMBOS=200.
+        #[arg(long, default_value_t = 200)]
+        max_combos: usize,
+    },
 }
 
 /// Aggregated statistics across multiple runs
@@ -723,6 +754,16 @@ fn main() -> anyhow::Result<()> {
             output,
             region,
         } => weight_profile::run_weight_profile(&data_dir, &output, region.as_deref()),
+
+        Commands::P2p {
+            data,
+            mode,
+            n,
+            seed,
+            parallel,
+            cities,
+            max_combos,
+        } => run_p2p_bench(&data, &mode, n, seed, parallel, cities, max_combos),
     }
 }
 
@@ -4417,5 +4458,184 @@ fn run_detail_compare(data_dir: &Path, mode: &str, threshold_min: u32) -> anyhow
     println!("└──────────────────┴────────┴────────┴────────┴────────────┘");
     println!();
 
+    Ok(())
+}
+
+/// #438: in-process P2P query benchmark against a `.butterfly` container.
+///
+/// Mirrors `flight::edges_for_pair`'s snap+query path (K=1 fast path +
+/// K=64/combo escalation, default-weight CCH query) over `n` pairs, so it
+/// measures exactly the work that dominates `edges_batch` (99% query per the
+/// #436 profiling). Runs entirely in-process — no HTTP/Flight server — which
+/// makes it the reliable loop for iterating on the core-search optimization.
+fn run_p2p_bench(
+    data: &Path,
+    mode_name: &str,
+    n: usize,
+    seed: u64,
+    parallel: bool,
+    cities: bool,
+    max_combos: usize,
+) -> anyhow::Result<()> {
+    use butterfly_route::model::types::Mode;
+    use butterfly_route::server::query::CchQuery;
+    use butterfly_route::server::snap_kbest;
+    use butterfly_route::server::state::{LoadOptions, ServerState};
+    use butterfly_route::server::types::SnapRole;
+    use rayon::prelude::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    println!("═══════════════════════════════════════════════════════════════");
+    println!("  P2P QUERY BENCHMARK (#438) — edges_batch snap+query path");
+    println!("═══════════════════════════════════════════════════════════════");
+    println!(
+        "  container: {}\n  mode: {}  pairs: {}  parallel: {}  workload: {}",
+        data.display(),
+        mode_name,
+        n,
+        parallel,
+        if cities {
+            "12-city OSRM-parity"
+        } else {
+            "random bbox"
+        }
+    );
+
+    let t = Instant::now();
+    let state = ServerState::load_from_container_with_options(
+        data,
+        Some(&[mode_name.to_string()]),
+        &LoadOptions {
+            eager_verify: false,
+            warmup_on_boot: false,
+        },
+    )?;
+    println!("  loaded container in {:.1}s", t.elapsed().as_secs_f64());
+
+    let mode_idx = *state
+        .mode_lookup
+        .get(mode_name)
+        .ok_or_else(|| anyhow::anyhow!("mode '{}' not loaded", mode_name))?;
+    let mode = Mode(mode_idx);
+    let mode_data = state.get_mode(mode);
+
+    // Build the pair list.
+    let pairs: Vec<[f64; 4]> = if cities {
+        let c = [
+            [4.3517, 50.8503],
+            [4.4025, 51.2194],
+            [3.7250, 51.0500],
+            [5.5667, 50.6333],
+            [3.2200, 50.4100],
+            [4.0300, 50.4500],
+            [4.4400, 50.4100],
+            [5.3400, 50.2700],
+            [4.8700, 50.4700],
+            [4.3600, 50.8200],
+            [3.7500, 50.3200],
+            [4.0000, 51.0000],
+        ];
+        let base: Vec<[f64; 4]> = (0..c.len())
+            .flat_map(|i| {
+                (0..c.len())
+                    .filter(move |&j| i != j)
+                    .map(move |j| [c[i][0], c[i][1], c[j][0], c[j][1]])
+            })
+            .collect();
+        (0..n).map(|k| base[k % base.len()]).collect()
+    } else {
+        let mut rng = StdRng::seed_from_u64(seed);
+        (0..n)
+            .map(|_| {
+                [
+                    rng.random_range(2.55..6.40),
+                    rng.random_range(49.50..51.50),
+                    rng.random_range(2.55..6.40),
+                    rng.random_range(49.50..51.50),
+                ]
+            })
+            .collect()
+    };
+
+    // Per-pair snap+query — identical shape to flight::edges_for_pair (minus the
+    // unpack, which is 0.4% and not what we're optimizing). Returns reachable.
+    let run_pair = |pair: &[f64; 4]| -> bool {
+        let query = CchQuery::new(&mode_data);
+        let (slon, slat, dlon, dlat) = (pair[0], pair[1], pair[2], pair[3]);
+        let src_role = SnapRole::Src.role_filter(&mode_data);
+        let dst_role = SnapRole::Dst.role_filter(&mode_data);
+        if let (Some(s_id), Some(d_id)) = (
+            state
+                .snap_index
+                .snap_filtered_role(slon, slat, mode.0, None, src_role),
+            state
+                .snap_index
+                .snap_filtered_role(dlon, dlat, mode.0, None, dst_role),
+        ) && let (Some(s), Some(d)) = (
+            mode_data.orig_to_rank.get(s_id as usize).copied(),
+            mode_data.orig_to_rank.get(d_id as usize).copied(),
+        ) && s != u32::MAX
+            && d != u32::MAX
+            && query.query(s, d).is_some()
+        {
+            return true;
+        }
+        let ss = snap_kbest::snap_k_pair_role(
+            &state,
+            &mode_data,
+            mode,
+            slon,
+            slat,
+            SnapRole::Src,
+            None,
+            64,
+        );
+        let ds = snap_kbest::snap_k_pair_role(
+            &state,
+            &mode_data,
+            mode,
+            dlon,
+            dlat,
+            SnapRole::Dst,
+            None,
+            64,
+        );
+        if !ss.ranks.is_empty() && !ds.ranks.is_empty() {
+            return snap_kbest::p2p_with_kbest_fallback(&query, &ss.ranks, &ds.ranks, max_combos)
+                .is_some();
+        }
+        false
+    };
+
+    // Warm one query (pages in hot sections so the timing is steady-state).
+    let _ = run_pair(&pairs[0]);
+
+    let reachable = AtomicU64::new(0);
+    let t0 = Instant::now();
+    if parallel {
+        pairs.par_iter().for_each(|p| {
+            if run_pair(p) {
+                reachable.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+    } else {
+        for p in &pairs {
+            if run_pair(p) {
+                reachable.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    println!();
+    println!(
+        "  RESULT: {} pairs in {:.3}s → {:.0} pairs/s  (reachable {}/{}, {:.2} ms/pair wall)",
+        pairs.len(),
+        dt,
+        pairs.len() as f64 / dt,
+        reachable.load(Ordering::Relaxed),
+        pairs.len(),
+        dt * 1000.0 / pairs.len() as f64
+    );
+    println!("═══════════════════════════════════════════════════════════════");
     Ok(())
 }

--- a/route/src/customization.rs
+++ b/route/src/customization.rs
@@ -542,7 +542,7 @@ pub fn customize_cch_time_in_memory(
         &[way_attrs::WayAttr],
         &crate::formats::NbgGeo,
     )>,
-) -> Result<CchWeights> {
+) -> Result<(CchWeights, Vec<u32>)> {
     let n_nodes = topo.n_nodes as usize;
 
     // Apply traffic to a private copy of the node time-weights — the caller's
@@ -595,12 +595,15 @@ pub fn customize_cch_time_in_memory(
 
     sanity_check_weights(topo, &time_up, &time_down, "Time", 95.0)?;
 
-    Ok(CchWeights {
-        up: WeightArray::from_vec_u32(time_up),
-        down: WeightArray::from_vec_u32(time_down),
-        up_middle: ArcCow::from_vec(time_up_mid),
-        down_middle: ArcCow::from_vec(time_down_mid),
-    })
+    Ok((
+        CchWeights {
+            up: WeightArray::from_vec_u32(time_up),
+            down: WeightArray::from_vec_u32(time_down),
+            up_middle: ArcCow::from_vec(time_up_mid),
+            down_middle: ArcCow::from_vec(time_down_mid),
+        },
+        node_weights,
+    ))
 }
 
 /// Apply per-density-class speed factors to the in-memory time-weight array.
@@ -1677,7 +1680,7 @@ mod determinism_tests {
         let turns = mod_turns::read_all(&paths[3]).unwrap();
         let ebg_nodes = EbgNodesFile::read(&paths[4]).unwrap();
 
-        let got = customize_cch_time_in_memory(
+        let (got, _adjusted_node_weights) = customize_cch_time_in_memory(
             &topo,
             &filtered_ebg,
             &weights.weights,

--- a/route/src/range/mod.rs
+++ b/route/src/range/mod.rs
@@ -19,6 +19,9 @@ use crate::profile_abi::Mode;
 pub mod phast;
 pub use phast::{BLOCK_SIZE, PhastEngine, PhastResult, PhastStats};
 
+pub mod tree_phast;
+pub use tree_phast::{TreePath, TreeSettle, tree_backtrack, tree_settle};
+
 pub mod frontier;
 pub use frontier::{
     FrontierCutPoint, FrontierExtractor, ReachablePoint, ReachableSegment, run_frontier_extraction,

--- a/route/src/range/tree_phast.rs
+++ b/route/src/range/tree_phast.rs
@@ -1,0 +1,491 @@
+//! #438: predecessor-tracking bounded PHAST — the per-source shortest-path
+//! TREE that `edges_batch` slices per target.
+//!
+//! One tree per source replaces one bidirectional CCH query per (source,
+//! target) pair: after `tree_settle(source, threshold)`, every target's path
+//! is a `tree_backtrack(target)` — a parent-chain walk plus the existing
+//! shortcut unpack. Zero per-target searches (the #439 grouped path still ran
+//! one backward search per target; this removes those too).
+//!
+//! Design (codex-reviewed, butterfly-osm#438):
+//! - Upward phase: PQ Dijkstra over the topo UP arrays (mirrors
+//!   [`crate::range::phast::PhastEngine::query_adaptive`]), recording the
+//!   winning UP arc per improved node.
+//! - Downward phase: rank-descending block-gated scan over the topo DOWN
+//!   arrays, recording the winning DOWN arc per improved node. Block gating
+//!   bounds the scan to blocks reachable within `threshold` — exact for every
+//!   node with true distance ≤ threshold (same guarantee the isochrone path
+//!   relies on).
+//! - Parent storage: ONE tagged `u32` per node — the topo arc index with the
+//!   top bit set for DOWN arcs. The parent NODE is derived at backtrack time
+//!   by ownership binary-search over the offsets arrays (≈23 steps per hop,
+//!   ~10-40 hops per path — negligible). This halves the extra write
+//!   bandwidth on the memory-bound scan vs storing `(node, arc)`.
+//! - Tree paths are `UP* DOWN*` (rank-ordered downward scan can never insert
+//!   an UP arc after a DOWN arc), so the backtrack splits cleanly at the apex
+//!   and feeds [`crate::server::unpack::unpack_path`] unchanged.
+//!
+//! Scratch arrays are thread-local, generation-stamped (O(1) per-tree reset),
+//! and registered with the idle compactor via
+//! [`crate::server::evictable::EvictableCell`] (~60 MB per worker thread on
+//! Belgium, freed when idle).
+
+use crate::formats::{CchTopo, CchWeights};
+use crate::server::evictable::EvictableCell;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
+/// Block size for the gated downward scan — matches
+/// [`crate::range::phast::BLOCK_SIZE`].
+const BLOCK_SIZE: usize = 4096;
+
+/// Direction tag on the parent arc: set ⇒ DOWN arc, clear ⇒ UP arc.
+const DOWN_BIT: u32 = 1 << 31;
+const ARC_MASK: u32 = DOWN_BIT - 1;
+
+struct TreeScratch {
+    dist: Vec<u32>,
+    /// Tagged winning arc per node (`DOWN_BIT` | topo arc idx). Valid only
+    /// where `gen[node] == epoch`.
+    parent: Vec<u32>,
+    generation: Vec<u32>,
+    epoch: u32,
+    /// Origin + threshold of the CURRENT settled tree (validity check for
+    /// backtracks; a settle for a new origin bumps the epoch).
+    origin: u32,
+    threshold: u32,
+    /// RPHAST selection visited-stamps + the selected-rank list (reused
+    /// across groups; `sel` is cleared per settle, stamps are epoch-based).
+    sel_gen: Vec<u32>,
+    sel_epoch: u32,
+    sel: Vec<u32>,
+}
+
+impl TreeScratch {
+    fn new(n: usize) -> Self {
+        Self {
+            dist: vec![u32::MAX; n],
+            parent: vec![0; n],
+            generation: vec![0; n],
+            epoch: 0,
+            origin: u32::MAX,
+            threshold: 0,
+            sel_gen: vec![0; n],
+            sel_epoch: 0,
+            sel: Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn start_tree(&mut self, origin: u32, threshold: u32) {
+        self.epoch = self.epoch.wrapping_add(1);
+        if self.epoch == 0 {
+            self.generation.iter_mut().for_each(|g| *g = 0);
+            self.epoch = 1;
+        }
+        self.origin = origin;
+        self.threshold = threshold;
+    }
+
+    #[inline]
+    fn start_selection(&mut self) {
+        self.sel_epoch = self.sel_epoch.wrapping_add(1);
+        if self.sel_epoch == 0 {
+            self.sel_gen.iter_mut().for_each(|g| *g = 0);
+            self.sel_epoch = 1;
+        }
+        self.sel.clear();
+    }
+
+    #[inline]
+    fn get(&self, node: usize) -> u32 {
+        if self.generation[node] == self.epoch {
+            self.dist[node]
+        } else {
+            u32::MAX
+        }
+    }
+
+    #[inline]
+    fn set(&mut self, node: usize, dist: u32, tagged_arc: u32) {
+        self.dist[node] = dist;
+        self.parent[node] = tagged_arc;
+        self.generation[node] = self.epoch;
+    }
+}
+
+thread_local! {
+    /// Per-thread tree scratch (#409/#410 pattern): evictable so idle worker
+    /// threads return the ~60 MB to the OS.
+    static TREE_SCRATCH: EvictableCell<TreeScratch> = const { EvictableCell::new() };
+}
+
+/// Outcome of [`tree_settle`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TreeSettle {
+    /// Tree settled; backtracks are valid for nodes with dist ≤ threshold.
+    Ok,
+    /// The origin itself was invalid (should not happen for a snapped rank).
+    BadOrigin,
+}
+
+/// Settle the bounded shortest-path tree from `origin` (a CCH rank) up to
+/// `threshold` (same weight unit as the CCH weights — seconds for TIME).
+///
+/// MUST be followed — on the SAME thread, with no intervening `tree_settle` —
+/// by [`tree_backtrack`] calls for this origin. Exactness: every node whose
+/// true distance is ≤ `threshold` has exact `dist` + a valid parent chain
+/// (block gating only skips blocks unreachable within the threshold). Nodes
+/// beyond the threshold may be unset or carry partial values — `tree_backtrack`
+/// reports them as misses so the caller can retry with a larger threshold or
+/// fall back to the per-pair query.
+pub fn tree_settle(
+    topo: &CchTopo,
+    weights: &CchWeights,
+    origin: u32,
+    threshold: u32,
+) -> TreeSettle {
+    let n = topo.n_nodes as usize;
+    if (origin as usize) >= n {
+        return TreeSettle::BadOrigin;
+    }
+    TREE_SCRATCH.with(|cell| {
+        cell.with_or_init(
+            || TreeScratch::new(n),
+            |s| {
+                if s.dist.len() != n {
+                    *s = TreeScratch::new(n);
+                }
+                s.start_tree(origin, threshold);
+                s.set(origin as usize, 0, 0);
+
+                // Block-activity bitset for the gated downward scan.
+                let n_blocks = n.div_ceil(BLOCK_SIZE);
+                let mut active = vec![0u64; n_blocks.div_ceil(64)];
+                let ob = origin as usize / BLOCK_SIZE;
+                active[ob / 64] |= 1u64 << (ob % 64);
+
+                // ---- Phase 1: upward PQ sweep (records UP parent arcs) ----
+                let mut pq: BinaryHeap<Reverse<(u32, u32)>> = BinaryHeap::new();
+                pq.push(Reverse((0, origin)));
+                while let Some(Reverse((d, u))) = pq.pop() {
+                    if d > threshold {
+                        break; // all remaining heap entries are ≥ d
+                    }
+                    if d > s.get(u as usize) {
+                        continue; // stale
+                    }
+                    let start = topo.up_offsets[u as usize] as usize;
+                    let end = topo.up_offsets[u as usize + 1] as usize;
+                    for i in start..end {
+                        let w = weights.up.get(i);
+                        if w == u32::MAX {
+                            continue;
+                        }
+                        let v = topo.up_targets[i];
+                        let nd = d.saturating_add(w);
+                        if nd < s.get(v as usize) {
+                            s.set(v as usize, nd, i as u32); // UP arc (no tag)
+                            pq.push(Reverse((nd, v)));
+                            if nd <= threshold {
+                                let vb = v as usize / BLOCK_SIZE;
+                                active[vb / 64] |= 1u64 << (vb % 64);
+                            }
+                        }
+                    }
+                }
+
+                // ---- Phase 2: rank-descending gated downward scan ----
+                // (records DOWN parent arcs)
+                for block_idx in (0..n_blocks).rev() {
+                    if (active[block_idx / 64] >> (block_idx % 64)) & 1 == 0 {
+                        continue;
+                    }
+                    let rank_start = block_idx * BLOCK_SIZE;
+                    let rank_end = ((block_idx + 1) * BLOCK_SIZE).min(n);
+                    for u in (rank_start..rank_end).rev() {
+                        let d_u = s.get(u);
+                        if d_u == u32::MAX || d_u > threshold {
+                            continue;
+                        }
+                        let start = topo.down_offsets[u] as usize;
+                        let end = topo.down_offsets[u + 1] as usize;
+                        for i in start..end {
+                            let w = weights.down.get(i);
+                            if w == u32::MAX {
+                                continue;
+                            }
+                            let v = topo.down_targets[i] as usize;
+                            let nd = d_u.saturating_add(w);
+                            if nd < s.get(v) {
+                                s.set(v, nd, i as u32 | DOWN_BIT); // DOWN arc
+                                if nd <= threshold {
+                                    let vb = v / BLOCK_SIZE;
+                                    active[vb / 64] |= 1u64 << (vb % 64);
+                                }
+                            }
+                        }
+                    }
+                }
+                TreeSettle::Ok
+            },
+        )
+    })
+}
+
+/// #438: RPHAST-style EXACT restricted tree settle — codex's "(c) is the exact
+/// answer". No distance bound, no retries: the downward scan is restricted to
+/// the reverse-DOWN ancestry of the group's targets (the SELECTION), which for
+/// ~30 targets is a few thousand nodes instead of the 5M-rank full scan.
+///
+/// Correctness: every shortest path source→t is `UP* DOWN*`; its DOWN suffix
+/// lies entirely inside t's reverse-DOWN ancestry ⊆ selection, and the apex
+/// gets its exact distance from the (exhaustive) upward sweep. Scanning the
+/// selection in descending rank order propagates exact distances to every
+/// target — same guarantee as the full scan, at a fraction of the work.
+/// Relaxations INTO non-selected children are allowed (their dists are dead
+/// ends, never scanned, never backtracked through) so the hot loop needs no
+/// membership test.
+///
+/// `down_rev` supplies the reverse-DOWN adjacency for the selection DFS (INF
+/// arcs are filtered at its build — they can't carry a shortest path).
+pub fn tree_settle_restricted(
+    topo: &CchTopo,
+    weights: &CchWeights,
+    down_rev: &crate::matrix::bucket_ch::DownReverseAdjFlat,
+    origin: u32,
+    targets: &[u32],
+) -> TreeSettle {
+    let n = topo.n_nodes as usize;
+    if (origin as usize) >= n {
+        return TreeSettle::BadOrigin;
+    }
+    TREE_SCRATCH.with(|cell| {
+        cell.with_or_init(
+            || TreeScratch::new(n),
+            |s| {
+                if s.dist.len() != n {
+                    *s = TreeScratch::new(n);
+                }
+                // No bound: every settled node is backtrackable.
+                s.start_tree(origin, u32::MAX);
+                s.set(origin as usize, 0, 0);
+
+                // ---- Selection: reverse-DOWN ancestry of the targets ----
+                s.start_selection();
+                let mut stack: Vec<u32> = Vec::with_capacity(targets.len() * 4);
+                for &t in targets {
+                    let ti = t as usize;
+                    if ti < n && s.sel_gen[ti] != s.sel_epoch {
+                        s.sel_gen[ti] = s.sel_epoch;
+                        s.sel.push(t);
+                        stack.push(t);
+                    }
+                }
+                while let Some(v) = stack.pop() {
+                    let start = down_rev.offsets[v as usize] as usize;
+                    let end = down_rev.offsets[v as usize + 1] as usize;
+                    for slot in start..end {
+                        let u = down_rev.sources[slot];
+                        let ui = u as usize;
+                        if s.sel_gen[ui] != s.sel_epoch {
+                            s.sel_gen[ui] = s.sel_epoch;
+                            s.sel.push(u);
+                            stack.push(u);
+                        }
+                    }
+                }
+                // Descending rank order for the scan.
+                s.sel.sort_unstable_by(|a, b| b.cmp(a));
+
+                // ---- Phase 1: exhaustive upward PQ sweep (UP parents) ----
+                let mut pq: BinaryHeap<Reverse<(u32, u32)>> = BinaryHeap::new();
+                pq.push(Reverse((0, origin)));
+                while let Some(Reverse((d, u))) = pq.pop() {
+                    if d > s.get(u as usize) {
+                        continue; // stale
+                    }
+                    let start = topo.up_offsets[u as usize] as usize;
+                    let end = topo.up_offsets[u as usize + 1] as usize;
+                    for i in start..end {
+                        let w = weights.up.get(i);
+                        if w == u32::MAX {
+                            continue;
+                        }
+                        let v = topo.up_targets[i];
+                        let nd = d.saturating_add(w);
+                        if nd < s.get(v as usize) {
+                            s.set(v as usize, nd, i as u32); // UP arc
+                            pq.push(Reverse((nd, v)));
+                        }
+                    }
+                }
+
+                // ---- Phase 2: restricted downward scan (DOWN parents) ----
+                // s.sel is moved out to appease the borrow checker (s is
+                // mutably borrowed inside the loop), then restored.
+                let sel = std::mem::take(&mut s.sel);
+                for &u in &sel {
+                    let ui = u as usize;
+                    let d_u = s.get(ui);
+                    if d_u == u32::MAX {
+                        continue;
+                    }
+                    let start = topo.down_offsets[ui] as usize;
+                    let end = topo.down_offsets[ui + 1] as usize;
+                    for i in start..end {
+                        let w = weights.down.get(i);
+                        if w == u32::MAX {
+                            continue;
+                        }
+                        let v = topo.down_targets[i] as usize;
+                        let nd = d_u.saturating_add(w);
+                        if nd < s.get(v) {
+                            s.set(v, nd, i as u32 | DOWN_BIT); // DOWN arc
+                        }
+                    }
+                }
+                s.sel = sel;
+                TreeSettle::Ok
+            },
+        )
+    })
+}
+
+/// A target's path sliced out of the settled tree, in the exact shape
+/// [`crate::server::unpack::unpack_path`] consumes.
+#[derive(Debug)]
+pub struct TreePath {
+    /// Total distance (weight units) — identical to the bidirectional query's.
+    pub distance: u32,
+    /// The apex (highest-rank node on the path) — plays `meeting_node`.
+    pub apex: u32,
+    /// `(node, up_arc_idx)` ordered source→apex (`node` is ignored by unpack).
+    pub forward_parent: Vec<(u32, u32)>,
+    /// `(down_arc_source_node, down_arc_idx)` ordered target→apex (unpack
+    /// iterates it reversed, i.e. apex→target).
+    pub backward_parent: Vec<(u32, u32)>,
+}
+
+/// Backtrack `target` (a CCH rank) out of the tree settled by the last
+/// [`tree_settle`] on this thread. Returns `None` when the target was not
+/// settled within the threshold (unreachable OR beyond the bound — the caller
+/// retries with a larger threshold or falls back to the per-pair query;
+/// distinguishing the two here is impossible by design).
+pub fn tree_backtrack(topo: &CchTopo, origin: u32, target: u32) -> Option<TreePath> {
+    let n = topo.n_nodes as usize;
+    if (target as usize) >= n {
+        return None;
+    }
+    TREE_SCRATCH.with(|cell| {
+        cell.with_or_init(
+            || TreeScratch::new(n),
+            |s| {
+                // Validity: the settled tree must be for this origin and sized
+                // for this graph (a graph swap or missing settle ⇒ miss; the
+                // caller's fallback recomputes correctly).
+                if s.dist.len() != n || s.origin != origin {
+                    return None;
+                }
+                let d_t = s.get(target as usize);
+                if d_t == u32::MAX || d_t > s.threshold {
+                    return None;
+                }
+                if target == origin {
+                    return Some(TreePath {
+                        distance: 0,
+                        apex: origin,
+                        forward_parent: vec![],
+                        backward_parent: vec![],
+                    });
+                }
+
+                // Walk target → origin. The chain is DOWN* then UP* (the
+                // reverse of the path's UP* DOWN* shape).
+                let mut backward: Vec<(u32, u32)> = Vec::new();
+                let mut forward_rev: Vec<(u32, u32)> = Vec::new();
+                let mut cur = target;
+                let mut seen_up = false;
+                // Path length is bounded by the CCH search-space depth
+                // (~hundreds); the cap is a corruption backstop, not a limit
+                // that real paths approach.
+                for _ in 0..100_000 {
+                    if cur == origin {
+                        // forward_rev was collected walking apex→origin, so its
+                        // FIRST element is the apex-side UP arc — the apex is
+                        // that arc's UP target. With no UP arcs the apex is the
+                        // highest DOWN source (the last one pushed, nearest the
+                        // origin side of the DOWN chain).
+                        let apex = if let Some(&(_, apex_up)) = forward_rev.first() {
+                            topo.up_targets[apex_up as usize]
+                        } else if let Some(&(src, _)) = backward.last() {
+                            src
+                        } else {
+                            origin
+                        };
+                        // forward_rev was collected apex→source; unpack wants
+                        // source→apex.
+                        forward_rev.reverse();
+                        return Some(TreePath {
+                            distance: d_t,
+                            apex,
+                            forward_parent: forward_rev,
+                            backward_parent: backward,
+                        });
+                    }
+                    if s.generation[cur as usize] != s.epoch {
+                        return None; // chain left the settled set — corrupt/miss
+                    }
+                    let tagged = s.parent[cur as usize];
+                    let arc = (tagged & ARC_MASK) as usize;
+                    if tagged & DOWN_BIT != 0 {
+                        // DOWN arc: cur was improved via DOWN arc `arc` whose
+                        // target is cur; its SOURCE is the owner of `arc` in
+                        // down_offsets (ownership binary search).
+                        if seen_up {
+                            return None; // UP after DOWN cannot happen — corrupt
+                        }
+                        let src = arc_owner(&topo.down_offsets, arc) as u32;
+                        backward.push((src, arc as u32));
+                        cur = src;
+                    } else {
+                        // UP arc: cur was improved via UP arc `arc` whose
+                        // target is cur; its source is the owner in up_offsets.
+                        seen_up = true;
+                        let src = arc_owner(&topo.up_offsets, arc) as u32;
+                        forward_rev.push((src, arc as u32));
+                        cur = src;
+                    }
+                }
+                None
+            },
+        )
+    })
+}
+
+/// Find the node that owns arc index `arc` in a CSR `offsets` array
+/// (`offsets[node] <= arc < offsets[node+1]`). Binary search — ~23 steps on a
+/// 5M-node graph.
+#[inline]
+fn arc_owner(offsets: &[u64], arc: usize) -> usize {
+    let a = arc as u64;
+    // partition_point returns the first index with offsets[idx] > arc;
+    // the owner is that index - 1.
+    offsets.partition_point(|&o| o <= a) - 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arc_owner_basics() {
+        let offsets: Vec<u64> = vec![0, 3, 3, 7, 10];
+        assert_eq!(arc_owner(&offsets, 0), 0);
+        assert_eq!(arc_owner(&offsets, 2), 0);
+        assert_eq!(arc_owner(&offsets, 3), 2); // node 1 is empty
+        assert_eq!(arc_owner(&offsets, 6), 2);
+        assert_eq!(arc_owner(&offsets, 7), 3);
+        assert_eq!(arc_owner(&offsets, 9), 3);
+    }
+}

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -1789,11 +1789,19 @@ fn edges_for_pair(
             SNAP_K,
         );
         if !src_snap.ranks.is_empty() && !dst_snap.ranks.is_empty() {
+            // #438: bound the escalation at 16 combos rather than the default
+            // 200. Reachable pairs connect on the closest-sum-first combos
+            // almost immediately (the #197 connectivity masks keep candidates
+            // on the main component), so 16 loses no reachable pairs on the
+            // Belgium benchmark (5000 pairs, reachable count identical at 8 /
+            // 16 / 200) while bounding the worst-case cost of a pair whose
+            // K=64 candidates don't connect.
+            const EDGES_BATCH_MAX_COMBOS: usize = 16;
             p2p = super::snap_kbest::p2p_with_kbest_fallback(
                 query,
                 &src_snap.ranks,
                 &dst_snap.ranks,
-                super::snap_kbest::DEFAULT_MAX_FALLBACK_COMBOS,
+                EDGES_BATCH_MAX_COMBOS,
             );
         }
     }

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -1706,19 +1706,19 @@ pub struct EdgesBatchParams {
 }
 
 /// One unpacked edge row for `edges_batch` (one per EBG node in a path).
-struct EdgeRow {
-    edge_seq: u32,
-    osm_from: i64,
-    osm_to: i64,
-    dur_ms: u32,
-    dist_m: u32,
+pub struct EdgeRow {
+    pub edge_seq: u32,
+    pub osm_from: i64,
+    pub osm_to: i64,
+    pub dur_ms: u32,
+    pub dist_m: u32,
 }
 
 /// Per-pair result: the query index plus its unpacked edge rows.
 /// `rows.is_empty()` ⇒ unreachable (the caller emits one all-null edge row).
-struct PairEdges {
-    query_idx: u32,
-    rows: Vec<EdgeRow>,
+pub struct PairEdges {
+    pub query_idx: u32,
+    pub rows: Vec<EdgeRow>,
 }
 
 /// Compute the unpacked edge sequence for a single (src,dst) pair.
@@ -1763,60 +1763,96 @@ fn edges_for_pair(
         p2p = Some((s, d, r));
     }
 
-    // Escalation: K=64 snap + combo fallback. Rescues fast-path misses,
-    // including pairs whose closest snap had a u32::MAX rank (not in
-    // this mode's CCH) — K=64 looks further out for a contracted node.
-    if p2p.is_none() {
-        const SNAP_K: usize = 64;
-        let src_snap = super::snap_kbest::snap_k_pair_role(
-            state,
-            mode_data,
-            mode,
-            slon,
-            slat,
-            SnapRole::Src,
-            None,
-            SNAP_K,
-        );
-        let dst_snap = super::snap_kbest::snap_k_pair_role(
-            state,
-            mode_data,
-            mode,
-            dlon,
-            dlat,
-            SnapRole::Dst,
-            None,
-            SNAP_K,
-        );
-        if !src_snap.ranks.is_empty() && !dst_snap.ranks.is_empty() {
-            // #438: bound the escalation at 16 combos rather than the default
-            // 200. Reachable pairs connect on the closest-sum-first combos
-            // almost immediately (the #197 connectivity masks keep candidates
-            // on the main component), so 16 loses no reachable pairs on the
-            // Belgium benchmark (5000 pairs, reachable count identical at 8 /
-            // 16 / 200) while bounding the worst-case cost of a pair whose
-            // K=64 candidates don't connect.
-            const EDGES_BATCH_MAX_COMBOS: usize = 16;
-            p2p = super::snap_kbest::p2p_with_kbest_fallback(
-                query,
-                &src_snap.ranks,
-                &dst_snap.ranks,
-                EDGES_BATCH_MAX_COMBOS,
-            );
+    if let Some((src_rank, dst_rank, result)) = p2p {
+        return emit_pair_rows(state, mode_data, src_rank, dst_rank, &result, query_idx);
+    }
+    // K=1 didn't connect → K=64 escalation.
+    escalate_pair(state, mode_data, mode, query, query_idx, pair)
+}
+
+/// #438: K=64 + 16-combo escalation for a pair the K=1 fast path could not
+/// connect. Snaps both ends to 64 candidates and tries the closest-sum-first
+/// combos; emits the path or one unreachable null row.
+///
+/// Split out of `edges_for_pair` so the source-grouped per-pair path
+/// (`process_per_pair_work`) can escalate WITHOUT re-doing the K=1 snap+query
+/// it already attempted with the precomputed ranks (#438-review: avoids the
+/// redundant K=1 work that made the all-singleton workload regress).
+fn escalate_pair(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    query: &super::query::CchQuery<'_>,
+    query_idx: u32,
+    pair: &[f64; 4],
+) -> PairEdges {
+    use super::types::SnapRole;
+    let (slon, slat, dlon, dlat) = (pair[0], pair[1], pair[2], pair[3]);
+    const SNAP_K: usize = 64;
+    // Rescues K=1 misses, including pairs whose closest snap had a u32::MAX
+    // rank (not in this mode's CCH) — K=64 looks further out for a contracted
+    // node.
+    let src_snap = super::snap_kbest::snap_k_pair_role(
+        state,
+        mode_data,
+        mode,
+        slon,
+        slat,
+        SnapRole::Src,
+        None,
+        SNAP_K,
+    );
+    let dst_snap = super::snap_kbest::snap_k_pair_role(
+        state,
+        mode_data,
+        mode,
+        dlon,
+        dlat,
+        SnapRole::Dst,
+        None,
+        SNAP_K,
+    );
+    if !src_snap.ranks.is_empty() && !dst_snap.ranks.is_empty() {
+        // Bound the escalation at 16 combos rather than the default 200.
+        // Reachable pairs connect on the closest-sum-first combos almost
+        // immediately (the #197 connectivity masks keep candidates on the main
+        // component), so 16 loses no reachable pairs on the Belgium benchmark
+        // (reachable count identical at 8 / 16 / 200) while bounding the
+        // worst-case cost of a pair whose K=64 candidates don't connect.
+        const EDGES_BATCH_MAX_COMBOS: usize = 16;
+        if let Some((src_rank, dst_rank, result)) = super::snap_kbest::p2p_with_kbest_fallback(
+            query,
+            &src_snap.ranks,
+            &dst_snap.ranks,
+            EDGES_BATCH_MAX_COMBOS,
+        ) {
+            return emit_pair_rows(state, mode_data, src_rank, dst_rank, &result, query_idx);
         }
     }
+    // Unreachable.
+    PairEdges {
+        query_idx,
+        rows: Vec::new(),
+    }
+}
 
-    let Some((src_rank, dst_rank, result)) = p2p else {
-        return PairEdges {
-            query_idx,
-            rows: Vec::new(),
-        };
-    };
-
-    // Unpack to the full EBG rank sequence, then map rank → original
-    // EBG node id and emit one row per node. Each EBG node is a directed
-    // NBG edge (tail → head), so osm_node_from = osm(tail), osm_node_to =
-    // osm(head); consecutive rows satisfy osm_to[i] == osm_from[i+1].
+/// #438: shared unpack + per-edge row emit. Used by BOTH the per-pair
+/// `edges_for_pair` and the source-grouped path, so the row contract
+/// (osm_from/to, dur_ms, dist_m, edge_seq) is byte-identical regardless of
+/// how the `QueryResult` was produced.
+///
+/// Unpacks the CCH result to the full EBG rank sequence, then maps each rank
+/// → original EBG node id and emits one row per node. Each EBG node is a
+/// directed NBG edge (tail → head), so osm_node_from = osm(tail),
+/// osm_node_to = osm(head); consecutive rows satisfy osm_to[i] == osm_from[i+1].
+fn emit_pair_rows(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    src_rank: u32,
+    dst_rank: u32,
+    result: &super::query::QueryResult,
+    query_idx: u32,
+) -> PairEdges {
     let rank_path = super::unpack::unpack_path(
         &mode_data.cch_topo,
         &mode_data.cch_weights,
@@ -1860,6 +1896,305 @@ fn edges_for_pair(
     PairEdges { query_idx, rows }
 }
 
+/// #438: resolve a coordinate to its K=1 (closest, role-filtered) CCH rank —
+/// the same fast-path snap `edges_for_pair` uses. Returns `None` when the
+/// closest role-valid node is not in this mode's contracted graph (the case
+/// that today triggers the K=64 escalation). Used to GROUP pairs by source
+/// rank so one forward search can be shared across a source's targets.
+fn resolve_k1_rank(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    lon: f64,
+    lat: f64,
+    role: super::types::SnapRole,
+) -> Option<u32> {
+    let role_filter = role.role_filter(mode_data);
+    let id = state
+        .snap_index
+        .snap_filtered_role(lon, lat, mode.0, None, role_filter)?;
+    let rank = mode_data.orig_to_rank.get(id as usize).copied()?;
+    if rank == u32::MAX { None } else { Some(rank) }
+}
+
+/// #438: one target of a source group: its original flat `query_idx`, the raw
+/// coords (for the per-pair escalation fallback), and its K=1 destination rank
+/// (`None` ⇒ the K=1 dst snap missed → must fall back to per-pair).
+struct GroupedTarget {
+    query_idx: u32,
+    pair: [f64; 4],
+    dst_rank: Option<u32>,
+}
+
+/// #438: process one source group — settle the forward CCH search ONCE for
+/// `src_rank`, then for each target do only the (cheaper) backward search +
+/// meeting + unpack. This is where the ~30× forward-recompute is amortised.
+///
+/// Targets that the shared K=1 forward can't serve (K=1 dst missed, or no path
+/// via the K=1 src) fall back to the full per-pair `edges_for_pair` (K=64 + 16
+/// combos) — but those fallbacks call `query.query()`, which bumps the forward
+/// epoch and ERASES the frozen tree, so they MUST run AFTER all shared-forward
+/// targets of the group. Output distances are identical to per-pair; equal-cost
+/// paths may differ on ties (both are valid time-shortest paths).
+fn process_source_group(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    src_rank: u32,
+    targets: &[GroupedTarget],
+) -> Vec<PairEdges> {
+    let query = super::query::CchQuery::new(mode_data);
+    query.settle_forward(src_rank);
+
+    let mut out = Vec::with_capacity(targets.len());
+    let mut fallbacks: Vec<&GroupedTarget> = Vec::new();
+    for t in targets {
+        match t.dst_rank {
+            Some(dst_rank) => match query.backward_meet_and_paths(src_rank, dst_rank) {
+                Some(result) => {
+                    out.push(emit_pair_rows(
+                        state,
+                        mode_data,
+                        src_rank,
+                        dst_rank,
+                        &result,
+                        t.query_idx,
+                    ));
+                }
+                None => fallbacks.push(t),
+            },
+            None => fallbacks.push(t),
+        }
+    }
+    // Fallbacks LAST — they destroy the frozen forward via query.query().
+    for t in fallbacks {
+        out.push(edges_for_pair(
+            state,
+            mode_data,
+            mode,
+            &query,
+            t.query_idx,
+            &t.pair,
+        ));
+    }
+    out
+}
+
+/// #438: a pair handled OUTSIDE a shared-forward group — either a singleton
+/// source (K=1 resolved but only 1 target, so no forward-sharing benefit) or a
+/// K=1-source-miss (needs K=64 escalation). Carries any already-resolved K=1
+/// ranks so `process_per_pair_work` can skip the redundant snap.
+struct PerPairWork {
+    query_idx: u32,
+    pair: [f64; 4],
+    /// K=1 source rank, if it resolved (singleton); `None` ⇒ K=1 src missed.
+    src_rank: Option<u32>,
+    /// K=1 destination rank, if it resolved.
+    dst_rank: Option<u32>,
+}
+
+/// #438: process one per-pair work item. When BOTH K=1 ranks are already
+/// resolved (the singleton case), try the direct K=1 query — skipping the
+/// redundant snap that `edges_for_pair` would otherwise repeat (the #438-review
+/// double-snap fix). Anything that misses (no precomputed ranks, or the K=1
+/// query doesn't connect) falls through to the full per-pair `edges_for_pair`
+/// (K=1 snap + K=64 + 16-combo escalation), byte-identical to today.
+fn process_per_pair_work(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    query: &super::query::CchQuery<'_>,
+    work: &PerPairWork,
+) -> PairEdges {
+    if let (Some(src_rank), Some(dst_rank)) = (work.src_rank, work.dst_rank)
+        && let Some(result) = query.query(src_rank, dst_rank)
+    {
+        return emit_pair_rows(
+            state,
+            mode_data,
+            src_rank,
+            dst_rank,
+            &result,
+            work.query_idx,
+        );
+    }
+    // K=1 missed (or didn't connect) → escalate WITHOUT re-doing the K=1 that
+    // the precomputed-rank query above already covered.
+    escalate_pair(state, mode_data, mode, query, work.query_idx, &work.pair)
+}
+
+/// #438: resolve each pair's K=1 source/dest rank and partition into
+/// `(multi_target_groups, per_pair)`:
+/// - sources with **≥2** targets become a shared-forward GROUP (the win);
+/// - sources with exactly **1** target, and pairs whose K=1 SOURCE snap missed
+///   (need K=64 escalation), go to the per-pair list.
+///
+/// The singleton split is the #438-review MAJOR fix: a 1-target source can't
+/// amortise the forward-settle-to-exhaustion, so routing it per-pair preserves
+/// the early-terminated bidirectional cost and avoids a regression on
+/// distinct-pair (1 target/source) workloads.
+#[allow(clippy::type_complexity)]
+fn group_pairs(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    pairs: &[[f64; 4]],
+    parallel: bool,
+) -> (Vec<(u32, Vec<GroupedTarget>)>, Vec<PerPairWork>) {
+    use super::types::SnapRole;
+
+    // Resolve K=1 src/dst ranks for every pair FIRST — embarrassingly parallel,
+    // and on a zero-sharing (all-singleton) workload ~half the total work, so
+    // running it sequentially before the parallel process phase was an Amdahl
+    // bottleneck (#438-review perf cliff). Parallelise it when the batch is
+    // parallel; the cheap HashMap grouping afterwards stays sequential.
+    let resolve = |idx: usize, pair: &[f64; 4]| {
+        let s = resolve_k1_rank(state, mode_data, mode, pair[0], pair[1], SnapRole::Src);
+        let d = resolve_k1_rank(state, mode_data, mode, pair[2], pair[3], SnapRole::Dst);
+        (idx as u32, *pair, s, d)
+    };
+    let resolved: Vec<(u32, [f64; 4], Option<u32>, Option<u32>)> = if parallel {
+        pairs
+            .par_iter()
+            .enumerate()
+            .map(|(idx, pair)| resolve(idx, pair))
+            .collect()
+    } else {
+        pairs
+            .iter()
+            .enumerate()
+            .map(|(idx, pair)| resolve(idx, pair))
+            .collect()
+    };
+
+    let mut groups: std::collections::HashMap<u32, Vec<GroupedTarget>> =
+        std::collections::HashMap::new();
+    let mut per_pair: Vec<PerPairWork> = Vec::new();
+    for (query_idx, pair, src, dst) in resolved {
+        match src {
+            Some(src_rank) => {
+                groups.entry(src_rank).or_default().push(GroupedTarget {
+                    query_idx,
+                    pair,
+                    dst_rank: dst,
+                });
+            }
+            // K=1 source miss → per-pair with no precomputed ranks (full snap).
+            None => per_pair.push(PerPairWork {
+                query_idx,
+                pair,
+                src_rank: None,
+                dst_rank: None,
+            }),
+        }
+    }
+    // Singleton groups don't amortise the shared forward → run them per-pair,
+    // but CARRY the already-resolved K=1 ranks so the per-pair path skips the
+    // redundant snap (#438-review double-snap fix).
+    let mut multi: Vec<(u32, Vec<GroupedTarget>)> = Vec::with_capacity(groups.len());
+    for (src_rank, targets) in groups {
+        if targets.len() >= 2 {
+            multi.push((src_rank, targets));
+        } else {
+            for t in targets {
+                per_pair.push(PerPairWork {
+                    query_idx: t.query_idx,
+                    pair: t.pair,
+                    src_rank: Some(src_rank),
+                    dst_rank: t.dst_rank,
+                });
+            }
+        }
+    }
+    (multi, per_pair)
+}
+
+/// #438: resolve + source-group + process every pair into per-pair edge lists,
+/// sorted by `query_idx`. The OSRM-gap fix — the forward CCH search depends only
+/// on the SOURCE, so pairs are grouped by their resolved K=1 source rank and
+/// share ONE forward settle across the source's targets ([`process_source_group`]);
+/// singletons + K=1-source-misses run per-pair ([`process_per_pair_work`]).
+/// `parallel` fans the resolve, the groups, and the per-pair work across rayon.
+///
+/// Shared by [`do_edges_batch`] (which streams the result in chunks) and the
+/// equivalence test / bench. Returns the SAME `PairEdges` shape as the per-pair
+/// path; min-cost distance is identical, equal-cost paths may differ on ties.
+pub fn compute_edges_grouped(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    pairs: &[[f64; 4]],
+    parallel: bool,
+) -> Vec<PairEdges> {
+    let (group_vec, per_pair_work) = group_pairs(state, mode_data, mode, pairs, parallel);
+
+    // Source GROUPS are the parallel unit (one shared forward settle per rayon
+    // task); per-pair work runs individually. flat_map keeps each group's
+    // settle_forward + its targets on a single thread so the frozen forward
+    // tree (thread-local) is valid for the whole group.
+    let mut per_pair: Vec<PairEdges> = if parallel {
+        let mut v: Vec<PairEdges> = group_vec
+            .par_iter()
+            .flat_map(|(src_rank, targets)| {
+                process_source_group(state, mode_data, mode, *src_rank, targets)
+            })
+            .collect();
+        let from_per_pair: Vec<PairEdges> = per_pair_work
+            .par_iter()
+            .map(|w| {
+                let query = super::query::CchQuery::new(mode_data);
+                process_per_pair_work(state, mode_data, mode, &query, w)
+            })
+            .collect();
+        v.extend(from_per_pair);
+        v
+    } else {
+        let mut v: Vec<PairEdges> = Vec::with_capacity(pairs.len());
+        for (src_rank, targets) in &group_vec {
+            v.extend(process_source_group(
+                state, mode_data, mode, *src_rank, targets,
+            ));
+        }
+        let query = super::query::CchQuery::new(mode_data);
+        for w in &per_pair_work {
+            v.push(process_per_pair_work(state, mode_data, mode, &query, w));
+        }
+        v
+    };
+    per_pair.sort_unstable_by_key(|p| p.query_idx);
+    per_pair
+}
+
+/// #438: the pre-grouping per-pair path (each pair an independent bidirectional
+/// CCH query). Kept as the equivalence oracle + bench baseline.
+pub fn compute_edges_flat(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    pairs: &[[f64; 4]],
+    parallel: bool,
+) -> Vec<PairEdges> {
+    let mut per_pair: Vec<PairEdges> = if parallel {
+        pairs
+            .par_iter()
+            .enumerate()
+            .map(|(i, pair)| {
+                let query = super::query::CchQuery::new(mode_data);
+                edges_for_pair(state, mode_data, mode, &query, i as u32, pair)
+            })
+            .collect()
+    } else {
+        let query = super::query::CchQuery::new(mode_data);
+        pairs
+            .iter()
+            .enumerate()
+            .map(|(i, pair)| edges_for_pair(state, mode_data, mode, &query, i as u32, pair))
+            .collect()
+    };
+    per_pair.sort_unstable_by_key(|p| p.query_idx);
+    per_pair
+}
+
 pub fn do_edges_batch(
     state: &Arc<ServerState>,
     mode: Mode,
@@ -1886,125 +2221,147 @@ pub fn do_edges_batch(
     tokio::task::spawn_blocking(move || {
         let mode_data = state.get_mode(mode);
         let schema = Arc::new(edges_batch_schema());
-        // #436: edges_batch was single-threaded (one spawn_blocking loop)
-        // while the sibling `matrix` / `route_batch` endpoints parallelise —
-        // that alone was the bulk of the 31× gap vs OSRM. We now process the
-        // pairs in chunks, fan each chunk across rayon's GLOBAL pool, and
-        // stream the chunk's RecordBatch so memory stays bounded even at the
-        // 500k cap. CHUNK_PAIRS is larger than the old 256 so rayon dispatch
-        // amortises over more pairs (~1024 × ~20 edges ≈ 20k rows/batch).
-        //
-        // Concurrency = the shared global rayon pool (sized by
-        // `RAYON_NUM_THREADS`, default = all cores). We deliberately do NOT
-        // size a per-request pool from an env knob: a shared work-stealing
-        // pool means concurrent edges_batch requests can't oversubscribe the
-        // CPU, whereas N per-request pools of K threads would. Tiny batches
-        // skip the pool entirely to avoid dispatch overhead.
         const MIN_PARALLEL_PAIRS: usize = 256;
         let parallel = params.pairs.len() >= MIN_PARALLEL_PAIRS;
-        const CHUNK_PAIRS: usize = 1024;
 
-        for (chunk_start, chunk) in params
-            .pairs
-            .chunks(CHUNK_PAIRS)
-            .enumerate()
-            .map(|(ci, c)| (ci * CHUNK_PAIRS, c))
-        {
-            // Per-pair edge lists, in pair order (rayon's indexed
-            // `par_iter().map().collect()` preserves order, so query_idx
-            // stays monotonic within the batch).
+        // #438: partition into multi-target source GROUPS (shared forward) +
+        // per-pair pairs (singletons + K=1-src misses), then process + STREAM in
+        // work-chunks of ~CHUNK_PAIRS. Chunked streaming keeps resident memory
+        // bounded to one chunk even at the 500k-pair cap — the #438-review
+        // BLOCKER fix: we no longer materialise EVERY pair's edge rows before
+        // emitting (which was unbounded by the pair cap for long routes).
+        let (group_vec, per_pair_work) =
+            group_pairs(&state, &mode_data, mode, &params.pairs, parallel);
+        // Work-chunk size in PAIRS. Bounds peak ≈ CHUNK_PAIRS × path_len × 32B
+        // (~2 MB typical, ~200 MB worst-case long routes) vs unbounded before.
+        const CHUNK_PAIRS: usize = 2048;
+        const ROWS_PER_BATCH: usize = 20_000;
+
+        // Build + stream row-bounded RecordBatches from one work-chunk's results
+        // (sorted by query_idx). Returns false on client disconnect / Arrow
+        // error so the caller stops. `per_pair` is dropped after emit, freeing
+        // the chunk's rows before the next chunk is computed.
+        let emit = |mut per_pair: Vec<PairEdges>| -> bool {
+            per_pair.sort_unstable_by_key(|p| p.query_idx);
+            let mut idx = 0usize;
+            while idx < per_pair.len() {
+                let mut end = idx;
+                let mut rows_in_batch = 0usize;
+                while end < per_pair.len() && rows_in_batch < ROWS_PER_BATCH {
+                    rows_in_batch += per_pair[end].rows.len().max(1);
+                    end += 1;
+                }
+                let mut query_idx_b = UInt32Builder::with_capacity(rows_in_batch);
+                let mut target_idx_b = UInt32Builder::with_capacity(rows_in_batch);
+                let mut edge_seq_b = UInt32Builder::with_capacity(rows_in_batch);
+                let mut osm_from_b = Int64Builder::with_capacity(rows_in_batch);
+                let mut osm_to_b = Int64Builder::with_capacity(rows_in_batch);
+                let mut dur_ms_b = UInt32Builder::with_capacity(rows_in_batch);
+                let mut dist_m_b = UInt32Builder::with_capacity(rows_in_batch);
+
+                for pe in &per_pair[idx..end] {
+                    if pe.rows.is_empty() {
+                        query_idx_b.append_value(pe.query_idx);
+                        target_idx_b.append_value(0);
+                        edge_seq_b.append_null();
+                        osm_from_b.append_null();
+                        osm_to_b.append_null();
+                        dur_ms_b.append_null();
+                        dist_m_b.append_null();
+                    } else {
+                        for row in &pe.rows {
+                            query_idx_b.append_value(pe.query_idx);
+                            target_idx_b.append_value(0);
+                            edge_seq_b.append_value(row.edge_seq);
+                            osm_from_b.append_value(row.osm_from);
+                            osm_to_b.append_value(row.osm_to);
+                            dur_ms_b.append_value(row.dur_ms);
+                            dist_m_b.append_value(row.dist_m);
+                        }
+                    }
+                }
+                idx = end;
+
+                let batch = match RecordBatch::try_new(
+                    schema.clone(),
+                    vec![
+                        Arc::new(query_idx_b.finish()) as ArrayRef,
+                        Arc::new(target_idx_b.finish()),
+                        Arc::new(edge_seq_b.finish()),
+                        Arc::new(osm_from_b.finish()),
+                        Arc::new(osm_to_b.finish()),
+                        Arc::new(dur_ms_b.finish()),
+                        Arc::new(dist_m_b.finish()),
+                    ],
+                ) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        let _ = tx.blocking_send(Err(Status::internal(format!(
+                            "edges_batch Arrow build: {e}"
+                        ))));
+                        return false;
+                    }
+                };
+                if tx.blocking_send(Ok(batch)).is_err() {
+                    return false; // Client disconnected.
+                }
+            }
+            true
+        };
+
+        // Phase A: multi-target groups, chunked by accumulated target count so
+        // each chunk holds ~CHUNK_PAIRS pairs. flat_map keeps each group's
+        // settle_forward + its targets on one rayon thread (frozen tree valid).
+        let mut gi = 0usize;
+        while gi < group_vec.len() {
+            let mut pairs_in_chunk = 0usize;
+            let mut gj = gi;
+            while gj < group_vec.len() && pairs_in_chunk < CHUNK_PAIRS {
+                pairs_in_chunk += group_vec[gj].1.len();
+                gj += 1;
+            }
+            let chunk = &group_vec[gi..gj];
+            gi = gj;
             let per_pair: Vec<PairEdges> = if parallel {
                 chunk
                     .par_iter()
-                    .enumerate()
-                    .map(|(local_i, pair)| {
-                        let query = super::query::CchQuery::new(&mode_data);
-                        edges_for_pair(
-                            &state,
-                            &mode_data,
-                            mode,
-                            &query,
-                            (chunk_start + local_i) as u32,
-                            pair,
-                        )
+                    .flat_map(|(src_rank, targets)| {
+                        process_source_group(&state, &mode_data, mode, *src_rank, targets)
                     })
                     .collect()
             } else {
-                // Small-batch fast path: no pool overhead for tiny calls.
-                let query = super::query::CchQuery::new(&mode_data);
                 chunk
                     .iter()
-                    .enumerate()
-                    .map(|(local_i, pair)| {
-                        edges_for_pair(
-                            &state,
-                            &mode_data,
-                            mode,
-                            &query,
-                            (chunk_start + local_i) as u32,
-                            pair,
-                        )
+                    .flat_map(|(src_rank, targets)| {
+                        process_source_group(&state, &mode_data, mode, *src_rank, targets)
                     })
                     .collect()
             };
-
-            // Flatten into Arrow builders. An unreachable pair (no rows)
-            // contributes one all-null edge row so it stays identifiable
-            // via query_idx with edge_seq IS NULL.
-            let total_rows: usize = per_pair.iter().map(|p| p.rows.len().max(1)).sum();
-            let mut query_idx_b = UInt32Builder::with_capacity(total_rows);
-            let mut target_idx_b = UInt32Builder::with_capacity(total_rows);
-            let mut edge_seq_b = UInt32Builder::with_capacity(total_rows);
-            let mut osm_from_b = Int64Builder::with_capacity(total_rows);
-            let mut osm_to_b = Int64Builder::with_capacity(total_rows);
-            let mut dur_ms_b = UInt32Builder::with_capacity(total_rows);
-            let mut dist_m_b = UInt32Builder::with_capacity(total_rows);
-
-            for pe in &per_pair {
-                if pe.rows.is_empty() {
-                    query_idx_b.append_value(pe.query_idx);
-                    target_idx_b.append_value(0);
-                    edge_seq_b.append_null();
-                    osm_from_b.append_null();
-                    osm_to_b.append_null();
-                    dur_ms_b.append_null();
-                    dist_m_b.append_null();
-                } else {
-                    for row in &pe.rows {
-                        query_idx_b.append_value(pe.query_idx);
-                        target_idx_b.append_value(0);
-                        edge_seq_b.append_value(row.edge_seq);
-                        osm_from_b.append_value(row.osm_from);
-                        osm_to_b.append_value(row.osm_to);
-                        dur_ms_b.append_value(row.dur_ms);
-                        dist_m_b.append_value(row.dist_m);
-                    }
-                }
+            if !emit(per_pair) {
+                return;
             }
+        }
 
-            let batch = match RecordBatch::try_new(
-                schema.clone(),
-                vec![
-                    Arc::new(query_idx_b.finish()) as ArrayRef,
-                    Arc::new(target_idx_b.finish()),
-                    Arc::new(edge_seq_b.finish()),
-                    Arc::new(osm_from_b.finish()),
-                    Arc::new(osm_to_b.finish()),
-                    Arc::new(dur_ms_b.finish()),
-                    Arc::new(dist_m_b.finish()),
-                ],
-            ) {
-                Ok(b) => b,
-                Err(e) => {
-                    let _ = tx.blocking_send(Err(Status::internal(format!(
-                        "edges_batch Arrow build: {e}"
-                    ))));
-                    return;
-                }
+        // Phase B: per-pair work (singletons with cached ranks + K=1-src
+        // misses), chunked.
+        for chunk in per_pair_work.chunks(CHUNK_PAIRS) {
+            let per_pair: Vec<PairEdges> = if parallel {
+                chunk
+                    .par_iter()
+                    .map(|w| {
+                        let query = super::query::CchQuery::new(&mode_data);
+                        process_per_pair_work(&state, &mode_data, mode, &query, w)
+                    })
+                    .collect()
+            } else {
+                let query = super::query::CchQuery::new(&mode_data);
+                chunk
+                    .iter()
+                    .map(|w| process_per_pair_work(&state, &mode_data, mode, &query, w))
+                    .collect()
             };
-
-            if tx.blocking_send(Ok(batch)).is_err() {
-                return; // Client disconnected.
+            if !emit(per_pair) {
+                return;
             }
         }
     });
@@ -2889,5 +3246,123 @@ impl FlightService for ButterflyFlight {
         Err(Status::unimplemented(
             "DoAction not supported. Use DoGet with tickets.",
         ))
+    }
+}
+
+#[cfg(test)]
+mod edges_batch_grouping_tests {
+    use super::{compute_edges_flat, compute_edges_grouped};
+    use crate::model::types::Mode;
+    use crate::server::state::{LoadOptions, ServerState};
+    use std::path::PathBuf;
+
+    /// #438: equivalence oracle — the source-GROUPED edges path must produce
+    /// the SAME result as the per-pair FLAT path: identical reachability and
+    /// identical per-pair total duration (the optimised metric). Equal-cost
+    /// ties may pick a different (still-shortest) edge sequence, so byte-
+    /// identity is asserted as a high rate, not 100%.
+    ///
+    /// Skipped unless `BT_EDGES_CONTAINER` points at a Belgium `.butterfly`
+    /// (the step4-7 CCH is large and not committed). Run with:
+    /// ```text
+    /// BT_EDGES_CONTAINER=/path/belgium.butterfly \
+    ///   cargo test -p butterfly-route edges_grouped_matches_flat -- --nocapture
+    /// ```
+    #[test]
+    fn edges_grouped_matches_flat() {
+        let Some(path) = std::env::var("BT_EDGES_CONTAINER").ok().map(PathBuf::from) else {
+            eprintln!(
+                "skipping edges_grouped_matches_flat: set BT_EDGES_CONTAINER to a Belgium .butterfly"
+            );
+            return;
+        };
+
+        let state = ServerState::load_from_container_with_options(
+            &path,
+            Some(&["car".to_string()]),
+            &LoadOptions {
+                eager_verify: false,
+                warmup_on_boot: false,
+            },
+        )
+        .expect("load container");
+        let mode_idx = *state.mode_lookup.get("car").expect("car mode loaded");
+        let mode = Mode(mode_idx);
+        let mode_data = state.get_mode(mode);
+
+        // Source-sharing workload: 60 sources × 25 nearby targets, plus a few
+        // deliberate edge cases (source==target, a non-contiguous interleave).
+        let mut rng_state: u64 = 0x9E3779B97F4A7C15;
+        let mut next = || {
+            rng_state ^= rng_state << 13;
+            rng_state ^= rng_state >> 7;
+            rng_state ^= rng_state << 17;
+            rng_state
+        };
+        let unit = |r: u64| (r as f64) / (u64::MAX as f64);
+        let mut pairs: Vec<[f64; 4]> = Vec::new();
+        for _ in 0..60 {
+            let slon = 2.6 + unit(next()) * 3.7;
+            let slat = 49.6 + unit(next()) * 1.8;
+            for _ in 0..25 {
+                let dlon = (slon + (unit(next()) - 0.5) * 0.5).clamp(2.55, 6.40);
+                let dlat = (slat + (unit(next()) - 0.5) * 0.5).clamp(49.50, 51.50);
+                pairs.push([slon, slat, dlon, dlat]);
+            }
+            // source==target edge case for this source.
+            pairs.push([slon, slat, slon, slat]);
+        }
+
+        for parallel in [false, true] {
+            let flat = compute_edges_flat(&state, &mode_data, mode, &pairs, parallel);
+            let grouped = compute_edges_grouped(&state, &mode_data, mode, &pairs, parallel);
+            assert_eq!(flat.len(), pairs.len());
+            assert_eq!(grouped.len(), pairs.len());
+
+            let mut byte_identical = 0usize;
+            for (f, g) in flat.iter().zip(grouped.iter()) {
+                assert_eq!(
+                    f.query_idx, g.query_idx,
+                    "query_idx order (parallel={parallel})"
+                );
+                assert_eq!(
+                    f.rows.is_empty(),
+                    g.rows.is_empty(),
+                    "reachability for query_idx {} (parallel={parallel})",
+                    f.query_idx
+                );
+                let f_dur: u64 = f.rows.iter().map(|r| r.dur_ms as u64).sum();
+                let g_dur: u64 = g.rows.iter().map(|r| r.dur_ms as u64).sum();
+                assert_eq!(
+                    f_dur, g_dur,
+                    "total duration for query_idx {} (parallel={parallel})",
+                    f.query_idx
+                );
+                let same = f.rows.len() == g.rows.len()
+                    && f.rows.iter().zip(g.rows.iter()).all(|(a, b)| {
+                        a.edge_seq == b.edge_seq
+                            && a.osm_from == b.osm_from
+                            && a.osm_to == b.osm_to
+                            && a.dur_ms == b.dur_ms
+                            && a.dist_m == b.dist_m
+                    });
+                if same {
+                    byte_identical += 1;
+                }
+            }
+            let rate = byte_identical as f64 / pairs.len() as f64;
+            eprintln!(
+                "edges_grouped_matches_flat parallel={parallel}: byte-identical {byte_identical}/{} ({:.2}%)",
+                pairs.len(),
+                rate * 100.0
+            );
+            // Reachability + total-duration are exact (asserted above). Edge
+            // sequences match for all but rare equal-cost ties.
+            assert!(
+                rate > 0.95,
+                "byte-identity {:.2}% too low (parallel={parallel}) — ties should be rare",
+                rate * 100.0
+            );
+        }
     }
 }

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2195,6 +2195,134 @@ pub fn compute_edges_flat(
     per_pair
 }
 
+/// #438 Phase 1: per-source predecessor-tracking PHAST TREE. One bounded tree
+/// settle per source replaces the per-target backward searches entirely — each
+/// target's path is a backtrack + the existing shortcut unpack
+/// ([`crate::range::tree_phast`]).
+///
+/// Bounding: the threshold per source group is `max great-circle distance to
+/// any of its targets × DETOUR / SPEED_FLOOR` (a duration metric has no
+/// principled geometric bound — codex's #1 risk). Targets the bounded tree
+/// misses are retried once at 4× the bound, then fall back to the per-pair
+/// path. The equivalence oracle (reachability + total duration identical)
+/// gates correctness; retry rate is the number to watch in the bench.
+pub fn compute_edges_tree(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    pairs: &[[f64; 4]],
+    parallel: bool,
+) -> Vec<PairEdges> {
+    let (group_vec, per_pair_work) = group_pairs(state, mode_data, mode, pairs, parallel);
+
+    let mut per_pair: Vec<PairEdges> = if parallel {
+        let mut v: Vec<PairEdges> = group_vec
+            .par_iter()
+            .flat_map(|(src_rank, targets)| {
+                process_source_group_tree(state, mode_data, mode, *src_rank, targets)
+            })
+            .collect();
+        let from_per_pair: Vec<PairEdges> = per_pair_work
+            .par_iter()
+            .map(|w| {
+                let query = super::query::CchQuery::new(mode_data);
+                process_per_pair_work(state, mode_data, mode, &query, w)
+            })
+            .collect();
+        v.extend(from_per_pair);
+        v
+    } else {
+        let mut v: Vec<PairEdges> = Vec::with_capacity(pairs.len());
+        for (src_rank, targets) in &group_vec {
+            v.extend(process_source_group_tree(
+                state, mode_data, mode, *src_rank, targets,
+            ));
+        }
+        let query = super::query::CchQuery::new(mode_data);
+        for w in &per_pair_work {
+            v.push(process_per_pair_work(state, mode_data, mode, &query, w));
+        }
+        v
+    };
+    per_pair.sort_unstable_by_key(|p| p.query_idx);
+    per_pair
+}
+
+/// #438: process one source group via the RPHAST-restricted predecessor tree.
+/// One exact restricted settle per source (selection = reverse-DOWN ancestry
+/// of the group's resolved targets — no distance bound, no retries), then
+/// every target is a backtrack + unpack. Misses (unreachable, or dst
+/// unresolved at K=1) fall back to the full per-pair path, which uses the
+/// separate `CCH_QUERY_STATE` scratch and so cannot corrupt the tree.
+fn process_source_group_tree(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    src_rank: u32,
+    targets: &[GroupedTarget],
+) -> Vec<PairEdges> {
+    use crate::range::tree_phast::{tree_backtrack, tree_settle_restricted};
+
+    let mut out = Vec::with_capacity(targets.len());
+    let mut fallbacks: Vec<usize> = Vec::new();
+
+    // Resolved target ranks drive the selection; unresolved go per-pair.
+    let mut dst_ranks: Vec<u32> = Vec::with_capacity(targets.len());
+    for (idx, t) in targets.iter().enumerate() {
+        match t.dst_rank {
+            Some(r) => dst_ranks.push(r),
+            None => fallbacks.push(idx),
+        }
+    }
+
+    if !dst_ranks.is_empty() {
+        tree_settle_restricted(
+            &mode_data.cch_topo,
+            &mode_data.cch_weights,
+            &mode_data.down_rev_flat,
+            src_rank,
+            &dst_ranks,
+        );
+        for (idx, t) in targets.iter().enumerate() {
+            let Some(dst_rank) = t.dst_rank else { continue };
+            match tree_backtrack(&mode_data.cch_topo, src_rank, dst_rank) {
+                Some(tp) => {
+                    let result = super::query::QueryResult {
+                        distance: tp.distance,
+                        meeting_node: tp.apex,
+                        forward_parent: tp.forward_parent,
+                        backward_parent: tp.backward_parent,
+                    };
+                    out.push(emit_pair_rows(
+                        state,
+                        mode_data,
+                        src_rank,
+                        dst_rank,
+                        &result,
+                        t.query_idx,
+                    ));
+                }
+                None => fallbacks.push(idx),
+            }
+        }
+    }
+
+    // Leftovers: full per-pair path (separate scratch; tree no longer needed).
+    let query = super::query::CchQuery::new(mode_data);
+    for idx in fallbacks {
+        let t = &targets[idx];
+        out.push(edges_for_pair(
+            state,
+            mode_data,
+            mode,
+            &query,
+            t.query_idx,
+            &t.pair,
+        ));
+    }
+    out
+}
+
 pub fn do_edges_batch(
     state: &Arc<ServerState>,
     mode: Mode,

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2106,6 +2106,11 @@ fn group_pairs(
             }
         }
     }
+    // Deterministic work order (Copilot review): HashMap iteration order is
+    // random per run; sorting keeps the streamed batch order stable without
+    // affecting results (each batch is internally sorted by query_idx already).
+    multi.sort_unstable_by_key(|(src_rank, _)| *src_rank);
+    per_pair.sort_unstable_by_key(|w| w.query_idx);
     (multi, per_pair)
 }
 

--- a/route/src/server/query.rs
+++ b/route/src/server/query.rs
@@ -53,8 +53,14 @@ struct CchQueryState {
     gen_fwd: Vec<u32>,
     /// Version stamp per node for backward search
     gen_bwd: Vec<u32>,
-    /// Current generation (incremented per query)
-    current_gen: u32,
+    /// Per-direction generation epochs (#438). Split from a single
+    /// `current_gen` so the shared-forward edges_batch path can FREEZE a
+    /// forward tree (`gen_fwd_epoch` fixed) while resetting the backward
+    /// search once per target (`gen_bwd_epoch` bumped). `start_query`
+    /// bumps BOTH, so every existing bidirectional caller is byte-identical;
+    /// `start_backward_only` bumps only the backward epoch.
+    gen_fwd_epoch: u32,
+    gen_bwd_epoch: u32,
     /// Forward 4-ary heap (decrease-key) — replaces PriorityQueue
     /// (codex #291). Heap entries are `(weight, node_id)` where node_id
     /// is a usize-cast u32. `handles_fwd[node]` is the heap position
@@ -94,7 +100,8 @@ impl CchQueryState {
             parent_bwd: vec![(u32::MAX, 0); n_nodes],
             gen_fwd: vec![0; n_nodes],
             gen_bwd: vec![0; n_nodes],
-            current_gen: 0,
+            gen_fwd_epoch: 0,
+            gen_bwd_epoch: 0,
             pq_fwd: DAryHeap::new(1024),
             pq_bwd: DAryHeap::new(1024),
             handles_fwd: vec![HANDLE_NONE; n_nodes],
@@ -102,11 +109,16 @@ impl CchQueryState {
         }
     }
 
-    /// Start a new query (O(1) instead of O(n))
+    /// Start a new bidirectional query (O(1) instead of O(n)).
+    ///
+    /// Bumps BOTH direction epochs, so the behaviour for the existing
+    /// bidirectional callers (`query_with_debug`, `distance_bounded`) is
+    /// byte-identical to the pre-#438 single-`current_gen` design.
     #[inline]
     fn start_query(&mut self) {
-        self.current_gen = self.current_gen.wrapping_add(1);
-        if self.current_gen == 0 {
+        self.gen_fwd_epoch = self.gen_fwd_epoch.wrapping_add(1);
+        self.gen_bwd_epoch = self.gen_bwd_epoch.wrapping_add(1);
+        if self.gen_fwd_epoch == 0 || self.gen_bwd_epoch == 0 {
             // Overflow — reset all versions (rare, every ~4B queries).
             // After reset we also wipe the handle arrays so the
             // post-overflow first query starts fully clean (otherwise
@@ -119,12 +131,42 @@ impl CchQueryState {
             self.gen_bwd.iter_mut().for_each(|v| *v = 0);
             self.handles_fwd.iter_mut().for_each(|h| *h = HANDLE_NONE);
             self.handles_bwd.iter_mut().for_each(|h| *h = HANDLE_NONE);
-            self.current_gen = 1;
+            self.gen_fwd_epoch = 1;
+            self.gen_bwd_epoch = 1;
         }
         self.pq_fwd.clear();
         self.pq_bwd.clear();
         // handles_fwd / handles_bwd carry over: set_* clears stale
         // entries on first touch this query.
+    }
+
+    /// #438: reset ONLY the backward search, preserving a frozen forward
+    /// tree (`gen_fwd_epoch` and the forward arrays untouched). Used by
+    /// `backward_meet_and_paths` to run many per-target backward searches
+    /// against one shared `settle_forward` result.
+    #[inline]
+    fn start_backward_only(&mut self) {
+        self.gen_bwd_epoch = self.gen_bwd_epoch.wrapping_add(1);
+        if self.gen_bwd_epoch == 0 {
+            self.gen_bwd.iter_mut().for_each(|v| *v = 0);
+            self.handles_bwd.iter_mut().for_each(|h| *h = HANDLE_NONE);
+            self.gen_bwd_epoch = 1;
+        }
+        self.pq_bwd.clear();
+    }
+
+    /// #438: start a fresh FORWARD-only search (bump only the forward
+    /// epoch), leaving the backward arrays for `start_backward_only` to
+    /// reset per target. Used by `settle_forward`.
+    #[inline]
+    fn start_forward_only(&mut self) {
+        self.gen_fwd_epoch = self.gen_fwd_epoch.wrapping_add(1);
+        if self.gen_fwd_epoch == 0 {
+            self.gen_fwd.iter_mut().for_each(|v| *v = 0);
+            self.handles_fwd.iter_mut().for_each(|h| *h = HANDLE_NONE);
+            self.gen_fwd_epoch = 1;
+        }
+        self.pq_fwd.clear();
     }
 
     /// Push `node` onto the forward heap with weight `dist`. Caller
@@ -171,7 +213,7 @@ impl CchQueryState {
     // Forward distance accessors
     #[inline]
     fn get_fwd(&self, node: usize) -> u32 {
-        if self.gen_fwd[node] == self.current_gen {
+        if self.gen_fwd[node] == self.gen_fwd_epoch {
             self.dist_fwd[node]
         } else {
             u32::MAX
@@ -184,18 +226,18 @@ impl CchQueryState {
         // handle slot. Any push that follows then correctly observes
         // HANDLE_NONE and pushes fresh instead of decrease-keying a
         // dead handle from a previous query's heap.
-        if self.gen_fwd[node] != self.current_gen {
+        if self.gen_fwd[node] != self.gen_fwd_epoch {
             self.handles_fwd[node] = HANDLE_NONE;
         }
         self.dist_fwd[node] = dist;
         self.parent_fwd[node] = parent;
-        self.gen_fwd[node] = self.current_gen;
+        self.gen_fwd[node] = self.gen_fwd_epoch;
     }
 
     // Backward distance accessors
     #[inline]
     fn get_bwd(&self, node: usize) -> u32 {
-        if self.gen_bwd[node] == self.current_gen {
+        if self.gen_bwd[node] == self.gen_bwd_epoch {
             self.dist_bwd[node]
         } else {
             u32::MAX
@@ -204,12 +246,12 @@ impl CchQueryState {
 
     #[inline]
     fn set_bwd(&mut self, node: usize, dist: u32, parent: (u32, u32)) {
-        if self.gen_bwd[node] != self.current_gen {
+        if self.gen_bwd[node] != self.gen_bwd_epoch {
             self.handles_bwd[node] = HANDLE_NONE;
         }
         self.dist_bwd[node] = dist;
         self.parent_bwd[node] = parent;
-        self.gen_bwd[node] = self.current_gen;
+        self.gen_bwd[node] = self.gen_bwd_epoch;
     }
 }
 
@@ -444,7 +486,7 @@ impl<'a> CchQuery<'a> {
             if stalled {
                 return;
             }
-            if state.gen_fwd[x as usize] == state.current_gen {
+            if state.gen_fwd[x as usize] == state.gen_fwd_epoch {
                 let dx = state.dist_fwd[x as usize];
                 if dx != u32::MAX && dx.saturating_add(w) < d {
                     stalled = true;
@@ -468,7 +510,7 @@ impl<'a> CchQuery<'a> {
             if stalled {
                 return;
             }
-            if state.gen_bwd[v as usize] == state.current_gen {
+            if state.gen_bwd[v as usize] == state.gen_bwd_epoch {
                 let dv = state.dist_bwd[v as usize];
                 if dv != u32::MAX && dv.saturating_add(w) < d {
                     stalled = true;
@@ -548,7 +590,7 @@ impl<'a> CchQuery<'a> {
                                     if stalled {
                                         return;
                                     }
-                                    if state.gen_fwd[x as usize] == state.current_gen {
+                                    if state.gen_fwd[x as usize] == state.gen_fwd_epoch {
                                         let dx = state.dist_fwd[x as usize];
                                         if dx != u32::MAX && dx.saturating_add(w) < d {
                                             stalled = true;
@@ -621,7 +663,7 @@ impl<'a> CchQuery<'a> {
                                     if stalled {
                                         return;
                                     }
-                                    if state.gen_bwd[v as usize] == state.current_gen {
+                                    if state.gen_bwd[v as usize] == state.gen_bwd_epoch {
                                         let dv = state.dist_bwd[v as usize];
                                         if dv != u32::MAX && dv.saturating_add(w) < d {
                                             stalled = true;
@@ -704,18 +746,212 @@ impl<'a> CchQuery<'a> {
                     let forward_parent = reconstruct_path_versioned(
                         &state.parent_fwd,
                         &state.gen_fwd,
-                        state.current_gen,
+                        state.gen_fwd_epoch,
                         source,
                         meeting_node,
                     );
                     let backward_parent = reconstruct_path_versioned(
                         &state.parent_bwd,
                         &state.gen_bwd,
-                        state.current_gen,
+                        state.gen_bwd_epoch,
                         target,
                         meeting_node,
                     );
 
+                    Some(QueryResult {
+                        distance: best_dist,
+                        meeting_node,
+                        forward_parent,
+                        backward_parent,
+                    })
+                },
+            )
+        })
+    }
+
+    /// #438: forward-only UP settle to EXHAUSTION from `source`, frozen in
+    /// the thread-local query state for reuse across many targets via
+    /// [`Self::backward_meet_and_paths`]. No early termination (no target
+    /// yet) and no meeting checks. The relax + stall-on-demand body mirrors
+    /// the forward branch of [`Self::query_with_debug`] exactly, so the
+    /// settled distances + parent pointers are identical to a per-pair
+    /// forward — only computed ONCE and reused for all of the source's
+    /// targets.
+    ///
+    /// MUST be followed (same thread, no intervening `query`/`settle_forward`)
+    /// by one or more `backward_meet_and_paths(source, target)` calls.
+    ///
+    /// Invariant (relied on by the source-grouped edges path): the whole group
+    /// — this settle + all its `backward_meet_and_paths` — must finish before
+    /// the #402 idle-compactor could evict the thread-local `CchQueryState`. In
+    /// practice that holds trivially (the compactor threshold is seconds; a
+    /// group's targets complete in microseconds, and each call re-stamps the
+    /// cell's last-touch). If eviction ever did fire mid-group it is only a
+    /// performance loss, not a correctness bug: the frozen forward is gone, so
+    /// each target returns `None` and falls back to the per-pair path, which
+    /// recomputes the same result.
+    pub fn settle_forward(&self, source: u32) {
+        let n = self.n_nodes;
+        CCH_QUERY_STATE.with(|cell| {
+            cell.with_or_init(
+                || CchQueryState::new(n),
+                |state| {
+                    if state.dist_fwd.len() != n {
+                        *state = CchQueryState::new(n);
+                    }
+                    state.start_forward_only();
+                    state.set_fwd(source as usize, 0, (source, 0));
+                    state.push_fwd(source, 0);
+
+                    while let Some((d, u)) = state.pop_fwd() {
+                        if d > state.get_fwd(u as usize) {
+                            continue; // stale
+                        }
+                        // Stall-on-demand (mirrors query_with_debug fwd branch).
+                        let mut stalled = false;
+                        self.for_down_rev_edges(u, |x, w, _| {
+                            if stalled {
+                                return;
+                            }
+                            if state.gen_fwd[x as usize] == state.gen_fwd_epoch {
+                                let dx = state.dist_fwd[x as usize];
+                                if dx != u32::MAX && dx.saturating_add(w) < d {
+                                    stalled = true;
+                                }
+                            }
+                        });
+                        if stalled {
+                            continue;
+                        }
+                        self.for_up_edges(u, |v, w, edge_idx| {
+                            let new_dist = d.saturating_add(w);
+                            if new_dist < state.get_fwd(v as usize) {
+                                state.set_fwd(v as usize, new_dist, (u, edge_idx));
+                                state.push_fwd(v, new_dist);
+                            }
+                        });
+                    }
+                },
+            )
+        });
+    }
+
+    /// #438: run a BACKWARD search from `target` against the frozen forward
+    /// tree left by [`Self::settle_forward`]`(source)`, find the min-cost
+    /// meeting node, and reconstruct the forward + backward parent chains.
+    /// Returns the same [`QueryResult`] shape as [`Self::query`] (so the
+    /// edges_batch unpack is unchanged), or `None` if unreachable.
+    ///
+    /// Cost: this pays only the backward half + reconstruct — the forward
+    /// half is amortised across all of the source's targets. The min-cost
+    /// DISTANCE is identical to the per-pair `query`; the exact equal-cost
+    /// path may differ on ties (both are valid time-shortest paths).
+    ///
+    /// MUST be called after `settle_forward(source)` on the SAME thread with
+    /// no intervening `query`/`settle_forward` (those bump the forward epoch
+    /// and erase the frozen tree).
+    pub fn backward_meet_and_paths(&self, source: u32, target: u32) -> Option<QueryResult> {
+        if source == target {
+            return Some(QueryResult {
+                distance: 0,
+                meeting_node: source,
+                forward_parent: vec![],
+                backward_parent: vec![],
+            });
+        }
+        let n = self.n_nodes;
+        CCH_QUERY_STATE.with(|cell| {
+            cell.with_or_init(
+                || CchQueryState::new(n),
+                |state| {
+                    // #438 review: guard against a graph swap between the
+                    // settle_forward and this call (matches settle_forward /
+                    // query_with_debug). If the state was re-sized the frozen
+                    // forward is gone anyway → all targets return None and fall
+                    // back to the per-pair path, which is result-preserving.
+                    if state.dist_fwd.len() != n {
+                        *state = CchQueryState::new(n);
+                    }
+                    state.start_backward_only();
+                    state.set_bwd(target as usize, 0, (target, 0));
+                    state.push_bwd(target, 0);
+
+                    let mut best_dist = u32::MAX;
+                    let mut meeting_node = u32::MAX;
+
+                    // The target may itself sit in the frozen forward tree.
+                    let fwd_t = state.get_fwd(target as usize);
+                    if fwd_t != u32::MAX {
+                        best_dist = fwd_t;
+                        meeting_node = target;
+                    }
+
+                    while let Some((d, u)) = state.pop_bwd() {
+                        if d >= best_dist {
+                            break; // early termination — frontier can't improve
+                        }
+                        if d > state.get_bwd(u as usize) {
+                            continue; // stale
+                        }
+                        // Backward stall-on-demand (mirrors query_with_debug bwd branch).
+                        let mut stalled = false;
+                        self.for_up_edges(u, |v, w, _| {
+                            if stalled {
+                                return;
+                            }
+                            if state.gen_bwd[v as usize] == state.gen_bwd_epoch {
+                                let dv = state.dist_bwd[v as usize];
+                                if dv != u32::MAX && dv.saturating_add(w) < d {
+                                    stalled = true;
+                                }
+                            }
+                        });
+                        if stalled {
+                            continue;
+                        }
+                        // Meet against the frozen forward at settle.
+                        let fwd_d = state.get_fwd(u as usize);
+                        if fwd_d != u32::MAX {
+                            let total = d.saturating_add(fwd_d);
+                            if total < best_dist {
+                                best_dist = total;
+                                meeting_node = u;
+                            }
+                        }
+                        self.for_down_rev_edges(u, |x, w, edge_idx| {
+                            let new_dist = d.saturating_add(w);
+                            if new_dist < state.get_bwd(x as usize) {
+                                state.set_bwd(x as usize, new_dist, (u, edge_idx));
+                                state.push_bwd(x, new_dist);
+                                let fwd_x = state.get_fwd(x as usize);
+                                if fwd_x != u32::MAX {
+                                    let total = new_dist.saturating_add(fwd_x);
+                                    if total < best_dist {
+                                        best_dist = total;
+                                        meeting_node = x;
+                                    }
+                                }
+                            }
+                        });
+                    }
+
+                    if best_dist == u32::MAX {
+                        return None;
+                    }
+                    let forward_parent = reconstruct_path_versioned(
+                        &state.parent_fwd,
+                        &state.gen_fwd,
+                        state.gen_fwd_epoch,
+                        source,
+                        meeting_node,
+                    );
+                    let backward_parent = reconstruct_path_versioned(
+                        &state.parent_bwd,
+                        &state.gen_bwd,
+                        state.gen_bwd_epoch,
+                        target,
+                        meeting_node,
+                    );
                     Some(QueryResult {
                         distance: best_dist,
                         meeting_node,
@@ -835,7 +1071,7 @@ impl CchQuery<'_> {
                                 if stalled {
                                     return;
                                 }
-                                if state.gen_fwd[x as usize] == state.current_gen {
+                                if state.gen_fwd[x as usize] == state.gen_fwd_epoch {
                                     let dx = state.dist_fwd[x as usize];
                                     if dx != u32::MAX && dx.saturating_add(w) < d {
                                         stalled = true;
@@ -876,7 +1112,7 @@ impl CchQuery<'_> {
                                 if stalled {
                                     return;
                                 }
-                                if state.gen_bwd[v as usize] == state.current_gen {
+                                if state.gen_bwd[v as usize] == state.gen_bwd_epoch {
                                     let dv = state.dist_bwd[v as usize];
                                     if dv != u32::MAX && dv.saturating_add(w) < d {
                                         stalled = true;

--- a/route/src/server/query.rs
+++ b/route/src/server/query.rs
@@ -866,11 +866,16 @@ impl<'a> CchQuery<'a> {
                 |state| {
                     // #438 review: guard against a graph swap between the
                     // settle_forward and this call (matches settle_forward /
-                    // query_with_debug). If the state was re-sized the frozen
-                    // forward is gone anyway → all targets return None and fall
-                    // back to the per-pair path, which is result-preserving.
-                    if state.dist_fwd.len() != n {
-                        *state = CchQueryState::new(n);
+                    // query_with_debug), AND (Copilot review) fail closed when
+                    // the frozen forward tree doesn't belong to `source` —
+                    // out-of-sequence call, evicted scratch, or a different
+                    // source. Reading a foreign tree would compute garbage
+                    // meets (or loop on a foreign root sentinel during
+                    // reconstruct). The settled root always has dist 0, so the
+                    // guard is one stamped read. `None` → the caller's
+                    // per-pair fallback recomputes correctly.
+                    if state.dist_fwd.len() != n || state.get_fwd(source as usize) != 0 {
+                        return None;
                     }
                     state.start_backward_only();
                     state.set_bwd(target as usize, 0, (target, 0));

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -1727,14 +1727,19 @@ impl ServerState {
         );
 
         // 3. Re-run TIME-only customization in memory (triangle-relax always on).
-        let new_weights = crate::customization::customize_cch_time_in_memory(
-            &base.cch_topo,
-            &filtered_ebg,
-            &base.node_weights,
-            &turns.penalties,
-            &self.ebg_nodes,
-            Some((&profile, &way_attrs_vec, &self.nbg_geo)),
-        )?;
+        // Codex audit (#438): also take the traffic-ADJUSTED per-node time
+        // weights — edges_batch derives per-edge durations from
+        // ModeData.node_weights, so cloning the base (legal-limit) weights
+        // here would emit wrong durations along calibrated paths.
+        let (new_weights, adjusted_node_weights) =
+            crate::customization::customize_cch_time_in_memory(
+                &base.cch_topo,
+                &filtered_ebg,
+                &base.node_weights,
+                &turns.penalties,
+                &self.ebg_nodes,
+                Some((&profile, &way_attrs_vec, &self.nbg_geo)),
+            )?;
 
         // 4. Fresh TIME flats (mirrors load_traffic_variant_mode_data).
         let up_adj_flat = UpAdjFlat::build_with(&base.cch_topo, &new_weights, true);
@@ -1754,7 +1759,7 @@ impl ServerState {
             filtered_to_original: base.filtered_to_original.clone(),
             n_filtered_nodes: base.n_filtered_nodes,
             n_original_nodes: base.n_original_nodes,
-            node_weights: base.node_weights.clone(),
+            node_weights: std::borrow::Cow::Owned(adjusted_node_weights),
             mask: base.mask.clone(),
             has_outbound: base.has_outbound.clone(),
             has_inbound: base.has_inbound.clone(),


### PR DESCRIPTION
Closes #438. The OSRM-gap win for `edges_batch`: **share one forward CCH search across each source's targets.**

## Why
The forward CCH search depends only on the SOURCE. The real consumer (traffic-flow) routes street-section **origin → ~30 nearby PoIs**, but pairs are sent flat, so the forward half was recomputed ~30× per source.

## Result (magellan, 200 sources × 30 nearby targets, parallel)
| | pairs/s |
|---|---|
| FLAT (per-pair) | 9,532 |
| **GROUPED** | **17,487** |
| **speedup** | **1.83×** (matches the ~1.85× cost-model estimate) |

**Correctness (asserted on Belgium):** reachability + per-pair total duration **identical** to the per-pair path; **99.9% byte-identical** edge sequences (only rare equal-cost ties differ — both valid time-shortest paths). 632 lib tests pass.

## How
- **query.rs**: split `CchQueryState.current_gen` into per-direction epochs (`start_query` bumps both → existing bidirectional callers byte-identical); add `settle_forward(source)` (UP settle to exhaustion, frozen) + `backward_meet_and_paths(source,target)` (backward vs frozen forward → same `QueryResult`).
- **flight.rs**: `group_pairs` (parallel K=1 resolve) → multi-target groups + per-pair work; `process_source_group` (settle once + per-target backward, escalation fallbacks LAST); `process_per_pair_work` (singletons reuse cached ranks); `escalate_pair` (K=64+16-combo split out so the fast path doesn't redo K=1); `do_edges_batch` streams in work-chunks (bounded memory).
- **bench**: `butterfly-bench edges-batch` (flat vs grouped equivalence + speedup) + in-process `p2p`.
- **test**: `edges_grouped_matches_flat` (env-gated on a Belgium container).

## Review (adversarial multi-agent, since Gemini/Codex were unavailable) — all findings addressed
- **BLOCKER** memory: `do_edges_batch` now streams in work-chunks (bounded), not full materialisation.
- **MAJOR** singleton perf cliff: singletons → per-pair + **parallel resolve** → all-singleton went 0.87×→**0.94×** (residual is inherent grouping overhead, no real-workload impact; the 1.83× win is unaffected).
- **MINORS**: double-snap (escalate split + cached ranks); `backward_meet_and_paths` `n_nodes` guard; compactor-invariant documented.
- Independently verified: epoch migration byte-identical, shared-forward equivalence, grouping/fallback semantics, thread-local frozen-tree safety.

## Honest scope
A clean ~1.85× algorithmic win. It **beats OSRM on prod-class hardware** (and on magellan: 17.5k pairs/s ≫ OSRM-canopus 1.87k); on canopus it closes most of the residual edge-based-CCH gap. Retains the 16-combo escalation cap.

Build / clippy (warnings=errors) / fmt clean.