### PR TITLE
fix(serve): engine-clean recustomize cache key + repo-boundary rules (#444)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -883,3 +883,29 @@ The issue is that even with strict relax, the graph structure causes natural re-
 3. **Memory layout** (e.g., SoA vs AoS, rank-alignment)
 4. **Allocation reduction** (e.g., buffer reuse)
 5. **Parallelism** (only after above are exhausted)
+
+## Repo Boundaries (do not conflate)
+
+Four repos, one rule: **the only things that cross between them are data
+artifacts with documented contracts — never code, file-name conventions, or
+provider names.**
+
+| Repo | Visibility | Owns |
+|---|---|---|
+| **butterfly-osm** (this repo) | OPEN | the engine: pipeline, CCH, serve, calibration MATH (`calibrate-traffic`, boot recustomization) |
+| **butterfly-deploy** | private | build/precompute/deploy scripts, MinIO shipping, registry tags, `artifact-info` |
+| **infra** | private | k8s/Argo manifests, init containers, PVC layout (GitOps) |
+| **butterfly-speeds** | private | provider-coupled observed-speeds production: licensed feeds, segment→way_id matching, publishing `s3://butterfly-speeds/<env>/observed_speeds.parquet` |
+
+Rules for THIS repo:
+- May only consume: the `.butterfly` container + its sections, generic runtime
+  inputs at documented paths (`observed_speeds.parquet`, 3 columns: `way_id`,
+  `observed_avg_speed_kmh`, `sample_count`), and env vars.
+- Deploy-side names (`artifact-info`, MinIO buckets/keys, `mc` commands,
+  registry tags) must NOT appear in engine code. For provenance/invalidation,
+  use container-internal identity (`SectionEntry.crc`, `inputs_sha`) — the
+  #444 recustomize cache is the worked example (an `artifact-info` dependency
+  was a review-caught stale-cache bug for generic users).
+- No provider names or provider-specific logic here — that's butterfly-speeds;
+  conversely the calibration math never moves there (its docs/CONTRACT.md is
+  the seam).

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -1702,11 +1702,17 @@ impl ServerState {
 
         // #444: PVC-cached recustomization. The ~5-min calibrate+customize is
         // pure recompute when neither the observed table nor the artifact
-        // changed — key the cached weights on crc64(parquet) ⊕
-        // crc64(artifact-info) ⊕ algo version and skip straight to the flats
-        // on a hit. Cache failures are non-fatal in both directions.
+        // changed — key the cached weights on crc64(algo version ⊕ parquet ⊕
+        // the container's car TIME-weights section CRC) and skip straight to
+        // the flats on a hit. The section CRC is ENGINE-INTERNAL provenance
+        // (repo-boundary rule: no deploy-side file conventions in the open
+        // engine). Cache failures are non-fatal in both directions.
         let cache_path = observed_path.with_file_name("recustomize_cache.car.v1.bin");
-        let cache_key = recustomize_cache_key(observed_path);
+        let car_weights_crc = container
+            .get("mode/car/weights.time")
+            .map(|e| e.crc)
+            .unwrap_or(0);
+        let cache_key = recustomize_cache_key(observed_path, car_weights_crc);
         let cached = cache_key.and_then(|k| read_recustomize_cache(&cache_path, k));
 
         let (profile, new_weights, adjusted_node_weights) = if let Some(hit) = cached {
@@ -3601,15 +3607,15 @@ mod tests {
 const RECUSTOMIZE_CACHE_VERSION: &[u8] = b"recustomize-car-v1";
 
 /// Provenance key: crc64 over (algo version ⊕ observed parquet bytes ⊕ the
-/// sibling artifact-info, which changes with every artifact build). `None`
-/// (unreadable parquet) disables the cache for this boot.
-fn recustomize_cache_key(observed_path: &std::path::Path) -> Option<u64> {
+/// container's car TIME-weights section CRC). The section CRC is engine-
+/// internal — it changes with every rebuilt artifact, so the cache
+/// invalidates correctly without depending on deploy-side conventions.
+/// `None` (unreadable parquet) disables the cache for this boot.
+fn recustomize_cache_key(observed_path: &std::path::Path, car_weights_crc: u64) -> Option<u64> {
     let mut d = crate::formats::crc::Digest::new();
     d.update(RECUSTOMIZE_CACHE_VERSION);
     d.update(&std::fs::read(observed_path).ok()?);
-    if let Ok(info) = std::fs::read(observed_path.with_file_name("artifact-info")) {
-        d.update(&info);
-    }
+    d.update(&car_weights_crc.to_le_bytes());
     Some(d.finalize())
 }
 


### PR DESCRIPTION
The #445 cache keyed invalidation on `artifact-info` — a private butterfly-deploy convention leaked into the open engine, and a stale-cache bug for generic users (artifact swap + unchanged parquet → undetected). Now keyed on the container's own `mode/car/weights.time` `SectionEntry.crc` (engine-internal). CLAUDE.md gains the four-repo boundary table (butterfly-osm / -deploy / infra / -speeds). 633 tests.