### PR TITLE
feat(traffic): (highway_class × density) modifier matrix, opt-in, with calibrate-traffic --matrix (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,29 @@ For detailed tool-specific changes, see individual tool changelogs:
 
 ## [Unreleased]
 
-### 2026-05-27 — Drivetime distance consistency (2-channel bucket-M2M)
+### 2026-06-10 — Traffic profiles: (highway_class × density) modifier matrix (#428)
+
+Traffic profiles (`traffic/*.traffic.json`) may now carry an opt-in 2-D
+`matrix` section refining the per-density speed-factor vector with
+per-`(highway_class × density)` cells:
+
+- **Schema**: `"matrix": {"<highway_class_code>": {"<density>": factor, ...}}`.
+  Outer keys are the numeric `highway_class` codes stored per way in
+  `way_attrs.<mode>.bin` (assigned by the build model's `highway_class`
+  table — model-defined, so the code rather than a name is the exact value
+  available at customization time). Rows may be partial: a missing
+  `(highway, density)` cell falls back to the per-density `speed_factors`
+  vector, which stays required and complete. Factors validated in
+  `[0.1, 1.5]`; unknown keys, non-canonical codes, empty matrices/rows
+  rejected. Vector-only profiles are unchanged and round-trip
+  byte-for-byte (the `matrix` key is omitted when absent).
+- **Application**: step 8 `--traffic` and the serve-boot car
+  recustomization both resolve `factor_for_cell(highway, density)` —
+  identical to the pre-#428 behavior when no matrix is present.
+- **Calibration**: `calibrate-traffic --matrix` fits the matrix from the
+  same observed table — per-cell sample-count-weighted median, same
+  clamp band, cells emitted only above `--min-samples` (omitted cells
+  fall back cell → density-marginal → global). Deterministic output.
 
 Closed #371/#372 — the matrix endpoints (`/table`, `/trip`, Flight)
 now report distance values that belong to the SAME path as the

--- a/route/src/calibrate.rs
+++ b/route/src/calibrate.rs
@@ -40,8 +40,25 @@
 //! the global all-class median — a closer proxy than a primary-road blend; only
 //! when *no* class clears the gate do we fall back to the global median. All
 //! five keys are always emitted.
+//!
+//! ## Optional matrix fit (#428)
+//!
+//! With [`CalibrationParams::fit_matrix`] (CLI `--matrix`), the fit
+//! additionally buckets the same ratios by **(highway_class × density)** —
+//! the highway axis being the model-defined u16 code step 2 stored per way in
+//! `way_attrs.<mode>.bin` — and emits a profile `matrix` section. Per cell:
+//! sample-count-weighted median, clamped to the same sanity band, **emitted
+//! only when the cell clears `min_samples`** (sum of `sample_count`). An
+//! under-sampled or unobserved cell is simply omitted: at application time it
+//! falls back to the per-density vector (the density marginal), which itself
+//! falls back own-median → nearest-class → global — giving the
+//! cell → density-marginal → global hierarchy without ever duplicating a
+//! fallback value into the matrix. The per-density vector is always fitted
+//! and emitted regardless, so a matrix profile degrades gracefully to the
+//! vector everywhere the matrix is silent. Output is deterministic
+//! (`BTreeMap` bucketing + stable sorts).
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use anyhow::{Context, Result, bail, ensure};
@@ -78,6 +95,12 @@ pub struct CalibrationParams {
     /// profile schema's hard bounds `[MIN_FACTOR, MAX_FACTOR]`.
     pub clamp_min: f32,
     pub clamp_max: f32,
+    /// #428: when true, additionally fit a (highway_class × density) factor
+    /// matrix (see the module docs). Only cells clearing `min_samples` are
+    /// emitted; everything else falls back to the per-density vector at
+    /// application time. Off by default — the per-density profile stays the
+    /// default output.
+    pub fit_matrix: bool,
 }
 
 impl Default for CalibrationParams {
@@ -88,6 +111,7 @@ impl Default for CalibrationParams {
             min_samples: 100,
             clamp_min: 0.30,
             clamp_max: 1.20,
+            fit_matrix: false,
         }
     }
 }
@@ -159,12 +183,36 @@ pub struct ClassFit {
     pub factor: f32,
 }
 
