### PR TITLE
perf(flight): tree lever stack — stalled sweep, probe escalation, shape-adaptive dispatch (#438)

### DIFF
--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -540,6 +540,11 @@ enum Commands {
         /// Random seed.
         #[arg(long, default_value_t = 42)]
         seed: u64,
+        /// Target jitter radius in degrees (~111 km/deg). Small radius around
+        /// city anchors ⇒ ~100% reachable (isolates tree-core cost from
+        /// unreachable-escalation cost).
+        #[arg(long, default_value_t = 0.30)]
+        radius: f64,
     },
 }
 
@@ -795,7 +800,8 @@ fn main() -> anyhow::Result<()> {
             n_sources,
             targets_per_source,
             seed,
-        } => run_edges_batch_bench(&data, &mode, n_sources, targets_per_source, seed),
+            radius,
+        } => run_edges_batch_bench(&data, &mode, n_sources, targets_per_source, seed, radius),
     }
 }
 
@@ -4687,6 +4693,7 @@ fn run_edges_batch_bench(
     n_sources: usize,
     targets_per_source: usize,
     seed: u64,
+    radius: f64,
 ) -> anyhow::Result<()> {
     use butterfly_route::model::types::Mode;
     use butterfly_route::server::flight::{
@@ -4752,8 +4759,8 @@ fn run_edges_batch_bench(
         let slat = (c[1] + rng.random_range(-0.15_f64..0.15)).clamp(49.50, 51.50);
         for _ in 0..targets_per_source {
             // Targets NEAR the source (±~25 km).
-            let dlon = (slon + rng.random_range(-0.30_f64..0.30)).clamp(2.55, 6.40);
-            let dlat = (slat + rng.random_range(-0.30_f64..0.30)).clamp(49.50, 51.50);
+            let dlon = (slon + rng.random_range(-radius..radius)).clamp(2.55, 6.40);
+            let dlat = (slat + rng.random_range(-radius..radius)).clamp(49.50, 51.50);
             pairs.push([slon, slat, dlon, dlat]);
         }
     }

--- a/route/src/range/tree_phast.rs
+++ b/route/src/range/tree_phast.rs
@@ -31,7 +31,9 @@
 //! Belgium, freed when idle).
 
 use crate::formats::{CchTopo, CchWeights};
+use crate::matrix::bucket_ch::{DAryHeap, DownReverseAdjFlat};
 use crate::server::evictable::EvictableCell;
+use crate::server::query::HANDLE_NONE;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 
@@ -59,6 +61,10 @@ struct TreeScratch {
     sel_gen: Vec<u32>,
     sel_epoch: u32,
     sel: Vec<u32>,
+    /// Lever-1 (#438): reused 4-ary decrease-key heap + handle slots for the
+    /// upward sweep (replaces a per-settle std::BinaryHeap with lazy dupes).
+    pq: DAryHeap,
+    handles: Vec<u32>,
 }
 
 impl TreeScratch {
@@ -73,6 +79,8 @@ impl TreeScratch {
             sel_gen: vec![0; n],
             sel_epoch: 0,
             sel: Vec::new(),
+            pq: DAryHeap::new(1024),
+            handles: vec![HANDLE_NONE; n],
         }
     }
 
@@ -106,8 +114,28 @@ impl TreeScratch {
         }
     }
 
+    /// Push-or-decrease into the reused 4-ary heap (mirrors
+    /// CchQueryState::push_fwd; `set` clears stale handles on first touch).
+    #[inline]
+    fn push_up(&mut self, node: u32, dist: u32) {
+        if self.handles[node as usize] != HANDLE_NONE {
+            let h = self.handles[node as usize];
+            self.pq.decrease(h, dist, node, &mut self.handles);
+        } else {
+            self.pq.push(dist, node, &mut self.handles);
+        }
+    }
+
+    #[inline]
+    fn pop_up(&mut self) -> Option<(u32, u32)> {
+        self.pq.pop(&mut self.handles)
+    }
+
     #[inline]
     fn set(&mut self, node: usize, dist: u32, tagged_arc: u32) {
+        if self.generation[node] != self.epoch {
+            self.handles[node] = HANDLE_NONE;
+        }
         self.dist[node] = dist;
         self.parent[node] = tagged_arc;
         self.generation[node] = self.epoch;
@@ -252,7 +280,7 @@ pub fn tree_settle(
 pub fn tree_settle_restricted(
     topo: &CchTopo,
     weights: &CchWeights,
-    down_rev: &crate::matrix::bucket_ch::DownReverseAdjFlat,
+    down_rev: &DownReverseAdjFlat,
     origin: u32,
     targets: &[u32],
 ) -> TreeSettle {
@@ -298,12 +326,34 @@ pub fn tree_settle_restricted(
                 // Descending rank order for the scan.
                 s.sel.sort_unstable_by(|a, b| b.cmp(a));
 
-                // ---- Phase 1: exhaustive upward PQ sweep (UP parents) ----
-                let mut pq: BinaryHeap<Reverse<(u32, u32)>> = BinaryHeap::new();
-                pq.push(Reverse((0, origin)));
-                while let Some(Reverse((d, u))) = pq.pop() {
+                // ---- Phase 1: exhaustive upward sweep (UP parents) ----
+                // Lever-1 (#438): reused 4-ary decrease-key heap (no lazy
+                // duplicate pops) + stall-on-demand against the reverse-DOWN
+                // adjacency, mirroring the tuned bidirectional query (#272).
+                // Stalling prunes nodes whose distance is witnessed shorter
+                // via a higher-rank neighbour — distances on shortest paths
+                // are unaffected.
+                s.pq.clear();
+                s.push_up(origin, 0);
+                while let Some((d, u)) = s.pop_up() {
                     if d > s.get(u as usize) {
                         continue; // stale
+                    }
+                    let rs = down_rev.offsets[u as usize] as usize;
+                    let re = down_rev.offsets[u as usize + 1] as usize;
+                    let mut stalled = false;
+                    for slot in rs..re {
+                        let x = down_rev.sources[slot] as usize;
+                        if s.generation[x] == s.epoch {
+                            let dx = s.dist[x];
+                            if dx != u32::MAX && dx.saturating_add(down_rev.weights.get(slot)) < d {
+                                stalled = true;
+                                break;
+                            }
+                        }
+                    }
+                    if stalled {
+                        continue;
                     }
                     let start = topo.up_offsets[u as usize] as usize;
                     let end = topo.up_offsets[u as usize + 1] as usize;
@@ -316,7 +366,7 @@ pub fn tree_settle_restricted(
                         let nd = d.saturating_add(w);
                         if nd < s.get(v as usize) {
                             s.set(v as usize, nd, i as u32); // UP arc
-                            pq.push(Reverse((nd, v)));
+                            s.push_up(v, nd);
                         }
                     }
                 }

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2253,6 +2253,89 @@ pub fn compute_edges_tree(
     per_pair
 }
 
+/// #438 lever-4: escalation for a TREE-mode miss. The settled tree is EXACT
+/// and unbounded for the group's root, so every escalation combo whose source
+/// IS the tree root is decidable by a free tree probe — provably-dead combos
+/// skip their full bidirectional query (each of which explores both cones
+/// exhaustively before failing). Combos with ALTERNATE source candidates run
+/// the real query as before, in the same closest-sum-first order, so the
+/// first CONNECTING combo (the result) is identical to `escalate_pair`'s.
+fn escalate_pair_with_tree(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    query: &super::query::CchQuery<'_>,
+    query_idx: u32,
+    pair: &[f64; 4],
+    tree_root: u32,
+) -> PairEdges {
+    use super::types::SnapRole;
+    let (slon, slat, dlon, dlat) = (pair[0], pair[1], pair[2], pair[3]);
+    const SNAP_K: usize = 64;
+    let src_snap = super::snap_kbest::snap_k_pair_role(
+        state,
+        mode_data,
+        mode,
+        slon,
+        slat,
+        SnapRole::Src,
+        None,
+        SNAP_K,
+    );
+    let dst_snap = super::snap_kbest::snap_k_pair_role(
+        state,
+        mode_data,
+        mode,
+        dlon,
+        dlat,
+        SnapRole::Dst,
+        None,
+        SNAP_K,
+    );
+    if !src_snap.ranks.is_empty() && !dst_snap.ranks.is_empty() {
+        const EDGES_BATCH_MAX_COMBOS: usize = 16;
+        for (i, j) in super::snap_kbest::combo_order(
+            src_snap.ranks.len(),
+            dst_snap.ranks.len(),
+            EDGES_BATCH_MAX_COMBOS,
+        ) {
+            let s_rank = src_snap.ranks[i];
+            let d_rank = dst_snap.ranks[j];
+            if s_rank == d_rank {
+                continue;
+            }
+            if s_rank == tree_root {
+                // Free, exact decision from the settled tree.
+                match crate::range::tree_phast::tree_backtrack(
+                    &mode_data.cch_topo,
+                    tree_root,
+                    d_rank,
+                ) {
+                    Some(tp) => {
+                        let result = super::query::QueryResult {
+                            distance: tp.distance,
+                            meeting_node: tp.apex,
+                            forward_parent: tp.forward_parent,
+                            backward_parent: tp.backward_parent,
+                        };
+                        return emit_pair_rows(
+                            state, mode_data, s_rank, d_rank, &result, query_idx,
+                        );
+                    }
+                    None => continue, // provably dead — skip the full query
+                }
+            }
+            if let Some(result) = query.query(s_rank, d_rank) {
+                return emit_pair_rows(state, mode_data, s_rank, d_rank, &result, query_idx);
+            }
+        }
+    }
+    PairEdges {
+        query_idx,
+        rows: Vec::new(),
+    }
+}
+
 /// #438: process one source group via the RPHAST-restricted predecessor tree.
 /// One exact restricted settle per source (selection = reverse-DOWN ancestry
 /// of the group's resolved targets — no distance bound, no retries), then
@@ -2312,18 +2395,28 @@ fn process_source_group_tree(
         }
     }
 
-    // Leftovers: full per-pair path (separate scratch; tree no longer needed).
+    // Leftovers. CAUTION on ordering: escalate_pair_with_tree PROBES the
+    // settled tree, but edges_for_pair (and the probe's own alternate-source
+    // queries) only touch the separate CCH_QUERY_STATE scratch — the tree
+    // stays valid throughout this loop. Tree-miss targets (resolved dst, no
+    // path via the root) take the probe escalation (lever-4: provably-dead
+    // combos skipped for free); dst-unresolved targets take the plain
+    // per-pair path as before.
     let query = super::query::CchQuery::new(mode_data);
     for idx in fallbacks {
         let t = &targets[idx];
-        out.push(edges_for_pair(
-            state,
-            mode_data,
-            mode,
-            &query,
-            t.query_idx,
-            &t.pair,
-        ));
+        out.push(match t.dst_rank {
+            Some(_) => escalate_pair_with_tree(
+                state,
+                mode_data,
+                mode,
+                &query,
+                t.query_idx,
+                &t.pair,
+                src_rank,
+            ),
+            None => edges_for_pair(state, mode_data, mode, &query, t.query_idx, &t.pair),
+        });
     }
     out
 }

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2336,6 +2336,32 @@ fn escalate_pair_with_tree(
     }
 }
 
+/// #438: shape-adaptive group dispatch. Short-radius groups (all targets
+/// within ~GC_SWITCH_M of the source) run the GROUPED path — early-terminated
+/// backward searches are so cheap there that the tree's exhaustive sweep +
+/// selection overhead isn't repaid (measured: grouped 31.8k vs tree 24.5k
+/// pairs/s at radius 0.08°). Long-radius groups run the TREE (tree 16.8k vs
+/// grouped 10.5k at 0.30°). Both paths are oracle-proven identical, so the
+/// dispatch is purely a cost choice.
+fn process_source_group_adaptive(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    src_rank: u32,
+    targets: &[GroupedTarget],
+) -> Vec<PairEdges> {
+    const GC_SWITCH_M: f64 = 15_000.0;
+    let max_gc = targets
+        .iter()
+        .map(|t| crate::nbg::haversine_distance(t.pair[1], t.pair[0], t.pair[3], t.pair[2]))
+        .fold(0.0_f64, f64::max);
+    if max_gc <= GC_SWITCH_M {
+        process_source_group(state, mode_data, mode, src_rank, targets)
+    } else {
+        process_source_group_tree(state, mode_data, mode, src_rank, targets)
+    }
+}
+
 /// #438: process one source group via the RPHAST-restricted predecessor tree.
 /// One exact restricted settle per source (selection = reverse-DOWN ancestry
 /// of the group's resolved targets — no distance bound, no retries), then
@@ -2552,14 +2578,14 @@ pub fn do_edges_batch(
                 chunk
                     .par_iter()
                     .flat_map(|(src_rank, targets)| {
-                        process_source_group_tree(&state, &mode_data, mode, *src_rank, targets)
+                        process_source_group_adaptive(&state, &mode_data, mode, *src_rank, targets)
                     })
                     .collect()
             } else {
                 chunk
                     .iter()
                     .flat_map(|(src_rank, targets)| {
-                        process_source_group_tree(&state, &mode_data, mode, *src_rank, targets)
+                        process_source_group_adaptive(&state, &mode_data, mode, *src_rank, targets)
                     })
                     .collect()
             };


### PR DESCRIPTION
Three oracle-gated increments on the tree engine: (1) reused 4-ary decrease-key heap + stall-on-demand in the restricted sweep (neutral perf, cleaner asymptotics); (2) tree-probe dead-combo pruning in TREE-mode escalation (provably-dead root-sourced combos skip full queries, identical first-connecting-combo semantics); (3) **shape-adaptive dispatch** — grouped ≤15 km (31.8k pairs/s measured), tree beyond (16.8k vs 10.5k). All: 633 tests, 0 reachability/duration mismatches, continuity asserted, idle-host benches. Plus bench `--radius` flag for shape isolation.