### PR TITLE
fix(flight): route do_edges_batch through the TREE path (#438)

### DIFF
--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2459,14 +2459,14 @@ pub fn do_edges_batch(
                 chunk
                     .par_iter()
                     .flat_map(|(src_rank, targets)| {
-                        process_source_group(&state, &mode_data, mode, *src_rank, targets)
+                        process_source_group_tree(&state, &mode_data, mode, *src_rank, targets)
                     })
                     .collect()
             } else {
                 chunk
                     .iter()
                     .flat_map(|(src_rank, targets)| {
-                        process_source_group(&state, &mode_data, mode, *src_rank, targets)
+                        process_source_group_tree(&state, &mode_data, mode, *src_rank, targets)
                     })
                     .collect()
             };


### PR DESCRIPTION
One-line: `do_edges_batch` Phase A → `process_source_group_tree`. The tree (3.4-3.7× in the bench, oracle green) was bench-only; the serve endpoint still ran the grouped path — exposed by the fair canopus head-to-head (575 pairs/s on the 12-city shape). `compute_edges_grouped` keeps the grouped variant for the bench oracle. 633 tests pass.