+/// #428: per-(highway_class × density) cell diagnostic for the matrix fit.
+/// One entry per cell with at least one joined observation, ordered by
+/// (highway code, density) — deterministic.
+#[derive(Debug, Clone)]
+pub struct CellFit {
+    /// Model-defined highway-class code from `way_attrs.<mode>.bin`.
+    pub highway_class: u16,
+    pub class: DensityClass,
+    /// Joined observation rows landing in this cell.
+    pub n_obs: usize,
+    /// Sum of `sample_count` over those rows.
+    pub total_samples: u64,
+    /// Weighted-median ratio from this cell's own observations, before clamping.
+    pub raw_factor: f32,
+    /// True when the cell cleared `min_samples` and was written to the
+    /// profile matrix; false → omitted, falls back to the per-density vector.
+    pub emitted: bool,
+    /// Clamped factor written to the matrix; `None` when not emitted.
+    pub factor: Option<f32>,
+}
+
 /// Result of a fit: the ready-to-write profile plus diagnostics.
 #[derive(Debug, Clone)]
 pub struct CalibrationResult {
     pub profile: TrafficProfile,
     /// One entry per density class, in [`DensityClass::ALL`] order.
     pub per_class: Vec<ClassFit>,
+    /// #428: matrix-fit diagnostics; empty unless
+    /// [`CalibrationParams::fit_matrix`] was set.
+    pub per_cell: Vec<CellFit>,
     /// Observation rows joined to a way in the index.
     pub matched: usize,
     /// Observation rows whose `way_id` was absent from the index.
@@ -177,16 +225,21 @@ pub struct CalibrationResult {
     pub global_factor: f32,
 }
 
-/// Build the `way_id -> (base_speed_kmh, density_class_u8)` lookup from a
-/// loaded `way_attrs.<mode>.bin`. Base speed is converted from mm/s to km/h
-/// once here (`mm/s * 3600 / 1e6 = km/h`).
-pub fn index_ways(attrs: &[way_attrs::WayAttr]) -> HashMap<i64, (f32, u8)> {
-    let mut map: HashMap<i64, (f32, u8)> = HashMap::with_capacity(attrs.len());
+/// Build the `way_id -> (base_speed_kmh, density_class_u8, highway_class_u16)`
+/// lookup from a loaded `way_attrs.<mode>.bin`. Base speed is converted from
+/// mm/s to km/h once here (`mm/s * 3600 / 1e6 = km/h`). The highway class is
+/// the model-defined code step 2 stored per way — the matrix fit's highway
+/// axis (#428).
+pub fn index_ways(attrs: &[way_attrs::WayAttr]) -> HashMap<i64, (f32, u8, u16)> {
+    let mut map: HashMap<i64, (f32, u8, u16)> = HashMap::with_capacity(attrs.len());
     for wa in attrs {
         let base_kmh = wa.output.base_speed_mmps as f32 * 0.003_6;
         // way_attrs is sorted by way_id and ids are unique per mode, so the
         // last-writer-wins of insert is irrelevant; keep it simple.
-        map.insert(wa.way_id, (base_kmh, wa.output.density_class));
+        map.insert(
+            wa.way_id,
+            (base_kmh, wa.output.density_class, wa.output.highway_class),
+        );
     }
     map
 }
@@ -218,26 +271,32 @@ fn weighted_median(samples: &mut [(f32, u64)]) -> Option<f32> {
 /// Pure fitting core — no I/O. Buckets observations by the density class of
 /// their way, computes a sample-count-weighted median of `observed/base`
 /// ratios per class, clamps, and falls back to the global median for
-/// under-sampled classes.
+/// under-sampled classes. With [`CalibrationParams::fit_matrix`] the same
+/// ratios are additionally bucketed by (highway_class × density) and a
+/// profile `matrix` section is emitted (#428, see the module docs).
 ///
 /// Errors only when *nothing* joins (no way in the index matched any
 /// observation, or every matched row had a non-positive base/observed speed),
 /// since then there is no signal to fit and no defensible profile to emit.
 pub fn fit(
     observations: &[Observation],
-    way_index: &HashMap<i64, (f32, u8)>,
+    way_index: &HashMap<i64, (f32, u8, u16)>,
     params: &CalibrationParams,
 ) -> Result<CalibrationResult> {
     params.validate()?;
 
     let mut buckets: [Vec<(f32, u64)>; 5] = Default::default();
+    // #428: (highway_class, density) cell buckets — BTreeMap for
+    // deterministic iteration order. Only populated when fitting the matrix.
+    let mut cell_buckets: BTreeMap<u16, [Vec<(f32, u64)>; 5]> = BTreeMap::new();
     let mut global: Vec<(f32, u64)> = Vec::new();
     let mut matched = 0usize;
     let mut unmatched = 0usize;
     let mut skipped_bad = 0usize;
 
     for obs in observations {
-        let Some((base_kmh, density_u8)) = way_index.get(&obs.way_id).copied() else {
+        let Some((base_kmh, density_u8, highway_class)) = way_index.get(&obs.way_id).copied()
+        else {
             unmatched += 1;
             continue;
         };
@@ -257,6 +316,9 @@ pub fn fit(
         let class = DensityClass::from_u8(density_u8);
         let w = obs.sample_count.max(1) as u64;
         buckets[class.to_u8() as usize].push((ratio, w));
+        if params.fit_matrix {
+            cell_buckets.entry(highway_class).or_default()[class.to_u8() as usize].push((ratio, w));
+        }
         global.push((ratio, w));
         matched += 1;
     }
@@ -326,16 +388,62 @@ pub fn fit(
         });
     }
 
+    // #428: matrix fit — per (highway_class, density) cell weighted median,
+    // emitted only when the cell clears `min_samples`. Untrusted/unobserved
+    // cells are OMITTED so application falls back to the per-density vector
+    // (the density marginal), which itself carries the own → nearest-class →
+    // global hierarchy resolved above. Deterministic: cell_buckets is a
+    // BTreeMap and densities iterate in canonical order.
+    let mut matrix: BTreeMap<u16, crate::traffic::MatrixRow> = BTreeMap::new();
+    let mut per_cell: Vec<CellFit> = Vec::new();
+    for (highway_class, rows) in cell_buckets.iter_mut() {
+        let mut row: crate::traffic::MatrixRow = [None; 5];
+        let mut any = false;
+        for class in DensityClass::ALL {
+            let idx = class.to_u8() as usize;
+            let bucket = &mut rows[idx];
+            if bucket.is_empty() {
+                continue;
+            }
+            let n_obs = bucket.len();
+            let total_samples: u64 = bucket.iter().map(|(_, w)| *w).sum();
+            let raw = weighted_median(bucket).expect("non-empty bucket has a median");
+            let emitted = total_samples >= params.min_samples as u64;
+            let factor = if emitted {
+                let f = raw.clamp(params.clamp_min, params.clamp_max);
+                row[idx] = Some(f);
+                any = true;
+                Some(f)
+            } else {
+                None
+            };
+            per_cell.push(CellFit {
+                highway_class: *highway_class,
+                class,
+                n_obs,
+                total_samples,
+                raw_factor: raw,
+                emitted,
+                factor,
+            });
+        }
+        if any {
+            matrix.insert(*highway_class, row);
+        }
+    }
+
     let profile = TrafficProfile {
         name: params.name.clone(),
         base_model: params.base_model.clone(),
         factors,
+        matrix,
     };
 
     // Defensive guarantee: the emitted profile must satisfy the exact schema
-    // step 8 validates (all five keys, each in [0.1, 1.5]). Round-tripping it
-    // here turns any future drift in the clamp logic into a loud failure at
-    // calibration time rather than a silent reject at customization time.
+    // step 8 validates (all five keys + any matrix cells, each in [0.1, 1.5]).
+    // Round-tripping it here turns any future drift in the clamp logic into a
+    // loud failure at calibration time rather than a silent reject at
+    // customization time.
     let json = profile.to_json_string()?;
     TrafficProfile::from_json(&json)
         .context("internal error: calibrated profile failed its own schema validation")?;
@@ -343,6 +451,7 @@ pub fn fit(
     Ok(CalibrationResult {
         profile,
         per_class,
+        per_cell,
         matched,
         unmatched,
         skipped_bad,
@@ -611,10 +720,19 @@ mod tests {
     use super::*;
     use std::io::Write;
 
-    /// Build a way index from `(way_id, base_kmh, class)` triples.
-    fn idx(rows: &[(i64, f32, DensityClass)]) -> HashMap<i64, (f32, u8)> {
+    /// Build a way index from `(way_id, base_kmh, class)` triples
+    /// (highway_class 0 — fine for vector-only fits).
+    fn idx(rows: &[(i64, f32, DensityClass)]) -> HashMap<i64, (f32, u8, u16)> {
         rows.iter()
-            .map(|(id, base, c)| (*id, (*base, c.to_u8())))
+            .map(|(id, base, c)| (*id, (*base, c.to_u8(), 0u16)))
+            .collect()
+    }
+
+    /// Build a way index from `(way_id, base_kmh, class, highway_class)`
+    /// quadruples — for matrix fits (#428).
+    fn idx_hw(rows: &[(i64, f32, DensityClass, u16)]) -> HashMap<i64, (f32, u8, u16)> {
+        rows.iter()
+            .map(|(id, base, c, hw)| (*id, (*base, c.to_u8(), *hw)))
             .collect()
     }
 
@@ -972,6 +1090,160 @@ mod tests {
         assert_eq!(obs[0].sample_count, 5);
         assert_eq!(obs[2].way_id, 300);
         assert_eq!(obs[2].sample_count, 1);
+    }
+
+    // ---- #428 matrix fit -------------------------------------------------
+
+    fn matrix_params() -> CalibrationParams {
+        CalibrationParams {
+            fit_matrix: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn matrix_fit_recovers_known_per_cell_ratios() {
+        // Two highway codes inside the SAME density class with different
+        // observed ratios — exactly what the per-density vector cannot
+        // express and the matrix can. motorway(1)×Rural at 0.95,
+        // trunk(3)×Rural at 0.70, residential(12)×UrbanHigh at 0.50.
+        let index = idx_hw(&[
+            (1, 100.0, DensityClass::Rural, 1),
+            (2, 100.0, DensityClass::Rural, 3),
+            (3, 100.0, DensityClass::UrbanHigh, 12),
+        ]);
+        let mut observations = Vec::new();
+        for _ in 0..150 {
+            observations.push(obs(1, 95.0, 1));
+            observations.push(obs(2, 70.0, 1));
+            observations.push(obs(3, 50.0, 1));
+        }
+        let res = fit(&observations, &index, &matrix_params()).unwrap();
+        assert!(res.profile.has_matrix());
+        assert_eq!(res.profile.matrix.len(), 3);
+        let f = |hw: u16, c: DensityClass| res.profile.factor_for_cell(hw, c);
+        assert!((f(1, DensityClass::Rural) - 0.95).abs() < 1e-4);
+        assert!((f(3, DensityClass::Rural) - 0.70).abs() < 1e-4);
+        assert!((f(12, DensityClass::UrbanHigh) - 0.50).abs() < 1e-4);
+        // The vector's Rural marginal blends both motorway and trunk ratios.
+        let rural_vec = res.profile.factor_for(DensityClass::Rural);
+        assert!(
+            (0.70..=0.95).contains(&rural_vec),
+            "rural marginal {rural_vec} should blend 0.70 and 0.95"
+        );
+        // Cell diagnostics present, all emitted.
+        assert_eq!(res.per_cell.len(), 3);
+        assert!(res.per_cell.iter().all(|c| c.emitted));
+    }
+
+    #[test]
+    fn matrix_fit_omits_undersampled_cells_falling_back_to_vector() {
+        // motorway(1)×Rural well-sampled at 0.95; trunk(3)×Rural starved
+        // (5 obs < min_samples 100) → the cell must NOT be emitted, and the
+        // application-time lookup for trunk×Rural must return the density
+        // marginal (the vector's Rural factor).
+        let index = idx_hw(&[
+            (1, 100.0, DensityClass::Rural, 1),
+            (2, 100.0, DensityClass::Rural, 3),
+        ]);
+        let mut observations = Vec::new();
+        for _ in 0..200 {
+            observations.push(obs(1, 95.0, 1));
+        }
+        for _ in 0..5 {
+            observations.push(obs(2, 40.0, 1));
+        }
+        let res = fit(&observations, &index, &matrix_params()).unwrap();
+        // Code 3's only cell is untrusted → no row for code 3 at all.
+        assert!(res.profile.matrix.contains_key(&1));
+        assert!(!res.profile.matrix.contains_key(&3));
+        let rural_vec = res.profile.factor_for(DensityClass::Rural);
+        assert_eq!(
+            res.profile.factor_for_cell(3, DensityClass::Rural),
+            rural_vec,
+            "untrusted cell must fall back to the density marginal"
+        );
+        // Diagnostics still record the starved cell, marked not-emitted.
+        let starved = res
+            .per_cell
+            .iter()
+            .find(|c| c.highway_class == 3 && c.class == DensityClass::Rural)
+            .unwrap();
+        assert!(!starved.emitted);
+        assert_eq!(starved.factor, None);
+        assert_eq!(starved.n_obs, 5);
+    }
+
+    #[test]
+    fn matrix_fit_is_deterministic() {
+        let index = idx_hw(&[
+            (1, 100.0, DensityClass::Rural, 1),
+            (2, 100.0, DensityClass::Suburban, 3),
+            (3, 50.0, DensityClass::UrbanHigh, 12),
+            (4, 80.0, DensityClass::UrbanMedium, 7),
+        ]);
+        let mut observations = Vec::new();
+        for i in 0..400 {
+            observations.push(obs(1 + (i % 4) as i64, 30.0 + (i % 50) as f32, 1 + (i % 3)));
+        }
+        let a = fit(&observations, &index, &matrix_params()).unwrap();
+        let b = fit(&observations, &index, &matrix_params()).unwrap();
+        assert_eq!(a.profile, b.profile);
+        assert_eq!(
+            a.profile.to_json_string().unwrap(),
+            b.profile.to_json_string().unwrap(),
+            "two fits over the same input must serialize byte-identically"
+        );
+    }
+
+    #[test]
+    fn matrix_fit_clamps_cells_into_the_sanity_band() {
+        let p = CalibrationParams {
+            min_samples: 1,
+            fit_matrix: true,
+            ..Default::default()
+        };
+        let index = idx_hw(&[
+            (1, 100.0, DensityClass::UrbanHigh, 12),
+            (2, 100.0, DensityClass::Rural, 1),
+        ]);
+        // ratio 5.0 → clamp 1.20; ratio 0.02 → clamp 0.30.
+        let observations = vec![obs(1, 500.0, 10), obs(2, 2.0, 10)];
+        let res = fit(&observations, &index, &p).unwrap();
+        assert_eq!(
+            res.profile.factor_for_cell(12, DensityClass::UrbanHigh),
+            1.20
+        );
+        assert_eq!(res.profile.factor_for_cell(1, DensityClass::Rural), 0.30);
+    }
+
+    #[test]
+    fn matrix_off_by_default_emits_vector_only_profile() {
+        let index = idx_hw(&[(1, 100.0, DensityClass::UrbanHigh, 12)]);
+        let observations: Vec<_> = (0..200).map(|_| obs(1, 60.0, 1)).collect();
+        let res = fit(&observations, &index, &CalibrationParams::default()).unwrap();
+        assert!(!res.profile.has_matrix());
+        assert!(res.per_cell.is_empty());
+        let json = res.profile.to_json_string().unwrap();
+        assert!(!json.contains("matrix"), "unexpected matrix key in {json}");
+    }
+
+    #[test]
+    fn emitted_matrix_profile_passes_schema_validation() {
+        let index = idx_hw(&[
+            (1, 100.0, DensityClass::Rural, 1),
+            (2, 100.0, DensityClass::UrbanHigh, 12),
+        ]);
+        let mut observations = Vec::new();
+        for _ in 0..150 {
+            observations.push(obs(1, 95.0, 1));
+            observations.push(obs(2, 50.0, 1));
+        }
+        let res = fit(&observations, &index, &matrix_params()).unwrap();
+        let json = res.profile.to_json_string().unwrap();
+        let reparsed = TrafficProfile::from_json(&json).unwrap();
+        assert_eq!(reparsed, res.profile);
+        assert!(json.contains("\"matrix\""));
     }
 
     /// End-to-end through the production `way_attrs.<mode>.bin` writer +

--- a/route/src/calibrate.rs
+++ b/route/src/calibrate.rs
@@ -1312,6 +1312,138 @@ mod tests {
         // Profile is schema-valid and writeable.
         TrafficProfile::from_json(&res.profile.to_json_string().unwrap()).unwrap();
     }
+
+    /// #428 matrix counterpart of the e2e test above: end-to-end through the
+    /// production CRC-validated `way_attrs.<mode>.bin` v2 writer + reader and
+    /// the CSV adapter, with DISTINCT highway_class codes and per-cell
+    /// observed ratios planted. Proves `run_calibration` with
+    /// `fit_matrix: true` emits a matrix that SEPARATES two cells inside the
+    /// same density class (motorway×rural 0.95 vs trunk×rural 0.70 — exactly
+    /// what the per-density vector cannot express) while a starved cell is
+    /// omitted and falls back to the density marginal at application time.
+    #[test]
+    fn run_calibration_end_to_end_matrix_on_real_way_attrs_format() {
+        use crate::formats::way_attrs::{self as wa, WayAttr};
+        use crate::profile_abi::{Mode, WayOutput};
+
+        const MOTORWAY: u16 = 1;
+        const TRUNK: u16 = 3;
+        const RESIDENTIAL: u16 = 12;
+        const SERVICE: u16 = 13;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        let mmps = |kmh: f32| (kmh / 0.003_6) as u32;
+        let mut attrs: Vec<WayAttr> = Vec::new();
+        let mut plant = |ids: std::ops::Range<i64>, kmh: f32, density: DensityClass, hw: u16| {
+            for id in ids {
+                attrs.push(WayAttr {
+                    way_id: id,
+                    output: WayOutput {
+                        base_speed_mmps: mmps(kmh),
+                        density_class: density.to_u8(),
+                        highway_class: hw,
+                        ..Default::default()
+                    },
+                });
+            }
+        };
+        // Two highway codes inside the SAME density class (Rural) — the
+        // separation the per-density vector cannot express.
+        plant(0..150, 120.0, DensityClass::Rural, MOTORWAY);
+        plant(1000..1150, 100.0, DensityClass::Rural, TRUNK);
+        // A well-sampled UrbanHigh cell pins the density marginal at 0.50...
+        plant(2000..2150, 50.0, DensityClass::UrbanHigh, RESIDENTIAL);
+        // ...and a starved cell (5 obs < min_samples 100) at ratio 0.30 must
+        // NOT be emitted: lookups for it fall back to that 0.50 marginal.
+        plant(3000..3005, 50.0, DensityClass::UrbanHigh, SERVICE);
+
+        let wa_path = dir.path().join("way_attrs.car.bin");
+        wa::write(&wa_path, Mode(0), &attrs, &[0u8; 32], &[0u8; 32]).unwrap();
+
+        let obs_path = dir.path().join("obs.csv");
+        let mut f = std::fs::File::create(&obs_path).unwrap();
+        writeln!(f, "way_id,observed_avg_speed_kmh,sample_count").unwrap();
+        for id in 0..150i64 {
+            writeln!(f, "{id},114.0,1").unwrap(); // 114 / 120 = 0.95
+        }
+        for id in 1000..1150i64 {
+            writeln!(f, "{id},70.0,1").unwrap(); // 70 / 100 = 0.70
+        }
+        for id in 2000..2150i64 {
+            writeln!(f, "{id},25.0,1").unwrap(); // 25 / 50 = 0.50
+        }
+        for id in 3000..3005i64 {
+            writeln!(f, "{id},15.0,1").unwrap(); // 15 / 50 = 0.30, starved
+        }
+        f.flush().unwrap();
+
+        let params = CalibrationParams {
+            fit_matrix: true,
+            ..Default::default()
+        };
+        let res = run_calibration(&obs_path, &wa_path, &params).unwrap();
+        assert_eq!(res.matched, 455);
+        assert_eq!(res.unmatched, 0);
+
+        // The matrix separates motorway×rural from trunk×rural.
+        assert!(res.profile.has_matrix());
+        assert!(res.profile.matrix.contains_key(&MOTORWAY));
+        assert!(res.profile.matrix.contains_key(&TRUNK));
+        assert!(res.profile.matrix.contains_key(&RESIDENTIAL));
+        let cell = |hw: u16, c: DensityClass| res.profile.factor_for_cell(hw, c);
+        assert!(
+            (cell(MOTORWAY, DensityClass::Rural) - 0.95).abs() < 1e-3,
+            "motorway×rural: {}",
+            cell(MOTORWAY, DensityClass::Rural)
+        );
+        assert!(
+            (cell(TRUNK, DensityClass::Rural) - 0.70).abs() < 1e-3,
+            "trunk×rural: {}",
+            cell(TRUNK, DensityClass::Rural)
+        );
+        assert!(
+            (cell(RESIDENTIAL, DensityClass::UrbanHigh) - 0.50).abs() < 1e-3,
+            "residential×urban_high: {}",
+            cell(RESIDENTIAL, DensityClass::UrbanHigh)
+        );
+        // The vector's Rural marginal is a blend — it cannot carry both.
+        let rural_vec = res.profile.factor_for(DensityClass::Rural);
+        assert!(
+            (0.70 - 1e-3..=0.95 + 1e-3).contains(&rural_vec),
+            "rural marginal {rural_vec} should blend 0.70 and 0.95"
+        );
+
+        // The starved service×urban_high cell is OMITTED (no row for code 13)
+        // and application-time lookup falls back to the density marginal —
+        // NOT the starved cell's own 0.30 ratio.
+        assert!(!res.profile.matrix.contains_key(&SERVICE));
+        let urban_high_vec = res.profile.factor_for(DensityClass::UrbanHigh);
+        assert_eq!(
+            cell(SERVICE, DensityClass::UrbanHigh),
+            urban_high_vec,
+            "starved cell must fall back to the density marginal"
+        );
+        assert!(
+            (urban_high_vec - 0.50).abs() < 1e-3,
+            "urban_high marginal {urban_high_vec} pinned by the residential mass"
+        );
+        // Diagnostics record the starved cell, marked not-emitted.
+        let starved = res
+            .per_cell
+            .iter()
+            .find(|c| c.highway_class == SERVICE && c.class == DensityClass::UrbanHigh)
+            .unwrap();
+        assert!(!starved.emitted);
+        assert_eq!(starved.factor, None);
+        assert_eq!(starved.n_obs, 5);
+
+        // The emitted profile passes the exact schema step 8 validates.
+        let json = res.profile.to_json_string().unwrap();
+        let reparsed = TrafficProfile::from_json(&json).unwrap();
+        assert_eq!(reparsed, res.profile);
+        assert!(json.contains("\"matrix\""));
+    }
 }
 
 // =====================================================================

--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -1312,6 +1312,14 @@ pub enum Commands {
         #[arg(long, default_value_t = 1.20)]
         clamp_max: f32,
 
+        /// #428: additionally fit a (highway_class × density) factor matrix.
+        /// The highway axis is the model-defined u16 code stored per way in
+        /// way_attrs.<mode>.bin. Only cells clearing --min-samples are
+        /// emitted; omitted cells fall back to the per-density vector at
+        /// application time. Off by default (vector-only profile).
+        #[arg(long)]
+        matrix: bool,
+
         /// Output `*.traffic.json` path.
         #[arg(long)]
         out: PathBuf,
@@ -2915,6 +2923,7 @@ impl Cli {
                 min_samples,
                 clamp_min,
                 clamp_max,
+                matrix,
                 out,
             } => {
                 let wa_path = match (way_attrs, data_dir) {
@@ -2936,6 +2945,7 @@ impl Cli {
                     min_samples,
                     clamp_min,
                     clamp_max,
+                    fit_matrix: matrix,
                 };
                 let result = crate::calibrate::run_calibration(&observations, &wa_path, &params)?;
 
@@ -2970,6 +2980,35 @@ impl Cli {
                         source,
                         cf.factor
                     );
+                }
+
+                if matrix {
+                    let emitted = result.per_cell.iter().filter(|c| c.emitted).count();
+                    eprintln!(
+                        "matrix (#428): {} highway rows, {}/{} cells emitted (omitted cells fall back to the density vector)",
+                        result.profile.matrix.len(),
+                        emitted,
+                        result.per_cell.len()
+                    );
+                    eprintln!(
+                        "{:>8} {:<14} {:>10} {:>12} {:>10} {:>10}",
+                        "highway", "density", "n_obs", "samples", "raw", "factor"
+                    );
+                    for cell in &result.per_cell {
+                        let factor = cell
+                            .factor
+                            .map(|f| format!("{f:.3}"))
+                            .unwrap_or_else(|| "(vector)".to_string());
+                        eprintln!(
+                            "{:>8} {:<14} {:>10} {:>12} {:>10.3} {:>10}",
+                            cell.highway_class,
+                            cell.class.as_str(),
+                            cell.n_obs,
+                            cell.total_samples,
+                            cell.raw_factor,
+                            factor
+                        );
+                    }
                 }
 
                 let json = result.profile.to_json_string()?;

--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -1910,7 +1910,31 @@ impl Cli {
                         })?;
                         let profile = crate::traffic::TrafficProfile::load(&traffic_path)?;
                         // Validate base_model matches the mode we're customizing.
+                        // For profiles carrying a (highway_class × density)
+                        // matrix this is a HARD error: matrix keys are the
+                        // model-specific highway_class codes from
+                        // way_attrs.<mode>.bin (e.g. code 12 is residential in
+                        // the car model but maps to a different road type in
+                        // bike/foot), so applying the matrix to another mode
+                        // would silently scale the wrong roads. Vector-only
+                        // profiles key on the shared density classes, so a
+                        // mismatch stays a warning.
                         if profile.base_model != mode_name_str {
+                            if profile.has_matrix() {
+                                anyhow::bail!(
+                                    "traffic profile base_model='{}' but customizing mode='{}': \
+                                     the profile carries a (highway_class × density) matrix, and \
+                                     matrix highway-class codes are model-specific (the same code \
+                                     names different road types in different models), so applying \
+                                     it to another mode would scale the wrong roads. Re-run \
+                                     calibrate-traffic against way_attrs.{}.bin (emitting \
+                                     base_model='{}') or use a vector-only profile.",
+                                    profile.base_model,
+                                    mode_name_str,
+                                    mode_name_str,
+                                    mode_name_str
+                                );
+                            }
                             println!(
                                 "⚠️  warning: traffic profile base_model='{}' but customizing mode='{}'. Proceeding.",
                                 profile.base_model, mode_name_str

--- a/route/src/customization.rs
+++ b/route/src/customization.rs
@@ -698,8 +698,10 @@ pub(crate) fn apply_traffic_to_node_weights_in_memory(
     // (highway_class × density) matrix rows resolved to inverse factors, with
     // unspecified cells pre-filled from the vector (#428). Empty when the
     // profile has no matrix — the per-node lookup then always falls through
-    // to `inv_factors`, reproducing the pre-#428 behavior bit-for-bit.
-    let inv_matrix: HashMap<u16, [f64; 5]> = profile
+    // to `inv_factors`, reproducing the pre-#428 behavior bit-for-bit. Each
+    // row carries a hit counter so rows whose highway code never occurs in
+    // this graph can be flagged after the pass.
+    let mut inv_matrix: HashMap<u16, ([f64; 5], u64)> = profile
         .matrix
         .iter()
         .map(|(code, row)| {
@@ -709,7 +711,7 @@ pub(crate) fn apply_traffic_to_node_weights_in_memory(
                     inv[i] = 1.0 / *f as f64;
                 }
             }
-            (*code, inv)
+            (*code, (inv, 0u64))
         })
         .collect();
 
@@ -737,8 +739,11 @@ pub(crate) fn apply_traffic_to_node_weights_in_memory(
         let inv = match way_cell.get(&way_id) {
             Some((highway, class)) => {
                 let class_idx = (*class as usize).min(4);
-                match inv_matrix.get(highway) {
-                    Some(row) => row[class_idx],
+                match inv_matrix.get_mut(highway) {
+                    Some((row, hits)) => {
+                        *hits += 1;
+                        row[class_idx]
+                    }
                     None => inv_factors[class_idx],
                 }
             }
@@ -771,6 +776,21 @@ pub(crate) fn apply_traffic_to_node_weights_in_memory(
         100.0 * adjusted as f64 / weights.len() as f64,
         missing_way
     );
+
+    // Flag matrix rows whose highway code matched zero ways: the row is dead
+    // weight, and a profile full of dead rows usually means it was calibrated
+    // against a different model's highway_class table. Iterate the profile's
+    // BTreeMap so the output order is deterministic.
+    for code in profile.matrix.keys() {
+        let hits = inv_matrix.get(code).map_or(0, |(_, h)| *h);
+        if hits == 0 {
+            eprintln!(
+                "  ⚠️  traffic matrix row {code} matched zero ways — highway_class \
+                 code {code} does not occur in this graph's way_attrs (profile \
+                 calibrated against a different model, or stale?)"
+            );
+        }
+    }
 
     Ok(())
 }

--- a/route/src/customization.rs
+++ b/route/src/customization.rs
@@ -193,6 +193,21 @@ pub fn customize_cch(config: Step8Config) -> Result<Step8Result> {
                 t.profile.factor_for(class)
             );
         }
+        if t.profile.has_matrix() {
+            println!(
+                "  + (highway_class × density) matrix: {} highway rows (cells override the vector; missing cells fall back)",
+                t.profile.matrix.len()
+            );
+            for (code, row) in &t.profile.matrix {
+                let cells: Vec<String> = crate::density::DensityClass::ALL
+                    .iter()
+                    .filter_map(|c| {
+                        row[c.to_u8() as usize].map(|f| format!("{}={:.3}", c.as_str(), f))
+                    })
+                    .collect();
+                println!("    matrix[{}]: {}", code, cells.join(", "));
+            }
+        }
     } else {
         println!("\n🎨 Step 8: Customizing CCH for {}...\n", mode_name);
     }
@@ -610,8 +625,10 @@ pub fn customize_cch_time_in_memory(
 ///
 /// For every accessible EBG node `n`:
 ///   - `way_id = nbg_geo.edges[ebg_nodes[n].geom_idx].first_osm_way_id`
-///   - `class  = way_attrs[way_id].density_class`
-///   - `factor = profile.factor_for(class)`
+///   - `(highway, class) = way_attrs[way_id].{highway_class, density_class}`
+///   - `factor = profile.factor_for_cell(highway, class)` — the
+///     `(highway_class × density)` matrix cell when the profile has one
+///     (#428), else the per-density vector factor
 ///   - `weights[n] = round(weights[n] / factor)` saturating at u32::MAX,
 ///     preserving the `0 = inaccessible` sentinel.
 ///
@@ -663,10 +680,11 @@ pub(crate) fn apply_traffic_to_node_weights_in_memory(
     use crate::density::DensityClass;
     use std::collections::HashMap;
 
-    // way_id -> density class lookup
-    let way_density: HashMap<i64, u8> = way_attrs_slice
+    // way_id -> (highway_class, density_class) lookup. The highway class is
+    // the model-defined u16 code step 2 stored in way_attrs (#428).
+    let way_cell: HashMap<i64, (u16, u8)> = way_attrs_slice
         .iter()
-        .map(|w| (w.way_id, w.output.density_class))
+        .map(|w| (w.way_id, (w.output.highway_class, w.output.density_class)))
         .collect();
 
     // Pre-compute the inverse factors as fixed-point rationals to avoid f32
@@ -676,6 +694,24 @@ pub(crate) fn apply_traffic_to_node_weights_in_memory(
         let class = DensityClass::from_u8(i as u8);
         1.0 / profile.factor_for(class) as f64
     });
+
+    // (highway_class × density) matrix rows resolved to inverse factors, with
+    // unspecified cells pre-filled from the vector (#428). Empty when the
+    // profile has no matrix — the per-node lookup then always falls through
+    // to `inv_factors`, reproducing the pre-#428 behavior bit-for-bit.
+    let inv_matrix: HashMap<u16, [f64; 5]> = profile
+        .matrix
+        .iter()
+        .map(|(code, row)| {
+            let mut inv = inv_factors;
+            for (i, cell) in row.iter().enumerate() {
+                if let Some(f) = cell {
+                    inv[i] = 1.0 / *f as f64;
+                }
+            }
+            (*code, inv)
+        })
+        .collect();
 
     let mut adjusted = 0usize;
     let mut missing_way = 0usize;
@@ -698,15 +734,21 @@ pub(crate) fn apply_traffic_to_node_weights_in_memory(
             continue;
         }
         let way_id = nbg_geo.edges[geom_idx].first_osm_way_id;
-        let class_idx = match way_density.get(&way_id) {
-            Some(c) => *c as usize,
+        let inv = match way_cell.get(&way_id) {
+            Some((highway, class)) => {
+                let class_idx = (*class as usize).min(4);
+                match inv_matrix.get(highway) {
+                    Some(row) => row[class_idx],
+                    None => inv_factors[class_idx],
+                }
+            }
             None => {
-                // Treat unknown ways as Suburban (neutral).
+                // Treat unknown ways as Suburban (neutral) on the vector —
+                // their highway class is unknown, so no matrix row applies.
                 missing_way += 1;
-                3
+                inv_factors[3]
             }
         };
-        let inv = inv_factors[class_idx.min(4)];
         // weight / factor = weight * (1 / factor). Keep ≥ 1 to preserve the
         // accessibility invariant (only 0 means inaccessible).
         let scaled = (weights[i] as f64 * inv).round();
@@ -1714,5 +1756,151 @@ mod determinism_tests {
             got_dm, want_dm,
             "down middles diverged from CLI customize_cch"
         );
+    }
+}
+
+#[cfg(test)]
+mod traffic_apply_tests {
+    use super::*;
+    use crate::density::DensityClass;
+    use crate::formats::{EbgNode, NbgEdge, NbgGeo};
+    use crate::profile_abi::WayOutput;
+    use crate::traffic::TrafficProfile;
+    use std::collections::BTreeMap;
+
+    /// Synthetic 4-node fixture: one EBG node per way, ways spanning two
+    /// highway classes × two density classes, all weights 1000.
+    ///
+    /// | node | way | highway_class | density    |
+    /// |------|-----|---------------|------------|
+    /// | 0    | 10  | 1 (motorway)  | Rural      |
+    /// | 1    | 11  | 12 (resid.)   | UrbanHigh  |
+    /// | 2    | 12  | 12 (resid.)   | Rural      |
+    /// | 3    | 13  | 7 (secondary) | Suburban   |
+    fn fixture() -> (EbgNodes, NbgGeo, Vec<way_attrs::WayAttr>) {
+        let mk_node = |geom_idx: u32| EbgNode {
+            tail_nbg: 0,
+            head_nbg: 1,
+            geom_idx,
+            length_m: 10,
+            class_bits: 0,
+            primary_way: 0,
+        };
+        let ebg_nodes = EbgNodes {
+            n_nodes: 4,
+            created_unix: 0,
+            inputs_sha: [0; 32],
+            nodes: ArcCow::from_vec(vec![mk_node(0), mk_node(1), mk_node(2), mk_node(3)]),
+        };
+        let mk_edge = |way_id: i64| NbgEdge {
+            u_node: 0,
+            v_node: 1,
+            length_mm: 10_000,
+            bearing_deci_deg: 0,
+            n_poly_pts: 0,
+            poly_off: 0,
+            first_osm_way_id: way_id,
+            flags: 0,
+        };
+        let nbg_geo = NbgGeo {
+            n_edges_und: 4,
+            edges: vec![mk_edge(10), mk_edge(11), mk_edge(12), mk_edge(13)],
+            polylines: vec![],
+        };
+        let mk_attr = |way_id: i64, highway: u16, density: DensityClass| way_attrs::WayAttr {
+            way_id,
+            output: WayOutput {
+                access_fwd: true,
+                base_speed_mmps: 10_000,
+                highway_class: highway,
+                density_class: density.to_u8(),
+                ..Default::default()
+            },
+        };
+        let attrs = vec![
+            mk_attr(10, 1, DensityClass::Rural),
+            mk_attr(11, 12, DensityClass::UrbanHigh),
+            mk_attr(12, 12, DensityClass::Rural),
+            mk_attr(13, 7, DensityClass::Suburban),
+        ];
+        (ebg_nodes, nbg_geo, attrs)
+    }
+
+    fn vector_profile() -> TrafficProfile {
+        TrafficProfile {
+            name: "vec".to_string(),
+            base_model: "car".to_string(),
+            factors: [0.5, 0.6, 0.7, 0.8, 0.9],
+            matrix: BTreeMap::new(),
+        }
+    }
+
+    fn apply(profile: &TrafficProfile) -> Vec<u32> {
+        let (ebg_nodes, nbg_geo, attrs) = fixture();
+        let mut weights = vec![1000u32; 4];
+        apply_traffic_to_node_weights_in_memory(
+            &mut weights,
+            &ebg_nodes,
+            profile,
+            &attrs,
+            &nbg_geo,
+        )
+        .unwrap();
+        weights
+    }
+
+    #[test]
+    fn vector_profile_scales_by_density_class() {
+        let w = apply(&vector_profile());
+        // weight / factor, rounded: rural 1000/0.9, urban_high 1000/0.5,
+        // rural 1000/0.9, suburban 1000/0.8.
+        assert_eq!(w, vec![1111, 2000, 1111, 1250]);
+    }
+
+    #[test]
+    fn matrix_replicating_the_vector_is_bit_identical_to_vector_only() {
+        let base = vector_profile();
+        let mut replicated = base.clone();
+        // Full rows for every highway code in the fixture, each cell copying
+        // the vector value for its density.
+        for code in [1u16, 7, 12] {
+            let row: crate::traffic::MatrixRow = std::array::from_fn(|i| Some(base.factors[i]));
+            replicated.matrix.insert(code, row);
+        }
+        assert!(replicated.has_matrix());
+        assert_eq!(
+            apply(&base),
+            apply(&replicated),
+            "a matrix that replicates the vector must produce identical weights"
+        );
+    }
+
+    #[test]
+    fn matrix_cell_overrides_only_its_highway_density_cell() {
+        let mut p = vector_profile();
+        // residential (12) × Rural slowed to 0.4; every other cell falls back.
+        let mut row: crate::traffic::MatrixRow = [None; 5];
+        row[DensityClass::Rural.to_u8() as usize] = Some(0.4);
+        p.matrix.insert(12, row);
+
+        let w = apply(&p);
+        // node 0: motorway×Rural → vector 0.9 → 1111 (no row for code 1)
+        // node 1: residential×UrbanHigh → vector 0.5 → 2000 (cell absent in row)
+        // node 2: residential×Rural → matrix 0.4 → 2500 (overridden)
+        // node 3: secondary×Suburban → vector 0.8 → 1250
+        assert_eq!(w, vec![1111, 2000, 2500, 1250]);
+    }
+
+    #[test]
+    fn inaccessible_sentinel_preserved_with_matrix() {
+        let (ebg_nodes, nbg_geo, attrs) = fixture();
+        let mut p = vector_profile();
+        p.matrix.insert(12, std::array::from_fn(|_| Some(0.4)));
+        let mut weights = vec![1000u32, 0, 1000, 0];
+        apply_traffic_to_node_weights_in_memory(&mut weights, &ebg_nodes, &p, &attrs, &nbg_geo)
+            .unwrap();
+        assert_eq!(weights[1], 0, "0 = inaccessible must survive");
+        assert_eq!(weights[3], 0, "0 = inaccessible must survive");
+        assert_eq!(weights[2], 2500, "accessible node scaled by matrix cell");
     }
 }

--- a/route/src/range/tree_phast.rs
+++ b/route/src/range/tree_phast.rs
@@ -513,22 +513,6 @@ fn arc_owner(offsets: &[u64], arc: usize) -> usize {
     offsets.partition_point(|&o| o <= a) - 1
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn arc_owner_basics() {
-        let offsets: Vec<u64> = vec![0, 3, 3, 7, 10];
-        assert_eq!(arc_owner(&offsets, 0), 0);
-        assert_eq!(arc_owner(&offsets, 2), 0);
-        assert_eq!(arc_owner(&offsets, 3), 2); // node 1 is empty
-        assert_eq!(arc_owner(&offsets, 6), 2);
-        assert_eq!(arc_owner(&offsets, 7), 3);
-        assert_eq!(arc_owner(&offsets, 9), 3);
-    }
-}
-
 /// #438 K-lane: lanes per batch (matches the matrix subsystem's K).
 pub const TREE_LANES: usize = 8;
 const LANE_NONE: u32 = u32::MAX;
@@ -824,5 +808,21 @@ fn upward_sweep_body(
                 s.push_up(v, nd);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arc_owner_basics() {
+        let offsets: Vec<u64> = vec![0, 3, 3, 7, 10];
+        assert_eq!(arc_owner(&offsets, 0), 0);
+        assert_eq!(arc_owner(&offsets, 2), 0);
+        assert_eq!(arc_owner(&offsets, 3), 2); // node 1 is empty
+        assert_eq!(arc_owner(&offsets, 6), 2);
+        assert_eq!(arc_owner(&offsets, 7), 3);
+        assert_eq!(arc_owner(&offsets, 9), 3);
     }
 }

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -3850,61 +3850,6 @@ fn try_load_edge_geometry(
     Ok(Some(eg))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::build_role_masks;
-    use crate::formats::FilteredEbg;
-    use crate::profile_abi::Mode;
-
-    fn tiny_filtered_ebg(offsets: Vec<u64>, heads: Vec<u32>) -> FilteredEbg {
-        let n = offsets.len() - 1;
-        FilteredEbg {
-            mode: Mode(1),
-            n_filtered_nodes: n as u32,
-            n_filtered_arcs: heads.len() as u64,
-            n_original_nodes: n as u32,
-            inputs_sha: [0; 32],
-            offsets: crate::formats::ArcCow::from_vec(offsets),
-            heads: crate::formats::ArcCow::from_vec(heads.clone()),
-            original_arc_idx: crate::formats::ArcCow::from_vec((0..heads.len() as u32).collect()),
-            filtered_to_original: crate::formats::ArcCow::from_vec((0..n as u32).collect()),
-            original_to_filtered: crate::formats::ArcCow::from_vec((0..n as u32).collect()),
-        }
-    }
-
-    fn bit(mask: &[u64], node: usize) -> bool {
-        (mask[node / 64] & (1u64 << (node % 64))) != 0
-    }
-
-    #[test]
-    fn role_masks_keep_core_reachable_stubs_and_drop_small_sccs() {
-        // 0 -> 1, 1 <-> 2 <-> 6, 2 -> 3, plus isolated 4 <-> 5.
-        // The largest SCC is {1,2,6}. Sources may include 0 because it
-        // can reach the core; destinations may include 3 because the
-        // core can reach it. The isolated SCC looks internally valid
-        // but is not useful for Belgium-wide table/route snaps.
-        let fe = tiny_filtered_ebg(vec![0, 1, 2, 5, 5, 6, 7, 8], vec![1, 2, 1, 6, 3, 5, 4, 1]);
-
-        let (src, dst) = build_role_masks(&fe);
-
-        assert!(bit(&src, 0));
-        assert!(bit(&src, 1));
-        assert!(bit(&src, 2));
-        assert!(!bit(&src, 3));
-        assert!(!bit(&src, 4));
-        assert!(!bit(&src, 5));
-        assert!(bit(&src, 6));
-
-        assert!(!bit(&dst, 0));
-        assert!(bit(&dst, 1));
-        assert!(bit(&dst, 2));
-        assert!(bit(&dst, 3));
-        assert!(!bit(&dst, 4));
-        assert!(!bit(&dst, 5));
-        assert!(bit(&dst, 6));
-    }
-}
-
 /// #450: field-clone a loaded ModeData. Cheap on the container path — every
 /// heavy field is Arc/mmap-backed (ArcCow / WeightArray / flats borrowed from
 /// the container mapping); only small Vecs copy. Used to register
@@ -4100,5 +4045,60 @@ fn read_recustomize_cache(
             tracing::info!(error = %e, path = %path.display(), "recustomize cache unusable — recomputing");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_role_masks;
+    use crate::formats::FilteredEbg;
+    use crate::profile_abi::Mode;
+
+    fn tiny_filtered_ebg(offsets: Vec<u64>, heads: Vec<u32>) -> FilteredEbg {
+        let n = offsets.len() - 1;
+        FilteredEbg {
+            mode: Mode(1),
+            n_filtered_nodes: n as u32,
+            n_filtered_arcs: heads.len() as u64,
+            n_original_nodes: n as u32,
+            inputs_sha: [0; 32],
+            offsets: crate::formats::ArcCow::from_vec(offsets),
+            heads: crate::formats::ArcCow::from_vec(heads.clone()),
+            original_arc_idx: crate::formats::ArcCow::from_vec((0..heads.len() as u32).collect()),
+            filtered_to_original: crate::formats::ArcCow::from_vec((0..n as u32).collect()),
+            original_to_filtered: crate::formats::ArcCow::from_vec((0..n as u32).collect()),
+        }
+    }
+
+    fn bit(mask: &[u64], node: usize) -> bool {
+        (mask[node / 64] & (1u64 << (node % 64))) != 0
+    }
+
+    #[test]
+    fn role_masks_keep_core_reachable_stubs_and_drop_small_sccs() {
+        // 0 -> 1, 1 <-> 2 <-> 6, 2 -> 3, plus isolated 4 <-> 5.
+        // The largest SCC is {1,2,6}. Sources may include 0 because it
+        // can reach the core; destinations may include 3 because the
+        // core can reach it. The isolated SCC looks internally valid
+        // but is not useful for Belgium-wide table/route snaps.
+        let fe = tiny_filtered_ebg(vec![0, 1, 2, 5, 5, 6, 7, 8], vec![1, 2, 1, 6, 3, 5, 4, 1]);
+
+        let (src, dst) = build_role_masks(&fe);
+
+        assert!(bit(&src, 0));
+        assert!(bit(&src, 1));
+        assert!(bit(&src, 2));
+        assert!(!bit(&src, 3));
+        assert!(!bit(&src, 4));
+        assert!(!bit(&src, 5));
+        assert!(bit(&src, 6));
+
+        assert!(!bit(&dst, 0));
+        assert!(bit(&dst, 1));
+        assert!(bit(&dst, 2));
+        assert!(bit(&dst, 3));
+        assert!(!bit(&dst, 4));
+        assert!(!bit(&dst, 5));
+        assert!(bit(&dst, 6));
     }
 }

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -2040,6 +2040,7 @@ impl ServerState {
                     name: format!("edge_speeds:{matched}"),
                     base_model: "car".to_string(),
                     factors: [1.0; 5],
+                    matrix: std::collections::BTreeMap::new(),
                 };
                 if let Err(e) =
                     write_recustomize_cache(&cache_path, k, &marker, &new_weights, &adjusted)

--- a/route/src/traffic.rs
+++ b/route/src/traffic.rs
@@ -295,6 +295,21 @@ impl TrafficProfile {
                         MIN_FACTOR,
                         MAX_FACTOR
                     );
+                    // `DensityClass::parse` accepts spelling aliases (e.g.
+                    // "urban_high" and "urbanHigh"), so two distinct JSON keys
+                    // can land on the same cell. Without this guard the
+                    // lexicographically last key would win silently.
+                    anyhow::ensure!(
+                        row[class.to_u8() as usize].is_none(),
+                        "traffic profile '{}': matrix.{} specifies density '{}' more than once \
+                         (key '{}' aliases a key given earlier in the row — write each density \
+                         exactly once, canonical spelling '{}')",
+                        parsed.name,
+                        key,
+                        class.as_str(),
+                        dkey,
+                        class.as_str()
+                    );
                     row[class.to_u8() as usize] = Some(*value);
                 }
                 matrix.insert(code, row);
@@ -614,6 +629,25 @@ mod tests {
         }"#;
         let err = TrafficProfile::from_json(s).unwrap_err();
         assert!(format!("{err:#}").contains("unknown matrix.1 key"));
+    }
+
+    #[test]
+    fn rejects_duplicate_density_key_in_matrix_row() {
+        // "urban_high" and "urbanHigh" are distinct JSON keys that both parse
+        // to UrbanHigh — without the guard the lexicographically last one
+        // would win silently.
+        let s = r#"{
+          "name": "bad", "base_model": "car",
+          "speed_factors": {
+            "urban_high": 0.55, "urban_medium": 0.7,
+            "urban_low": 0.85, "suburban": 0.9, "rural": 0.95
+          },
+          "matrix": { "1": { "urban_high": 0.5, "urbanHigh": 0.6 } }
+        }"#;
+        let err = TrafficProfile::from_json(s).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("more than once"), "got: {msg}");
+        assert!(msg.contains("urban_high"), "got: {msg}");
     }
 
     #[test]

--- a/route/src/traffic.rs
+++ b/route/src/traffic.rs
@@ -32,13 +32,53 @@
 //! above 1.0 represents a road that's faster than the OSM speed limit
 //! (rare — bounded at 1.5 to keep the search hierarchy stable).
 //!
+//! ## Optional `matrix` section (#428)
+//!
+//! A profile may additionally carry a 2-D **(highway_class × density)**
+//! factor matrix that refines the per-density vector:
+//!
+//! ```json
+//! {
+//!   "name": "rush_hour",
+//!   "base_model": "car",
+//!   "speed_factors": { "urban_high": 0.55, "urban_medium": 0.70,
+//!                      "urban_low": 0.85, "suburban": 0.90, "rural": 0.95 },
+//!   "matrix": {
+//!     "1":  { "rural": 0.98, "suburban": 0.92 },
+//!     "12": { "urban_high": 0.45, "urban_medium": 0.60 }
+//!   }
+//! }
+//! ```
+//!
+//! - **Outer keys are the numeric `highway_class` codes** stored per way in
+//!   `way_attrs.<mode>.bin` — i.e. the values assigned by the build model's
+//!   `highway_class` table in `models/<base_model>.model.json` (shipped car
+//!   model: 1=motorway, 2=motorway_link, 3=trunk, …, 12=residential,
+//!   20=footway/path group, 99=construction). The codes are model-defined,
+//!   NOT a fixed engine enumeration, which is why the schema uses the code
+//!   rather than a name: the code is the exact value available at
+//!   customization time, in every context (CLI step 8 and serve-boot
+//!   recustomization), without needing the model JSON at hand.
+//! - Keys must be canonical decimal `u16` strings (`"12"`, not `"012"`).
+//! - Inner objects map density-class labels to factors and may be
+//!   **partial**: a missing `(highway, density)` cell falls back to the
+//!   per-density `speed_factors` vector, which therefore stays REQUIRED and
+//!   complete — the matrix only overrides cells it specifies. A way whose
+//!   highway code has no matrix row uses the vector as before.
+//! - `matrix` is opt-in: profiles without it behave exactly as today, and
+//!   [`TrafficProfile::to_json_string`] omits the key when no matrix is set,
+//!   so existing files round-trip byte-for-byte.
+//!
 //! ## Schema validation
 //!
 //! - `name` and `base_model` must be non-empty.
 //! - `speed_factors` MUST contain all five density-class keys
 //!   (urban_high, urban_medium, urban_low, suburban, rural).
-//! - Each factor MUST be in `[0.1, 1.5]`.
-//! - Unknown keys are rejected (typo guard).
+//! - Each factor (vector or matrix cell) MUST be in `[0.1, 1.5]`.
+//! - Unknown keys are rejected (typo guard) — at the top level, inside
+//!   `speed_factors`, and inside every `matrix` row.
+//! - When present, `matrix` must be non-empty and every row must contain at
+//!   least one density cell.
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -51,6 +91,11 @@ use crate::density::DensityClass;
 pub const MIN_FACTOR: f32 = 0.1;
 pub const MAX_FACTOR: f32 = 1.5;
 
+/// One matrix row: per-density factors for a single highway-class code.
+/// Indexed by `DensityClass::to_u8() as usize`; `None` = cell not specified,
+/// fall back to the profile's per-density vector.
+pub type MatrixRow = [Option<f32>; 5];
+
 /// Parsed traffic profile.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TrafficProfile {
@@ -58,13 +103,26 @@ pub struct TrafficProfile {
     pub base_model: String,
     /// Indexed by `DensityClass::to_u8() as usize`.
     pub factors: [f32; 5],
+    /// Optional (highway_class × density) overrides (#428). Outer key is the
+    /// numeric `highway_class` code stored per way in `way_attrs.<mode>.bin`
+    /// (model-defined — see the module docs). Empty map = no matrix; lookups
+    /// resolve through [`TrafficProfile::factor_for_cell`], which falls back
+    /// to `factors` for absent rows/cells. `BTreeMap` keeps iteration and
+    /// serialization deterministic.
+    pub matrix: BTreeMap<u16, MatrixRow>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct TrafficProfileJson {
     name: String,
     base_model: String,
     speed_factors: BTreeMap<String, f32>,
+    /// Optional (highway_class × density) factor matrix. Absent on legacy
+    /// profiles; omitted on output when empty so vector-only profiles
+    /// round-trip byte-for-byte.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    matrix: Option<BTreeMap<String, BTreeMap<String, f32>>>,
 }
 
 impl TrafficProfile {
@@ -75,18 +133,47 @@ impl TrafficProfile {
             name: "freeflow".to_string(),
             base_model: base_model.to_string(),
             factors: [1.0; 5],
+            matrix: BTreeMap::new(),
         }
     }
 
-    /// Returns true iff every factor equals 1.0 within float tolerance.
+    /// Returns true iff every factor equals 1.0 within float tolerance —
+    /// including every specified matrix cell.
     pub fn is_freeflow(&self) -> bool {
         self.factors.iter().all(|f| (f - 1.0).abs() < 1e-6)
+            && self
+                .matrix
+                .values()
+                .flatten()
+                .flatten()
+                .all(|f| (f - 1.0).abs() < 1e-6)
     }
 
-    /// Lookup factor for a density class.
+    /// Lookup factor for a density class (per-density vector only — ignores
+    /// the matrix; use [`Self::factor_for_cell`] when the way's highway class
+    /// is known).
     #[inline]
     pub fn factor_for(&self, class: DensityClass) -> f32 {
         self.factors[class.to_u8() as usize]
+    }
+
+    /// Lookup factor for a `(highway_class, density)` cell: the matrix cell
+    /// when specified, else the per-density vector. With an empty matrix this
+    /// is exactly [`Self::factor_for`].
+    #[inline]
+    pub fn factor_for_cell(&self, highway_class: u16, class: DensityClass) -> f32 {
+        if let Some(row) = self.matrix.get(&highway_class)
+            && let Some(f) = row[class.to_u8() as usize]
+        {
+            return f;
+        }
+        self.factors[class.to_u8() as usize]
+    }
+
+    /// True iff the profile carries a (highway × density) matrix.
+    #[inline]
+    pub fn has_matrix(&self) -> bool {
+        !self.matrix.is_empty()
     }
 
     /// Load + validate a profile from a JSON file on disk.
@@ -152,14 +239,81 @@ impl TrafficProfile {
             );
         }
 
+        // Optional (highway_class × density) matrix.
+        let mut matrix: BTreeMap<u16, MatrixRow> = BTreeMap::new();
+        if let Some(raw_matrix) = &parsed.matrix {
+            anyhow::ensure!(
+                !raw_matrix.is_empty(),
+                "traffic profile '{}': 'matrix' must be non-empty when present (omit the key for a vector-only profile)",
+                parsed.name
+            );
+            for (key, raw_row) in raw_matrix {
+                let code: u16 = key.parse().with_context(|| {
+                    format!(
+                        "traffic profile '{}': matrix key '{}' is not a u16 highway_class code (the per-way value from way_attrs.<mode>.bin, assigned by the build model's highway_class table)",
+                        parsed.name, key
+                    )
+                })?;
+                // Canonical decimal form only: rejects "012"/"+1"-style keys
+                // (and with it any aliasing of two spellings onto one code).
+                anyhow::ensure!(
+                    code.to_string() == *key,
+                    "traffic profile '{}': matrix key '{}' is not in canonical decimal form (write it as '{}')",
+                    parsed.name,
+                    key,
+                    code
+                );
+                anyhow::ensure!(
+                    !raw_row.is_empty(),
+                    "traffic profile '{}': matrix.{} must contain at least one density cell",
+                    parsed.name,
+                    key
+                );
+                let mut row: MatrixRow = [None; 5];
+                for (dkey, value) in raw_row {
+                    let class = DensityClass::parse(dkey).with_context(|| {
+                        format!(
+                            "traffic profile '{}': unknown matrix.{} key '{}' (allowed: urban_high, urban_medium, urban_low, suburban, rural)",
+                            parsed.name, key, dkey
+                        )
+                    })?;
+                    anyhow::ensure!(
+                        value.is_finite(),
+                        "traffic profile '{}': matrix.{}.{} = {} is not finite",
+                        parsed.name,
+                        key,
+                        dkey,
+                        value
+                    );
+                    anyhow::ensure!(
+                        (MIN_FACTOR..=MAX_FACTOR).contains(value),
+                        "traffic profile '{}': matrix.{}.{} = {} out of range [{}, {}]",
+                        parsed.name,
+                        key,
+                        dkey,
+                        value,
+                        MIN_FACTOR,
+                        MAX_FACTOR
+                    );
+                    row[class.to_u8() as usize] = Some(*value);
+                }
+                matrix.insert(code, row);
+            }
+        }
+
         Ok(Self {
             name: parsed.name,
             base_model: parsed.base_model,
             factors,
+            matrix,
         })
     }
 
-    /// Serialize back out (used by lock-file provenance).
+    /// Serialize back out (used by lock-file provenance). Deterministic:
+    /// `BTreeMap` ordering throughout (matrix keys sort lexicographically on
+    /// their decimal form). The `matrix` key is omitted entirely when the
+    /// profile has none, so vector-only profiles serialize exactly as before
+    /// #428.
     pub fn to_json_string(&self) -> Result<String> {
         let mut speed_factors = BTreeMap::new();
         for class in DensityClass::ALL {
@@ -168,10 +322,28 @@ impl TrafficProfile {
                 self.factors[class.to_u8() as usize],
             );
         }
+        let matrix = if self.matrix.is_empty() {
+            None
+        } else {
+            let mut out: BTreeMap<String, BTreeMap<String, f32>> = BTreeMap::new();
+            for (code, row) in &self.matrix {
+                let mut raw_row = BTreeMap::new();
+                for class in DensityClass::ALL {
+                    if let Some(f) = row[class.to_u8() as usize] {
+                        raw_row.insert(class.as_str().to_string(), f);
+                    }
+                }
+                // Rows are non-empty by construction (validation rejects empty
+                // rows on parse; the calibrator omits all-None rows).
+                out.insert(code.to_string(), raw_row);
+            }
+            Some(out)
+        };
         let payload = TrafficProfileJson {
             name: self.name.clone(),
             base_model: self.base_model.clone(),
             speed_factors,
+            matrix,
         };
         Ok(serde_json::to_string_pretty(&payload)?)
     }
@@ -334,6 +506,176 @@ mod tests {
                 p.factors
             );
         }
+    }
+
+    fn matrix_json() -> &'static str {
+        r#"{
+          "name": "rush_hour_matrix",
+          "base_model": "car",
+          "speed_factors": {
+            "urban_high": 0.55,
+            "urban_medium": 0.70,
+            "urban_low": 0.85,
+            "suburban": 0.90,
+            "rural": 0.95
+          },
+          "matrix": {
+            "1": { "rural": 0.98, "suburban": 0.92 },
+            "12": {
+              "urban_high": 0.45, "urban_medium": 0.60,
+              "urban_low": 0.70, "suburban": 0.80, "rural": 0.90
+            }
+          }
+        }"#
+    }
+
+    #[test]
+    fn parses_matrix_profile_with_partial_rows() {
+        let p = TrafficProfile::from_json(matrix_json()).unwrap();
+        assert!(p.has_matrix());
+        assert_eq!(p.matrix.len(), 2);
+        // Specified cells take precedence over the vector.
+        assert!((p.factor_for_cell(1, DensityClass::Rural) - 0.98).abs() < 1e-6);
+        assert!((p.factor_for_cell(1, DensityClass::Suburban) - 0.92).abs() < 1e-6);
+        assert!((p.factor_for_cell(12, DensityClass::UrbanHigh) - 0.45).abs() < 1e-6);
+        // Missing cell in a present row falls back to the vector.
+        assert!((p.factor_for_cell(1, DensityClass::UrbanHigh) - 0.55).abs() < 1e-6);
+        // Absent row falls back to the vector for every density.
+        for c in DensityClass::ALL {
+            assert!((p.factor_for_cell(7, c) - p.factor_for(c)).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn vector_only_profile_has_no_matrix_and_cell_lookup_matches_vector() {
+        let p = TrafficProfile::from_json(rush_hour_json()).unwrap();
+        assert!(!p.has_matrix());
+        for code in [0u16, 1, 12, 99, u16::MAX] {
+            for c in DensityClass::ALL {
+                assert_eq!(p.factor_for_cell(code, c), p.factor_for(c));
+            }
+        }
+    }
+
+    #[test]
+    fn matrix_profile_round_trips_through_json() {
+        let p = TrafficProfile::from_json(matrix_json()).unwrap();
+        let s = p.to_json_string().unwrap();
+        let p2 = TrafficProfile::from_json(&s).unwrap();
+        assert_eq!(p, p2);
+        // Determinism: serializing again yields identical bytes.
+        assert_eq!(s, p2.to_json_string().unwrap());
+    }
+
+    #[test]
+    fn vector_only_profile_serializes_without_matrix_key() {
+        let p = TrafficProfile::from_json(rush_hour_json()).unwrap();
+        let s = p.to_json_string().unwrap();
+        assert!(!s.contains("matrix"), "unexpected matrix key in {s}");
+    }
+
+    #[test]
+    fn rejects_non_numeric_matrix_key() {
+        let s = r#"{
+          "name": "bad", "base_model": "car",
+          "speed_factors": {
+            "urban_high": 0.55, "urban_medium": 0.7,
+            "urban_low": 0.85, "suburban": 0.9, "rural": 0.95
+          },
+          "matrix": { "motorway": { "rural": 0.9 } }
+        }"#;
+        let err = TrafficProfile::from_json(s).unwrap_err();
+        assert!(format!("{err:#}").contains("not a u16 highway_class code"));
+    }
+
+    #[test]
+    fn rejects_non_canonical_matrix_key() {
+        let s = r#"{
+          "name": "bad", "base_model": "car",
+          "speed_factors": {
+            "urban_high": 0.55, "urban_medium": 0.7,
+            "urban_low": 0.85, "suburban": 0.9, "rural": 0.95
+          },
+          "matrix": { "012": { "rural": 0.9 } }
+        }"#;
+        let err = TrafficProfile::from_json(s).unwrap_err();
+        assert!(format!("{err:#}").contains("canonical decimal form"));
+    }
+
+    #[test]
+    fn rejects_unknown_density_key_in_matrix_row() {
+        let s = r#"{
+          "name": "bad", "base_model": "car",
+          "speed_factors": {
+            "urban_high": 0.55, "urban_medium": 0.7,
+            "urban_low": 0.85, "suburban": 0.9, "rural": 0.95
+          },
+          "matrix": { "1": { "suburbann": 0.9 } }
+        }"#;
+        let err = TrafficProfile::from_json(s).unwrap_err();
+        assert!(format!("{err:#}").contains("unknown matrix.1 key"));
+    }
+
+    #[test]
+    fn rejects_out_of_range_matrix_cell() {
+        let s = r#"{
+          "name": "bad", "base_model": "car",
+          "speed_factors": {
+            "urban_high": 0.55, "urban_medium": 0.7,
+            "urban_low": 0.85, "suburban": 0.9, "rural": 0.95
+          },
+          "matrix": { "1": { "rural": 1.6 } }
+        }"#;
+        let err = TrafficProfile::from_json(s).unwrap_err();
+        assert!(format!("{err:#}").contains("out of range"));
+    }
+
+    #[test]
+    fn rejects_empty_matrix_and_empty_row() {
+        let empty_matrix = r#"{
+          "name": "bad", "base_model": "car",
+          "speed_factors": {
+            "urban_high": 0.55, "urban_medium": 0.7,
+            "urban_low": 0.85, "suburban": 0.9, "rural": 0.95
+          },
+          "matrix": {}
+        }"#;
+        let err = TrafficProfile::from_json(empty_matrix).unwrap_err();
+        assert!(format!("{err:#}").contains("must be non-empty"));
+
+        let empty_row = r#"{
+          "name": "bad", "base_model": "car",
+          "speed_factors": {
+            "urban_high": 0.55, "urban_medium": 0.7,
+            "urban_low": 0.85, "suburban": 0.9, "rural": 0.95
+          },
+          "matrix": { "1": {} }
+        }"#;
+        let err = TrafficProfile::from_json(empty_row).unwrap_err();
+        assert!(format!("{err:#}").contains("at least one density cell"));
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_key() {
+        let s = r#"{
+          "name": "bad", "base_model": "car",
+          "speed_factors": {
+            "urban_high": 0.55, "urban_medium": 0.7,
+            "urban_low": 0.85, "suburban": 0.9, "rural": 0.95
+          },
+          "matrxi": { "1": { "rural": 0.9 } }
+        }"#;
+        assert!(TrafficProfile::from_json(s).is_err());
+    }
+
+    #[test]
+    fn is_freeflow_accounts_for_matrix_cells() {
+        let mut p = TrafficProfile::freeflow("car");
+        assert!(p.is_freeflow());
+        p.matrix.insert(1, [None, None, None, None, Some(1.0)]);
+        assert!(p.is_freeflow(), "all-1.0 matrix is still freeflow");
+        p.matrix.insert(12, [Some(0.5), None, None, None, None]);
+        assert!(!p.is_freeflow(), "a non-1.0 cell breaks freeflow");
     }
 
     #[test]


### PR DESCRIPTION
Closes #428.

Generalises the traffic profile from a per-density 5-factor vector to an optional 2-D **(highway_class × density)** factor matrix — schema, application, and calibration — while keeping the per-density profile the default and byte-for-byte unchanged.

## Design decisions

### Matrix shape
```json
{
  "name": "rush_hour",
  "base_model": "car",
  "speed_factors": { "urban_high": 0.55, "urban_medium": 0.70, "urban_low": 0.85, "suburban": 0.90, "rural": 0.95 },
  "matrix": {
    "1":  { "rural": 0.98, "suburban": 0.92 },
    "12": { "urban_high": 0.45, "urban_medium": 0.60 }
  }
}
```
- `matrix` is **opt-in**; when absent, parsing, application, and serialization are identical to today (the key is omitted on output, so existing files round-trip byte-for-byte — pinned by tests).
- Strict validation: factors in `[0.1, 1.5]`, unknown density keys rejected per row, non-numeric / non-canonical (`"012"`) highway codes rejected, empty matrices and empty rows rejected, and `deny_unknown_fields` now guards top-level typos.

### Highway-class axis source
The outer keys are the **numeric `highway_class` codes stored per way in `way_attrs.<mode>.bin`** — the values assigned by the build model's `highway_class` table in `models/<base_model>.model.json` (shipped car model: 1=motorway, 2=motorway_link, 3=trunk, …, 12=residential, 20=footway group, 99=construction). Rationale: the codes are **model-defined, not a fixed engine enumeration** (`build_highway_classes()` in `model/profiling.rs` uses a *different* numbering than the shipped models), and the model JSON is not available in every application context (serve-boot recustomization reads only `.butterfly` container sections). The raw code is the exact value available at customization time everywhere — using names resolved through any fixed table would silently mis-bucket. This follows the issue's instruction to "use what exists". **No binary-format changes**: way_attrs v2 already carries `highway_class: u16` + `density_class: u8` per way.

### Fallback semantics (partial matrix, not full-matrix-required)
A full matrix is undefinable over a u16 code space, so cell-level fallback was the cleaner choice:
- `factor_for_cell(highway, density)` = matrix cell when specified → else the per-density vector.
- The vector (`speed_factors`, all 5 keys) stays **required and complete**, so lookups are total by construction.
- Applied identically in both consumers — step 8 `--traffic` CLI and serve-boot car recustomization — via the single shared `apply_traffic_to_node_weights_in_memory`. With no matrix the f64 inverse-factor computation is bit-identical to pre-#428.

### `calibrate-traffic --matrix`
- Buckets the same `observed/base` ratios by `(highway_class, density)`; per cell: sample-count-weighted median, same clamp band as the vector fit.
- A cell is **emitted only when it clears `--min-samples`** (sum of `sample_count`). Under-sampled/unobserved cells are *omitted*, giving the hierarchy **cell → density-marginal → global** at application time without duplicating fallback values into the matrix (the vector is always fitted with its existing own-median → nearest-class → global resolution).
- Deterministic: `BTreeMap` bucketing, stable sorts, `BTreeMap`-ordered serialization — two fits over the same input serialize byte-identically (tested).
- Per-cell diagnostics (`CellFit`) reported in the CLI summary.

## Test coverage (654 lib tests pass, +21 over main's 633, zero failures)
- **Schema**: matrix parse with partial rows; precedence + cell/row fallback; vector-only equivalence of `factor_for_cell`; round-trip + determinism; vector-only output has no `matrix` key; rejects non-numeric / non-canonical keys, unknown density keys, out-of-range cells, empty matrix/rows, unknown top-level keys; `is_freeflow` accounts for matrix cells.
- **Application** (synthetic EBG/NBG/way_attrs fixture): vector scaling baseline; **matrix replicating the vector is bit-identical to vector-only**; a matrix cell overrides exactly its (highway, density) cell; the `0 = inaccessible` sentinel survives.
- **Calibration**: matrix fit recovers planted per-cell ratios that the vector can't separate (two highway classes inside one density class); under-sampled cells omitted and fall back to the density marginal; byte-identical determinism across runs; clamping; matrix off by default; emitted matrix profile passes its own schema validation. Plus an end-to-end CLI smoke against a synthetic `way_attrs.car.bin` (production v2 format + CRC).
- Gates: `cargo clippy --workspace --all-targets --all-features` zero warnings; `cargo fmt --all -- --check` clean; full `cargo test --workspace` green.

## Note: includes a one-commit lint fix for main
`1feb9f9` relocates two mid-file `#[cfg(test)]` modules (`range/tree_phast.rs`, `server/state.rs`, introduced by 29b345f) that fail clippy's `items_after_test_module` and break the `--all-targets` gate on main. Pure relocation, no code changes.

Out of scope (per issue): provider data/licensing, segment-id→way_id matching.
