### PR TITLE
fix(serve): car_freeflow dispatch + snap mask (#450)

### DIFF
--- a/route/src/server/regions.rs
+++ b/route/src/server/regions.rs
@@ -378,14 +378,13 @@ impl RegionsState {
         let (peeked_bbox, peeked_modes, peeked_tiles) = peek_region_meta(&container)
             .map(|(_, b, m, t)| (b, m, t))
             .unwrap_or((None, Vec::new(), None));
-        // Prefer the live ServerState's mode names when available — for
-        // legacy step-tree containers the manifest may not list modes
-        // but the live state knows them.
-        let mode_names = if peeked_modes.is_empty() {
-            state.mode_names.clone()
-        } else {
-            peeked_modes
-        };
+        // #450: the LOADED state's mode names are authoritative — they
+        // include runtime-synthetic modes (car_freeflow, boot-recustomized
+        // variants) that the container sections can never list. The peeked
+        // (section-derived) list is only for the lazy/Pending constructor
+        // where no state exists yet.
+        let mode_names = state.mode_names.clone();
+        let _ = peeked_modes;
         let entry = RegionEntry {
             id: id.clone(),
             container,
@@ -436,11 +435,10 @@ impl RegionsState {
                 format!("loading region '{}' from {}", region_id, path.display())
             })?;
             let metrics = super::region_metrics::RegionMetrics::new(&region_id);
-            let mode_names = if peeked_modes.is_empty() {
-                state.mode_names.clone()
-            } else {
-                peeked_modes
-            };
+            // #450: loaded state's names are authoritative (include
+            // runtime-synthetic modes); peeked is for Pending only.
+            let mode_names = state.mode_names.clone();
+            let _ = peeked_modes;
             entries.push(RegionEntry {
                 id: region_id,
                 container: path.clone(),
@@ -651,11 +649,10 @@ impl RegionsState {
                 modes = ?state.mode_names,
                 "loaded region"
             );
-            let mode_names = if peeked_modes.is_empty() {
-                state.mode_names.clone()
-            } else {
-                peeked_modes
-            };
+            // #450: loaded state's names are authoritative (include
+            // runtime-synthetic modes); peeked is for Pending only.
+            let mode_names = state.mode_names.clone();
+            let _ = peeked_modes;
             regions.push(RegionEntry {
                 id,
                 container: path,

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -1515,6 +1515,14 @@ impl ServerState {
             modes_data.push(freeflow);
             mode_lookup.insert("car_freeflow".to_string(), new_index as u8);
             mode_names.push("car_freeflow".to_string());
+            // Snap masks are indexed by mode_idx — the synthetic mode shares
+            // car's eligible-edges mask (same fix as the traffic variants;
+            // without it every snap for this mode returns None → no routes).
+            if let Some(base_mask) = snap_index.masks.get(car_idx as usize).cloned() {
+                snap_index.masks.push(base_mask);
+            } else {
+                tracing::warn!("car snap mask missing — car_freeflow snapping degraded");
+            }
             tracing::info!("registered car_freeflow (clean legal-limit base) alongside car (#450)");
         }
 


### PR DESCRIPTION
Live-found: `car_freeflow` 400'd ('Invalid mode ... across loaded regions') because region dispatch validates against peeked container-section names (can't include runtime-synthetic modes) — loaded regions now use the authoritative state mode_names. Second gap: no snap mask at the synthetic index → all snaps None; now shares car's mask like traffic variants do. 633 tests.