### PR TITLE
fix(flight): actually remove the unsound lever-4 probe escalation (#443 take 2)

### DIFF
--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2253,89 +2253,6 @@ pub fn compute_edges_tree(
     per_pair
 }
 
-/// #438 lever-4: escalation for a TREE-mode miss. The settled tree is EXACT
-/// and unbounded for the group's root, so every escalation combo whose source
-/// IS the tree root is decidable by a free tree probe — provably-dead combos
-/// skip their full bidirectional query (each of which explores both cones
-/// exhaustively before failing). Combos with ALTERNATE source candidates run
-/// the real query as before, in the same closest-sum-first order, so the
-/// first CONNECTING combo (the result) is identical to `escalate_pair`'s.
-fn escalate_pair_with_tree(
-    state: &ServerState,
-    mode_data: &super::state::ModeData,
-    mode: Mode,
-    query: &super::query::CchQuery<'_>,
-    query_idx: u32,
-    pair: &[f64; 4],
-    tree_root: u32,
-) -> PairEdges {
-    use super::types::SnapRole;
-    let (slon, slat, dlon, dlat) = (pair[0], pair[1], pair[2], pair[3]);
-    const SNAP_K: usize = 64;
-    let src_snap = super::snap_kbest::snap_k_pair_role(
-        state,
-        mode_data,
-        mode,
-        slon,
-        slat,
-        SnapRole::Src,
-        None,
-        SNAP_K,
-    );
-    let dst_snap = super::snap_kbest::snap_k_pair_role(
-        state,
-        mode_data,
-        mode,
-        dlon,
-        dlat,
-        SnapRole::Dst,
-        None,
-        SNAP_K,
-    );
-    if !src_snap.ranks.is_empty() && !dst_snap.ranks.is_empty() {
-        const EDGES_BATCH_MAX_COMBOS: usize = 16;
-        for (i, j) in super::snap_kbest::combo_order(
-            src_snap.ranks.len(),
-            dst_snap.ranks.len(),
-            EDGES_BATCH_MAX_COMBOS,
-        ) {
-            let s_rank = src_snap.ranks[i];
-            let d_rank = dst_snap.ranks[j];
-            if s_rank == d_rank {
-                continue;
-            }
-            if s_rank == tree_root {
-                // Free, exact decision from the settled tree.
-                match crate::range::tree_phast::tree_backtrack(
-                    &mode_data.cch_topo,
-                    tree_root,
-                    d_rank,
-                ) {
-                    Some(tp) => {
-                        let result = super::query::QueryResult {
-                            distance: tp.distance,
-                            meeting_node: tp.apex,
-                            forward_parent: tp.forward_parent,
-                            backward_parent: tp.backward_parent,
-                        };
-                        return emit_pair_rows(
-                            state, mode_data, s_rank, d_rank, &result, query_idx,
-                        );
-                    }
-                    None => continue, // provably dead — skip the full query
-                }
-            }
-            if let Some(result) = query.query(s_rank, d_rank) {
-                return emit_pair_rows(state, mode_data, s_rank, d_rank, &result, query_idx);
-            }
-        }
-    }
-    PairEdges {
-        query_idx,
-        rows: Vec::new(),
-    }
-}
-
 /// #438: shape-adaptive group dispatch. Short-radius groups (all targets
 /// within ~GC_SWITCH_M of the source) run the GROUPED path — early-terminated
 /// backward searches are so cheap there that the tree's exhaustive sweep +
@@ -2421,28 +2338,21 @@ fn process_source_group_tree(
         }
     }
 
-    // Leftovers. CAUTION on ordering: escalate_pair_with_tree PROBES the
-    // settled tree, but edges_for_pair (and the probe's own alternate-source
-    // queries) only touch the separate CCH_QUERY_STATE scratch — the tree
-    // stays valid throughout this loop. Tree-miss targets (resolved dst, no
-    // path via the root) take the probe escalation (lever-4: provably-dead
-    // combos skipped for free); dst-unresolved targets take the plain
-    // per-pair path as before.
+    // Leftovers: full per-pair path (separate CCH_QUERY_STATE scratch; the
+    // tree is no longer needed). NOTE (#443): a probe-based escalation against
+    // the restricted tree was tried and reverted — the selection only covers
+    // the K=1 dst ranks, so probes for K=64 candidates are NOT decidable.
     let query = super::query::CchQuery::new(mode_data);
     for idx in fallbacks {
         let t = &targets[idx];
-        out.push(match t.dst_rank {
-            Some(_) => escalate_pair_with_tree(
-                state,
-                mode_data,
-                mode,
-                &query,
-                t.query_idx,
-                &t.pair,
-                src_rank,
-            ),
-            None => edges_for_pair(state, mode_data, mode, &query, t.query_idx, &t.pair),
-        });
+        out.push(edges_for_pair(
+            state,
+            mode_data,
+            mode,
+            &query,
+            t.query_idx,
+            &t.pair,
+        ));
     }
     out
 }


### PR DESCRIPTION
PR #443's revert silently dropped the fn removal (script asserted after editing, before writing). Verified this time: `escalate_pair_with_tree` gone (grep=0), tree-misses → plain per-pair fallback, stale comment rewritten with the why-not note. 633 tests.