### PR TITLE
perf(tree): interleaved lanes + UP-tree snapshots + locality batching + always-tree (#438)

### DIFF
--- a/route/src/range/tree_phast.rs
+++ b/route/src/range/tree_phast.rs
@@ -62,10 +62,27 @@ struct TreeScratch {
     sel_epoch: u32,
     sel: Vec<u32>,
     /// #438 K-lane: selection-position map (pos+1, valid where sel_gen ==
-    /// sel_epoch) + compact per-selection lane arrays (K × |sel|).
+    /// sel_epoch) + compact per-selection lane arrays, INTERLEAVED
+    /// (`[pos * lane_k + k]`): one arc relaxation touches one contiguous
+    /// dist run + one parent run per endpoint instead of `lane_k` strided
+    /// cache lines, and the inner lane loop auto-vectorizes.
     sel_pos: Vec<u32>,
     lane_dist: Vec<u32>,
     lane_parent: Vec<u32>,
+    /// Stride of the CURRENT batch's lane arrays (sources in the batch).
+    lane_k: usize,
+    /// Settled-node log of the LAST upward sweep (may hold duplicates —
+    /// a node can pop non-stale more than once; dedup at snapshot time).
+    up_log: Vec<u32>,
+    /// Per-lane UP-tree snapshots, flat + offset-indexed: the sorted settled
+    /// nodes of lane k's seed sweep and their FINAL tagged parents. Replaces
+    /// the per-lane resweep at backtrack time (the sweeps were ~half of
+    /// post-K-lane tree CPU; a snapshot is a few thousand entries).
+    lane_up_nodes: Vec<u32>,
+    lane_up_parent: Vec<u32>,
+    lane_up_off: Vec<u32>,
+    /// The CURRENT batch's sources (backtrack validity check per lane).
+    lane_sources: Vec<u32>,
     /// Lever-1 (#438): reused 4-ary decrease-key heap + handle slots for the
     /// upward sweep (replaces a per-settle std::BinaryHeap with lazy dupes).
     pq: DAryHeap,
@@ -87,6 +104,12 @@ impl TreeScratch {
             sel_pos: vec![0; n],
             lane_dist: Vec::new(),
             lane_parent: Vec::new(),
+            lane_k: 0,
+            up_log: Vec::new(),
+            lane_up_nodes: Vec::new(),
+            lane_up_parent: Vec::new(),
+            lane_up_off: Vec::new(),
+            lane_sources: Vec::new(),
             pq: DAryHeap::new(1024),
             handles: vec![HANDLE_NONE; n],
         }
@@ -513,22 +536,6 @@ fn arc_owner(offsets: &[u64], arc: usize) -> usize {
     offsets.partition_point(|&o| o <= a) - 1
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn arc_owner_basics() {
-        let offsets: Vec<u64> = vec![0, 3, 3, 7, 10];
-        assert_eq!(arc_owner(&offsets, 0), 0);
-        assert_eq!(arc_owner(&offsets, 2), 0);
-        assert_eq!(arc_owner(&offsets, 3), 2); // node 1 is empty
-        assert_eq!(arc_owner(&offsets, 6), 2);
-        assert_eq!(arc_owner(&offsets, 7), 3);
-        assert_eq!(arc_owner(&offsets, 9), 3);
-    }
-}
-
 /// #438 K-lane: lanes per batch (matches the matrix subsystem's K).
 pub const TREE_LANES: usize = 8;
 const LANE_NONE: u32 = u32::MAX;
@@ -536,9 +543,9 @@ const LANE_NONE: u32 = u32::MAX;
 /// #438 K-lane batched settle: up to [`TREE_LANES`] sources share ONE union
 /// selection and ONE restricted descending-rank scan — each DOWN arc's topo
 /// data is read once and relaxed for all lanes (the scan was 73% of tree CPU).
-/// Per-source UP sweeps seed the lanes; UP parent chains are NOT retained —
-/// before backtracking lane `k`, the caller MUST [`tree_resweep`]`(sources[k])`
-/// (sweeps are ~14%, paid twice by design).
+/// Per-source UP sweeps seed the lanes; each lane's UP tree (settled nodes +
+/// final tagged parents) is snapshotted at settle time, so backtracks need no
+/// resweep — [`tree_lane_backtrack`] works directly off this settle.
 pub fn tree_settle_restricted_batch(
     topo: &CchTopo,
     weights: &CchWeights,
@@ -595,26 +602,43 @@ pub fn tree_settle_restricted_batch(
                 );
                 let _t = std::time::Instant::now();
 
-                // Lane arrays (compact, cache-resident).
+                // Lane arrays (compact, cache-resident, INTERLEAVED:
+                // `[pos * k_lanes + k]` — see the field doc).
+                s.lane_k = k_lanes;
                 s.lane_dist.clear();
                 s.lane_dist.resize(k_lanes * sel_n, u32::MAX);
                 s.lane_parent.clear();
                 s.lane_parent.resize(k_lanes * sel_n, LANE_NONE);
 
                 // Seed: per-source UP sweep (single-lane scratch), copy dists
-                // of selection nodes into the lane.
+                // of selection nodes into the lane, then SNAPSHOT the lane's
+                // UP tree (sorted settled nodes + final tagged parents) so
+                // backtracks don't need a resweep.
+                s.lane_sources.clear();
+                s.lane_sources.extend_from_slice(sources);
+                s.lane_up_nodes.clear();
+                s.lane_up_parent.clear();
+                s.lane_up_off.clear();
+                s.lane_up_off.push(0);
                 let sel_snapshot = std::mem::take(&mut s.sel);
                 for (k, &src) in sources.iter().enumerate() {
                     s.start_tree(src, u32::MAX);
                     s.set(src as usize, 0, 0);
                     upward_sweep_body(s, topo, weights, down_rev, src);
-                    let base = k * sel_n;
                     for (i, &u) in sel_snapshot.iter().enumerate() {
                         let d = s.get(u as usize);
                         if d != u32::MAX {
-                            s.lane_dist[base + i] = d;
+                            s.lane_dist[i * k_lanes + k] = d;
                         }
                     }
+                    s.up_log.sort_unstable();
+                    s.up_log.dedup();
+                    for li in 0..s.up_log.len() {
+                        let u = s.up_log[li];
+                        s.lane_up_nodes.push(u);
+                        s.lane_up_parent.push(s.parent[u as usize]);
+                    }
+                    s.lane_up_off.push(s.lane_up_nodes.len() as u32);
                 }
                 s.sel = sel_snapshot;
                 TREE_PHASE_NS[1].fetch_add(
@@ -639,14 +663,13 @@ pub fn tree_settle_restricted_batch(
                             continue; // outside selection — dead end
                         }
                         let j = (s.sel_pos[v] - 1) as usize;
+                        // Contiguous lane runs at both endpoints; the loop
+                        // is branch-free saturating-add + min + select, so
+                        // LLVM vectorizes it (k_lanes ≤ 8 → one AVX2 row).
+                        let (bi, bj) = (i * k_lanes, j * k_lanes);
                         for k in 0..k_lanes {
-                            let di = k * sel_n + i;
-                            let d = s.lane_dist[di];
-                            if d == u32::MAX {
-                                continue;
-                            }
-                            let nd = d.saturating_add(w);
-                            let dj = k * sel_n + j;
+                            let nd = s.lane_dist[bi + k].saturating_add(w);
+                            let dj = bj + k;
                             if nd < s.lane_dist[dj] {
                                 s.lane_dist[dj] = nd;
                                 s.lane_parent[dj] = arc as u32;
@@ -665,55 +688,24 @@ pub fn tree_settle_restricted_batch(
     })
 }
 
-/// #438 K-lane: re-run the UP sweep for ONE lane's source into the
-/// single-lane scratch so [`tree_lane_backtrack`] can reconstruct UP parent
-/// chains. MUST be called (same thread) after the batch settle and before
-/// that lane's backtracks; does NOT touch the lane arrays or selection.
-pub fn tree_resweep(
-    topo: &CchTopo,
-    weights: &CchWeights,
-    down_rev: &DownReverseAdjFlat,
-    source: u32,
-) {
-    let n = topo.n_nodes as usize;
-    TREE_SCRATCH.with(|cell| {
-        cell.with_or_init(
-            || TreeScratch::new(n),
-            |s| {
-                if s.dist.len() != n {
-                    *s = TreeScratch::new(n);
-                }
-                let _t = std::time::Instant::now();
-                s.start_tree(source, u32::MAX);
-                s.set(source as usize, 0, 0);
-                upward_sweep_body(s, topo, weights, down_rev, source);
-                TREE_PHASE_NS[1].fetch_add(
-                    _t.elapsed().as_nanos() as u64,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-            },
-        )
-    });
-}
-
 /// #438 K-lane: backtrack `target` out of lane `k` (DOWN chain from the lane
-/// arrays; UP chain from the single-lane scratch left by [`tree_resweep`]).
+/// arrays; UP chain from the lane's UP-tree snapshot taken at settle time).
 pub fn tree_lane_backtrack(topo: &CchTopo, k: usize, source: u32, target: u32) -> Option<TreePath> {
     let n = topo.n_nodes as usize;
     TREE_SCRATCH.with(|cell| {
         cell.with_or_init(
             || TreeScratch::new(n),
             |s| {
-                if s.dist.len() != n || s.origin != source {
-                    return None; // resweep missing/mismatched — caller falls back
+                if s.dist.len() != n || k >= s.lane_k || s.lane_sources.get(k) != Some(&source) {
+                    return None; // settle missing/mismatched — caller falls back
                 }
-                let sel_n = s.sel.len();
+                let lane_k = s.lane_k;
                 let ti = target as usize;
                 if ti >= n || s.sel_gen[ti] != s.sel_epoch {
                     return None;
                 }
                 let tpos = (s.sel_pos[ti] - 1) as usize;
-                let dist = s.lane_dist[k * sel_n + tpos];
+                let dist = s.lane_dist[tpos * lane_k + k];
                 if dist == u32::MAX {
                     return None;
                 }
@@ -730,7 +722,7 @@ pub fn tree_lane_backtrack(topo: &CchTopo, k: usize, source: u32, target: u32) -
                 let mut cur_pos = tpos;
                 let mut cur_node = target;
                 for _ in 0..100_000 {
-                    let lp = s.lane_parent[k * sel_n + cur_pos];
+                    let lp = s.lane_parent[cur_pos * lane_k + k];
                     if lp == LANE_NONE {
                         break; // apex (seeded by the UP sweep)
                     }
@@ -744,10 +736,11 @@ pub fn tree_lane_backtrack(topo: &CchTopo, k: usize, source: u32, target: u32) -
                     cur_pos = (s.sel_pos[cur_node as usize] - 1) as usize;
                 }
                 let apex = cur_node;
-                // UP chain: from the resweep's single-lane parents apex→source.
-                if s.get(apex as usize) == u32::MAX {
-                    return None; // resweep didn't reach apex — inconsistent
-                }
+                // UP chain: from lane k's UP-tree snapshot, apex→source.
+                let seg_s = s.lane_up_off[k] as usize;
+                let seg_e = s.lane_up_off[k + 1] as usize;
+                let seg = &s.lane_up_nodes[seg_s..seg_e];
+                let segp = &s.lane_up_parent[seg_s..seg_e];
                 let mut forward_rev: Vec<(u32, u32)> = Vec::new();
                 let mut cur = apex;
                 for _ in 0..100_000 {
@@ -760,10 +753,10 @@ pub fn tree_lane_backtrack(topo: &CchTopo, k: usize, source: u32, target: u32) -
                             backward_parent: backward,
                         });
                     }
-                    if s.generation[cur as usize] != s.epoch {
-                        return None;
-                    }
-                    let tagged = s.parent[cur as usize];
+                    let Ok(idx) = seg.binary_search(&cur) else {
+                        return None; // apex/chain outside the lane's UP tree
+                    };
+                    let tagged = segp[idx];
                     if tagged & DOWN_BIT != 0 {
                         return None; // UP chain can't contain DOWN arcs
                     }
@@ -780,7 +773,7 @@ pub fn tree_lane_backtrack(topo: &CchTopo, k: usize, source: u32, target: u32) -
 
 /// #438: the exhaustive UP sweep (lever-1: reused 4-ary decrease-key heap +
 /// stall-on-demand) against the single-lane scratch. Shared by the
-/// single-source settle, the K-lane seeding pass, and [`tree_resweep`].
+/// single-source settle and the K-lane seeding pass.
 fn upward_sweep_body(
     s: &mut TreeScratch,
     topo: &CchTopo,
@@ -789,11 +782,16 @@ fn upward_sweep_body(
     origin: u32,
 ) {
     s.pq.clear();
+    s.up_log.clear();
     s.push_up(origin, 0);
     while let Some((d, u)) = s.pop_up() {
         if d > s.get(u as usize) {
             continue; // stale
         }
+        // Log BEFORE the stall check: stalled nodes are stamped with valid
+        // final dist/parent and the lane seeds copy them, so the UP-tree
+        // snapshot must contain them.
+        s.up_log.push(u);
         let rs = down_rev.offsets[u as usize] as usize;
         let re = down_rev.offsets[u as usize + 1] as usize;
         let mut stalled = false;
@@ -824,5 +822,21 @@ fn upward_sweep_body(
                 s.push_up(v, nd);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arc_owner_basics() {
+        let offsets: Vec<u64> = vec![0, 3, 3, 7, 10];
+        assert_eq!(arc_owner(&offsets, 0), 0);
+        assert_eq!(arc_owner(&offsets, 2), 0);
+        assert_eq!(arc_owner(&offsets, 3), 2); // node 1 is empty
+        assert_eq!(arc_owner(&offsets, 6), 2);
+        assert_eq!(arc_owner(&offsets, 7), 3);
+        assert_eq!(arc_owner(&offsets, 9), 3);
     }
 }

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2464,53 +2464,27 @@ pub fn do_edges_batch(
             }
             let chunk = &group_vec[gi..gj];
             gi = gj;
-            // #438 K-lane: shorts ride the grouped path per-group; longs are
-            // batched TREE_LANES at a time (shared selection + one scan).
-            let (shorts, longs): (Vec<_>, Vec<_>) = chunk
-                .iter()
-                .partition::<Vec<&(u32, Vec<GroupedTarget>)>, _>(|(_, targets)| {
-                    const GC_SWITCH_M: f64 = 15_000.0;
-                    targets
-                        .iter()
-                        .map(|t| {
-                            crate::nbg::haversine_distance(
-                                t.pair[1], t.pair[0], t.pair[3], t.pair[2],
-                            )
-                        })
-                        .fold(0.0_f64, f64::max)
-                        <= GC_SWITCH_M
-                });
-            let long_batches: Vec<Vec<(u32, Vec<GroupedTarget>)>> = Vec::new();
-            let _ = &long_batches; // replaced below
-            let long_refs: Vec<&(u32, Vec<GroupedTarget>)> = longs;
-            let long_batches: Vec<Vec<&(u32, Vec<GroupedTarget>)>> = long_refs
+            // #438: every group rides the K-lane tree — post-interleave/
+            // snapshot/locality the tree beats the grouped path on BOTH
+            // workload shapes (B 2.55×, C 1.40× vs grouped, oracle green),
+            // so the old 15 km adaptive dispatch is retired. Rank-sort for
+            // locality (ND ranks are spatially coherent → tight unions).
+            let mut group_refs: Vec<&(u32, Vec<GroupedTarget>)> = chunk.iter().collect();
+            group_refs.sort_unstable_by_key(|(src, _)| *src);
+            let batches: Vec<Vec<&(u32, Vec<GroupedTarget>)>> = group_refs
                 .chunks(crate::range::tree_phast::TREE_LANES)
                 .map(|c| c.to_vec())
                 .collect();
             let per_pair: Vec<PairEdges> = if parallel {
-                let mut v: Vec<PairEdges> = shorts
+                batches
                     .par_iter()
-                    .flat_map(|(src_rank, targets)| {
-                        process_source_group(&state, &mode_data, mode, *src_rank, targets)
-                    })
-                    .collect();
-                v.par_extend(
-                    long_batches
-                        .par_iter()
-                        .flat_map_iter(|b| process_tree_batch(&state, &mode_data, mode, b)),
-                );
-                v
+                    .flat_map_iter(|b| process_tree_batch(&state, &mode_data, mode, b))
+                    .collect()
             } else {
-                let mut v: Vec<PairEdges> = shorts
+                batches
                     .iter()
-                    .flat_map(|(src_rank, targets)| {
-                        process_source_group(&state, &mode_data, mode, *src_rank, targets)
-                    })
-                    .collect();
-                for b in &long_batches {
-                    v.extend(process_tree_batch(&state, &mode_data, mode, b));
-                }
-                v
+                    .flat_map(|b| process_tree_batch(&state, &mode_data, mode, b))
+                    .collect()
             };
             if !emit(per_pair) {
                 return;

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2223,7 +2223,13 @@ pub fn compute_edges_tree(
 ) -> Vec<PairEdges> {
     let (group_vec, per_pair_work) = group_pairs(state, mode_data, mode, pairs, parallel);
 
-    let group_refs: Vec<&(u32, Vec<GroupedTarget>)> = group_vec.iter().collect();
+    // Locality batching: CCH ranks come from nested dissection, so
+    // rank-adjacent sources are spatially close. Sorting groups by source
+    // rank before chunking keeps each K-lane batch's union selection tight
+    // (an arrival-order batch can mix sources from different cities, and
+    // every lane then pays the scan over the union's full ancestry).
+    let mut group_refs: Vec<&(u32, Vec<GroupedTarget>)> = group_vec.iter().collect();
+    group_refs.sort_unstable_by_key(|(src, _)| *src);
     let batches: Vec<Vec<&(u32, Vec<GroupedTarget>)>> = group_refs
         .chunks(crate::range::tree_phast::TREE_LANES)
         .map(|c| c.to_vec())
@@ -2268,9 +2274,7 @@ fn process_tree_batch(
     mode: Mode,
     batch: &[&(u32, Vec<GroupedTarget>)],
 ) -> Vec<PairEdges> {
-    use crate::range::tree_phast::{
-        TreeSettle, tree_lane_backtrack, tree_resweep, tree_settle_restricted_batch,
-    };
+    use crate::range::tree_phast::{TreeSettle, tree_lane_backtrack, tree_settle_restricted_batch};
     let sources: Vec<u32> = batch.iter().map(|(s, _)| *s).collect();
     let union_targets: Vec<u32> = batch
         .iter()
@@ -2290,14 +2294,6 @@ fn process_tree_batch(
         ) == TreeSettle::Ok;
 
     for (k, (src_rank, targets)) in batch.iter().enumerate() {
-        if settled {
-            tree_resweep(
-                &mode_data.cch_topo,
-                &mode_data.cch_weights,
-                &mode_data.down_rev_flat,
-                *src_rank,
-            );
-        }
         for t in targets {
             let hit = if settled {
                 t.dst_rank

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -3850,61 +3850,6 @@ fn try_load_edge_geometry(
     Ok(Some(eg))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::build_role_masks;
-    use crate::formats::FilteredEbg;
-    use crate::profile_abi::Mode;
-
-    fn tiny_filtered_ebg(offsets: Vec<u64>, heads: Vec<u32>) -> FilteredEbg {
-        let n = offsets.len() - 1;
-        FilteredEbg {
-            mode: Mode(1),
-            n_filtered_nodes: n as u32,
-            n_filtered_arcs: heads.len() as u64,
-            n_original_nodes: n as u32,
-            inputs_sha: [0; 32],
-            offsets: crate::formats::ArcCow::from_vec(offsets),
-            heads: crate::formats::ArcCow::from_vec(heads.clone()),
-            original_arc_idx: crate::formats::ArcCow::from_vec((0..heads.len() as u32).collect()),
-            filtered_to_original: crate::formats::ArcCow::from_vec((0..n as u32).collect()),
-            original_to_filtered: crate::formats::ArcCow::from_vec((0..n as u32).collect()),
-        }
-    }
-
-    fn bit(mask: &[u64], node: usize) -> bool {
-        (mask[node / 64] & (1u64 << (node % 64))) != 0
-    }
-
-    #[test]
-    fn role_masks_keep_core_reachable_stubs_and_drop_small_sccs() {
-        // 0 -> 1, 1 <-> 2 <-> 6, 2 -> 3, plus isolated 4 <-> 5.
-        // The largest SCC is {1,2,6}. Sources may include 0 because it
-        // can reach the core; destinations may include 3 because the
-        // core can reach it. The isolated SCC looks internally valid
-        // but is not useful for Belgium-wide table/route snaps.
-        let fe = tiny_filtered_ebg(vec![0, 1, 2, 5, 5, 6, 7, 8], vec![1, 2, 1, 6, 3, 5, 4, 1]);
-
-        let (src, dst) = build_role_masks(&fe);
-
-        assert!(bit(&src, 0));
-        assert!(bit(&src, 1));
-        assert!(bit(&src, 2));
-        assert!(!bit(&src, 3));
-        assert!(!bit(&src, 4));
-        assert!(!bit(&src, 5));
-        assert!(bit(&src, 6));
-
-        assert!(!bit(&dst, 0));
-        assert!(bit(&dst, 1));
-        assert!(bit(&dst, 2));
-        assert!(bit(&dst, 3));
-        assert!(!bit(&dst, 4));
-        assert!(!bit(&dst, 5));
-        assert!(bit(&dst, 6));
-    }
-}
-
 /// #450: field-clone a loaded ModeData. Cheap on the container path — every
 /// heavy field is Arc/mmap-backed (ArcCow / WeightArray / flats borrowed from
 /// the container mapping); only small Vecs copy. Used to register
@@ -4100,5 +4045,60 @@ fn read_recustomize_cache(
             tracing::info!(error = %e, path = %path.display(), "recustomize cache unusable — recomputing");
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_role_masks;
+    use crate::formats::FilteredEbg;
+    use crate::profile_abi::Mode;
+
+    fn tiny_filtered_ebg(offsets: Vec<u64>, heads: Vec<u32>) -> FilteredEbg {
+        let n = offsets.len() - 1;
+        FilteredEbg {
+            mode: Mode(1),
+            n_filtered_nodes: n as u32,
+            n_filtered_arcs: heads.len() as u64,
+            n_original_nodes: n as u32,
+            inputs_sha: [0; 32],
+            offsets: crate::formats::ArcCow::from_vec(offsets),
+            heads: crate::formats::ArcCow::from_vec(heads.clone()),
+            original_arc_idx: crate::formats::ArcCow::from_vec((0..heads.len() as u32).collect()),
+            filtered_to_original: crate::formats::ArcCow::from_vec((0..n as u32).collect()),
+            original_to_filtered: crate::formats::ArcCow::from_vec((0..n as u32).collect()),
+        }
+    }
+
+    fn bit(mask: &[u64], node: usize) -> bool {
+        (mask[node / 64] & (1u64 << (node % 64))) != 0
+    }
+
+    #[test]
+    fn role_masks_keep_core_reachable_stubs_and_drop_small_sccs() {
+        // 0 -> 1, 1 <-> 2 <-> 6, 2 -> 3, plus isolated 4 <-> 5.
+        // The largest SCC is {1,2,6}. Sources may include 0 because it
+        // can reach the core; destinations may include 3 because the
+        // core can reach it. The isolated SCC looks internally valid
+        // but is not useful for Belgium-wide table/route snaps.
+        let fe = tiny_filtered_ebg(vec![0, 1, 2, 5, 5, 6, 7, 8], vec![1, 2, 1, 6, 3, 5, 4, 1]);
+
+        let (src, dst) = build_role_masks(&fe);
+
+        assert!(bit(&src, 0));
+        assert!(bit(&src, 1));
+        assert!(bit(&src, 2));
+        assert!(!bit(&src, 3));
+        assert!(!bit(&src, 4));
+        assert!(!bit(&src, 5));
+        assert!(bit(&src, 6));
+
+        assert!(!bit(&dst, 0));
+        assert!(bit(&dst, 1));
+        assert!(bit(&dst, 2));
+        assert!(bit(&dst, 3));
+        assert!(!bit(&dst, 4));
+        assert!(!bit(&dst, 5));
+        assert!(bit(&dst, 6));
     }
 }


### PR DESCRIPTION
Four levers on the K-lane tree (idle-gated magellan, seed 11, oracle = reachability+duration equivalence & row-chain continuity, all green):

| shape | before (PR #458) | after | Δ |
|---|---|---|---|
| B (0.30) | 23.0k pairs/s | **28.1k** | +22% (5.98× flat, 2.55× grouped) |
| C (0.08) | 35.2k | **46.4k** | +32% (1.40× grouped) |

1. **Interleaved lane arrays** `[pos*k + lane]` — one contiguous cache line per arc endpoint instead of k strided; branch-free inner loop vectorizes.
2. **UP-tree snapshots** — seed sweep's parents snapshotted (sorted nodes + final tagged arcs); backtracks binary-search the snapshot. Kills the per-lane resweep (upward work halved).
3. **Locality batching** — groups rank-sorted before 8-lane chunking (ND ranks are spatially coherent → tight union selections).
4. **Always-tree** — the 15 km adaptive dispatch retired; tree wins both shapes now.

Also: `#[cfg(test)]` modules relocated to EOF in tree_phast.rs/state.rs (`items_after_test_module` under the full clippy gate) and TREE phase counters wired in the batch path (B split now: sel 0.8s / up 3.2s / scan 4.5s — next lever = RPHAST-restricting the UP sweep, tracked in #438).

Full clippy (`--workspace --all-targets --all-features`): 0. 633 lib tests.