### PR TITLE
fix(flight): revert unsound lever-4 probe escalation + comment fixes (#438)

### DIFF
--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -4758,7 +4758,7 @@ fn run_edges_batch_bench(
         let slon = (c[0] + rng.random_range(-0.15_f64..0.15)).clamp(2.55, 6.40);
         let slat = (c[1] + rng.random_range(-0.15_f64..0.15)).clamp(49.50, 51.50);
         for _ in 0..targets_per_source {
-            // Targets NEAR the source (±~25 km).
+            // Targets NEAR the source (within ±`radius` degrees).
             let dlon = (slon + rng.random_range(-radius..radius)).clamp(2.55, 6.40);
             let dlat = (slat + rng.random_range(-radius..radius)).clamp(49.50, 51.50);
             pairs.push([slon, slat, dlon, dlat]);

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2563,7 +2563,8 @@ pub fn do_edges_batch(
 
         // Phase A: multi-target groups, chunked by accumulated target count so
         // each chunk holds ~CHUNK_PAIRS pairs. flat_map keeps each group's
-        // settle_forward + its targets on one rayon thread (frozen tree valid).
+        // each group's settle (grouped OR tree, per the adaptive dispatch) +
+        // its targets on one rayon thread (thread-local state stays valid).
         let mut gi = 0usize;
         while gi < group_vec.len() {
             let mut pairs_in_chunk = 0usize;


### PR DESCRIPTION
Copilot caught that `tree_settle_restricted` is only exact for its selection (K=1 dst ranks) — probing K=64 candidates can false-miss or read partially-relaxed dead-end distances (latent divergence). Lever-4 measured ~neutral, so it's reverted outright; tree-misses fall back per-pair as before. Plus the stale Phase-A/bench comments from #441/#442 reviews. 633 tests.