### PR TITLE
feat(flight): edges_flow — server-side weighted flow accumulation (#460) + --transit toggle

### DIFF
--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -4928,6 +4928,96 @@ fn run_edges_batch_bench(
         flat_dt / tree_dt,
         grouped_dt / tree_dt
     );
+
+    // ---- #460 edges_flow: exact oracle vs aggregated TREE rows ----
+    // The flow path walks the SAME lane chains as compute_edges_tree and
+    // rides the SAME per-pair fallback, so aggregating tree rows × weight
+    // must reproduce the flow table EXACTLY (f64 addition order aside).
+    {
+        use butterfly_route::server::flow::compute_edges_flow;
+        use std::collections::HashMap;
+
+        let weights: Vec<f64> = (0..n_pairs).map(|i| 1.0 + (i % 7) as f64 * 0.25).collect();
+        let groups: Vec<u32> = (0..n_pairs).map(|i| (i % 3) as u32).collect();
+        let (flow_rows, summary) =
+            compute_edges_flow(&state, &mode_data, mode, &pairs, &weights, &groups, true);
+
+        let mut ref_map: HashMap<(u32, i64, i64), f64> = HashMap::new();
+        let mut tree_total_rows = 0usize;
+        for p in &tree {
+            if p.rows.is_empty() {
+                continue;
+            }
+            tree_total_rows += p.rows.len();
+            let w = weights[p.query_idx as usize];
+            let g = groups[p.query_idx as usize];
+            for r in &p.rows {
+                *ref_map.entry((g, r.osm_from, r.osm_to)).or_default() += w;
+            }
+        }
+        assert_eq!(
+            flow_rows.len(),
+            ref_map.len(),
+            "FLOW distinct-edge count mismatch vs aggregated TREE rows"
+        );
+        let mut max_rel = 0.0_f64;
+        for r in &flow_rows {
+            let reference = ref_map
+                .get(&(r.group, r.osm_from, r.osm_to))
+                .copied()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "FLOW edge ({},{},{}) absent from TREE aggregate",
+                        r.group, r.osm_from, r.osm_to
+                    )
+                });
+            let rel = (r.flow - reference).abs() / reference.abs().max(1.0);
+            max_rel = max_rel.max(rel);
+        }
+        assert!(
+            max_rel < 1e-9,
+            "FLOW value drift vs TREE aggregate: {max_rel}"
+        );
+
+        // Summary invariants vs the FLAT ground truth (reachability is
+        // already asserted identical across variants above).
+        let flat_unreachable = flat.iter().filter(|p| p.rows.is_empty()).count() as u64;
+        assert_eq!(summary.n_pairs, n_pairs as u64);
+        assert_eq!(summary.n_unreachable, flat_unreachable, "unreachable count");
+        let expect_assigned: f64 = flat
+            .iter()
+            .filter(|p| !p.rows.is_empty())
+            .map(|p| weights[p.query_idx as usize])
+            .sum();
+        let rel = (summary.total_weight_assigned - expect_assigned).abs()
+            / expect_assigned.abs().max(1.0);
+        assert!(rel < 1e-9, "conservation drift: {rel}");
+        println!();
+        println!("  EDGES_FLOW (#460): oracle vs TREE aggregate EXACT (max rel {max_rel:.1e})");
+        println!(
+            "    ✓ conservation: assigned {:.2} / in {:.2}, unreachable {}",
+            summary.total_weight_assigned, summary.total_weight_in, summary.n_unreachable
+        );
+        println!(
+            "    wire rows: {} flow rows vs {} per-pair rows ({:.0}× compression)",
+            flow_rows.len(),
+            tree_total_rows,
+            tree_total_rows as f64 / flow_rows.len().max(1) as f64
+        );
+
+        let mut flow_dt = f64::MAX;
+        for _ in 0..2 {
+            let t0 = Instant::now();
+            let _ = compute_edges_flow(&state, &mode_data, mode, &pairs, &weights, &groups, true);
+            flow_dt = flow_dt.min(t0.elapsed().as_secs_f64());
+        }
+        println!(
+            "    FLOW    {:.3}s  {:.0} pairs/s  ({:.2}× vs TREE-with-rows)",
+            flow_dt,
+            n_pairs as f64 / flow_dt,
+            tree_dt / flow_dt
+        );
+    }
     println!("═══════════════════════════════════════════════════════════════");
     Ok(())
 }

--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -725,6 +725,15 @@ pub enum Commands {
         #[arg(long)]
         modes: Option<String>,
 
+        /// Transit subsystem toggle: "on" (default) or "off". With "off",
+        /// `transit/` directories are ignored entirely — no feed parse, no
+        /// transfer-graph build/load — even when the foot mode is loaded.
+        /// Lean road-only deployments iterate much faster this way; flip
+        /// back to "on" (or drop the flag) to re-enable multimodal.
+        /// Env override: `BUTTERFLY_TRANSIT=off`.
+        #[arg(long, default_value = "on")]
+        transit: String,
+
         /// Load only specific regions (comma-separated). Default: every
         /// `*.butterfly` container in `--data-dir` is loaded.
         /// Example: `--regions BE,LU`. Ignored when `--data` is used
@@ -2116,6 +2125,7 @@ impl Cli {
                 grpc_port,
                 transport,
                 modes,
+                transit,
                 regions,
                 eager_regions,
                 rss_budget_gb,
@@ -2152,6 +2162,15 @@ impl Cli {
                 // so the compactor reads it without growing serve()'s sig.
                 if let Some(secs) = idle_compact_secs {
                     crate::server::set_idle_compact_secs(secs);
+                }
+                // Lean-deploy transit toggle: CLI flag or BUTTERFLY_TRANSIT
+                // env; "off"/"0"/"false"/"no" disables.
+                let transit_off = matches!(transit.to_lowercase().as_str(), "off" | "0" | "false")
+                    || std::env::var("BUTTERFLY_TRANSIT")
+                        .map(|v| matches!(v.to_lowercase().as_str(), "off" | "0" | "false" | "no"))
+                        .unwrap_or(false);
+                if transit_off {
+                    crate::server::set_transit_enabled(false);
                 }
 
                 let transport_mode = server::Transport::parse(&transport)?;

--- a/route/src/range/tree_phast.rs
+++ b/route/src/range/tree_phast.rs
@@ -42,8 +42,8 @@ use std::collections::BinaryHeap;
 const BLOCK_SIZE: usize = 4096;
 
 /// Direction tag on the parent arc: set ⇒ DOWN arc, clear ⇒ UP arc.
-const DOWN_BIT: u32 = 1 << 31;
-const ARC_MASK: u32 = DOWN_BIT - 1;
+pub(crate) const DOWN_BIT: u32 = 1 << 31;
+pub(crate) const ARC_MASK: u32 = DOWN_BIT - 1;
 
 struct TreeScratch {
     dist: Vec<u32>,
@@ -529,7 +529,7 @@ pub fn tree_backtrack(topo: &CchTopo, origin: u32, target: u32) -> Option<TreePa
 /// (`offsets[node] <= arc < offsets[node+1]`). Binary search — ~23 steps on a
 /// 5M-node graph.
 #[inline]
-fn arc_owner(offsets: &[u64], arc: usize) -> usize {
+pub(crate) fn arc_owner(offsets: &[u64], arc: usize) -> usize {
     let a = arc as u64;
     // partition_point returns the first index with offsets[idx] > arc;
     // the owner is that index - 1.
@@ -764,6 +764,85 @@ pub fn tree_lane_backtrack(topo: &CchTopo, k: usize, source: u32, target: u32) -
                     let srcn = arc_owner(&topo.up_offsets, arc) as u32;
                     forward_rev.push((srcn, tagged & ARC_MASK));
                     cur = srcn;
+                }
+                None
+            },
+        )
+    })
+}
+
+/// #460: collect every CCH arc on lane `k`'s `source → target` tree path
+/// into `buf` (cleared first) WITHOUT materializing a [`TreePath`]. Arcs are
+/// tagged (`DOWN_BIT | down_idx` for DOWN arcs, plain `up_idx` for UP arcs);
+/// order is unspecified — flow accumulation is order-independent. Returns
+/// the path's total distance; on `None` (lane can't serve the target —
+/// caller falls back, same contract as [`tree_lane_backtrack`]) `buf`
+/// content is unspecified and MUST NOT be committed, so partial walks can
+/// never double-count against the fallback path.
+pub fn tree_lane_path_arcs(
+    topo: &CchTopo,
+    k: usize,
+    source: u32,
+    target: u32,
+    buf: &mut Vec<u32>,
+) -> Option<u32> {
+    buf.clear();
+    let n = topo.n_nodes as usize;
+    TREE_SCRATCH.with(|cell| {
+        cell.with_or_init(
+            || TreeScratch::new(n),
+            |s| {
+                if s.dist.len() != n || k >= s.lane_k || s.lane_sources.get(k) != Some(&source) {
+                    return None;
+                }
+                let lane_k = s.lane_k;
+                let ti = target as usize;
+                if ti >= n || s.sel_gen[ti] != s.sel_epoch {
+                    return None;
+                }
+                let tpos = (s.sel_pos[ti] - 1) as usize;
+                let dist = s.lane_dist[tpos * lane_k + k];
+                if dist == u32::MAX {
+                    return None;
+                }
+                if source == target {
+                    return Some(0); // path = the source EBG node alone
+                }
+                // DOWN chain target→apex.
+                let mut cur_pos = tpos;
+                let mut cur_node = target;
+                for _ in 0..100_000 {
+                    let lp = s.lane_parent[cur_pos * lane_k + k];
+                    if lp == LANE_NONE {
+                        break; // apex
+                    }
+                    buf.push(lp | DOWN_BIT);
+                    let src = arc_owner(&topo.down_offsets, lp as usize) as u32;
+                    cur_node = src;
+                    if s.sel_gen[cur_node as usize] != s.sel_epoch {
+                        return None; // corrupt — caller falls back
+                    }
+                    cur_pos = (s.sel_pos[cur_node as usize] - 1) as usize;
+                }
+                // UP chain apex→source from the lane snapshot.
+                let seg_s = s.lane_up_off[k] as usize;
+                let seg_e = s.lane_up_off[k + 1] as usize;
+                let seg = &s.lane_up_nodes[seg_s..seg_e];
+                let segp = &s.lane_up_parent[seg_s..seg_e];
+                let mut cur = cur_node;
+                for _ in 0..100_000 {
+                    if cur == source {
+                        return Some(dist);
+                    }
+                    let Ok(idx) = seg.binary_search(&cur) else {
+                        return None;
+                    };
+                    let tagged = segp[idx];
+                    if tagged & DOWN_BIT != 0 {
+                        return None;
+                    }
+                    buf.push(tagged & ARC_MASK);
+                    cur = arc_owner(&topo.up_offsets, (tagged & ARC_MASK) as usize) as u32;
                 }
                 None
             },

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -314,6 +314,22 @@ pub fn edges_batch_schema() -> Schema {
     ])
 }
 
+/// Schema for the `edges_flow` DoExchange action (#460).
+///
+/// ONE row per `(group, directed edge)` with the accumulated flow —
+/// the server-side replacement for streaming per-pair edge lists that the
+/// consumer immediately re-aggregates. A trailing empty FlightData carries
+/// the conservation summary as JSON `app_metadata`:
+/// `{"n_pairs", "n_unreachable", "total_weight_in", "total_weight_assigned"}`.
+pub fn edges_flow_schema() -> Schema {
+    Schema::new(vec![
+        Field::new("group", DataType::UInt32, false),
+        Field::new("osm_node_from", DataType::Int64, false),
+        Field::new("osm_node_to", DataType::Int64, false),
+        Field::new("flow", DataType::Float64, false),
+    ])
+}
+
 /// Schema for `transit_bulk` Flight action (#119).
 ///
 /// One row per query in the batch. Successful queries carry the full
@@ -1731,7 +1747,7 @@ pub struct PairEdges {
 /// the first try. `CchQuery::new` is free (just references + a
 /// thread-local scratch reused across pairs on the same worker), so
 /// constructing it per pair carries no allocation.
-fn edges_for_pair(
+pub(crate) fn edges_for_pair(
     state: &ServerState,
     mode_data: &super::state::ModeData,
     mode: Mode,
@@ -1920,10 +1936,10 @@ fn resolve_k1_rank(
 /// #438: one target of a source group: its original flat `query_idx`, the raw
 /// coords (for the per-pair escalation fallback), and its K=1 destination rank
 /// (`None` ⇒ the K=1 dst snap missed → must fall back to per-pair).
-struct GroupedTarget {
-    query_idx: u32,
-    pair: [f64; 4],
-    dst_rank: Option<u32>,
+pub(crate) struct GroupedTarget {
+    pub(crate) query_idx: u32,
+    pub(crate) pair: [f64; 4],
+    pub(crate) dst_rank: Option<u32>,
 }
 
 /// #438: process one source group — settle the forward CCH search ONCE for
@@ -1987,8 +2003,8 @@ fn process_source_group(
 /// source (K=1 resolved but only 1 target, so no forward-sharing benefit) or a
 /// K=1-source-miss (needs K=64 escalation). Carries any already-resolved K=1
 /// ranks so `process_per_pair_work` can skip the redundant snap.
-struct PerPairWork {
-    query_idx: u32,
+pub(crate) struct PerPairWork {
+    pub(crate) query_idx: u32,
     pair: [f64; 4],
     /// K=1 source rank, if it resolved (singleton); `None` ⇒ K=1 src missed.
     src_rank: Option<u32>,
@@ -2002,7 +2018,7 @@ struct PerPairWork {
 /// double-snap fix). Anything that misses (no precomputed ranks, or the K=1
 /// query doesn't connect) falls through to the full per-pair `edges_for_pair`
 /// (K=1 snap + K=64 + 16-combo escalation), byte-identical to today.
-fn process_per_pair_work(
+pub(crate) fn process_per_pair_work(
     state: &ServerState,
     mode_data: &super::state::ModeData,
     mode: Mode,
@@ -2037,7 +2053,7 @@ fn process_per_pair_work(
 /// the early-terminated bidirectional cost and avoids a regression on
 /// distinct-pair (1 target/source) workloads.
 #[allow(clippy::type_complexity)]
-fn group_pairs(
+pub(crate) fn group_pairs(
     state: &ServerState,
     mode_data: &super::state::ModeData,
     mode: Mode,
@@ -2755,6 +2771,152 @@ fn catchment_schema() -> Schema {
 ///
 /// Input: flat denormalized Arrow table (store_id, store_lon, store_lat, client_lon, client_lat).
 /// Output: per-store × per-percentile polygon results.
+/// #460 `edges_flow` DoExchange: weighted OD pairs in, accumulated
+/// per-edge flow out. Input columns: `src_lon, src_lat, dst_lon, dst_lat`
+/// (f64, required), `weight` (f64, optional — default 1.0), `group`
+/// (u32, optional — default 0). Output: [`edges_flow_schema`] rows sorted
+/// by `(group, osm_node_from, osm_node_to)`, then one empty FlightData
+/// whose `app_metadata` is the JSON conservation summary.
+async fn do_exchange_edges_flow(
+    state: Arc<ServerState>,
+    mode: Mode,
+    batches: &[RecordBatch],
+) -> std::result::Result<
+    Response<Pin<Box<dyn futures::Stream<Item = std::result::Result<FlightData, Status>> + Send>>>,
+    Status,
+> {
+    const MAX_FLOW_PAIRS: usize = 2_000_000;
+
+    let mut pairs: Vec<[f64; 4]> = Vec::new();
+    let mut weights: Vec<f64> = Vec::new();
+    let mut groups: Vec<u32> = Vec::new();
+
+    for batch in batches {
+        let f64_col = |name: &str| -> std::result::Result<&Float64Array, Status> {
+            batch
+                .column_by_name(name)
+                .ok_or_else(|| Status::invalid_argument(format!("missing '{name}'")))?
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| Status::invalid_argument(format!("{name} must be f64")))
+        };
+        let slon = f64_col("src_lon")?;
+        let slat = f64_col("src_lat")?;
+        let dlon = f64_col("dst_lon")?;
+        let dlat = f64_col("dst_lat")?;
+        // weight / group are optional with documented defaults.
+        let weight = match batch.column_by_name("weight") {
+            Some(c) => Some(
+                c.as_any()
+                    .downcast_ref::<Float64Array>()
+                    .ok_or_else(|| Status::invalid_argument("weight must be f64"))?,
+            ),
+            None => None,
+        };
+        let group = match batch.column_by_name("group") {
+            Some(c) => Some(
+                c.as_any()
+                    .downcast_ref::<arrow::array::UInt32Array>()
+                    .ok_or_else(|| Status::invalid_argument("group must be u32"))?,
+            ),
+            None => None,
+        };
+
+        for i in 0..batch.num_rows() {
+            let pair = [slon.value(i), slat.value(i), dlon.value(i), dlat.value(i)];
+            validate_coord(pair[0], pair[1], &format!("row[{i}].src"))?;
+            validate_coord(pair[2], pair[3], &format!("row[{i}].dst"))?;
+            let w = weight.map(|a| a.value(i)).unwrap_or(1.0);
+            if !w.is_finite() || w < 0.0 {
+                return Err(Status::invalid_argument(format!(
+                    "row[{i}].weight must be finite and >= 0 (got {w})"
+                )));
+            }
+            pairs.push(pair);
+            weights.push(w);
+            groups.push(group.map(|a| a.value(i)).unwrap_or(0));
+        }
+        if pairs.len() > MAX_FLOW_PAIRS {
+            return Err(Status::invalid_argument(format!(
+                "max {MAX_FLOW_PAIRS} pairs per edges_flow request"
+            )));
+        }
+    }
+    if pairs.is_empty() {
+        return Err(Status::invalid_argument("no input rows"));
+    }
+
+    let schema = Arc::new(edges_flow_schema());
+    let (tx, rx) = tokio::sync::mpsc::channel::<std::result::Result<RecordBatch, Status>>(32);
+    let (sum_tx, sum_rx) = tokio::sync::oneshot::channel::<String>();
+
+    let schema_clone = schema.clone();
+    tokio::task::spawn_blocking(move || {
+        let start = std::time::Instant::now();
+        let n_pairs = pairs.len();
+        let mode_data = state.get_mode(mode);
+        let (rows, summary) = super::flow::compute_edges_flow(
+            &state, &mode_data, mode, &pairs, &weights, &groups, true,
+        );
+        tracing::info!(
+            n_pairs,
+            n_rows = rows.len(),
+            n_unreachable = summary.n_unreachable,
+            total_weight_in = summary.total_weight_in,
+            total_weight_assigned = summary.total_weight_assigned,
+            elapsed_s = start.elapsed().as_secs_f64(),
+            "do_exchange edges_flow"
+        );
+
+        const ROWS_PER_BATCH: usize = 65_536;
+        for chunk in rows.chunks(ROWS_PER_BATCH) {
+            let mut g_b = UInt32Builder::with_capacity(chunk.len());
+            let mut from_b = Int64Builder::with_capacity(chunk.len());
+            let mut to_b = Int64Builder::with_capacity(chunk.len());
+            let mut flow_b = Float64Builder::with_capacity(chunk.len());
+            for r in chunk {
+                g_b.append_value(r.group);
+                from_b.append_value(r.osm_from);
+                to_b.append_value(r.osm_to);
+                flow_b.append_value(r.flow);
+            }
+            let batch = RecordBatch::try_new(
+                schema_clone.clone(),
+                vec![
+                    Arc::new(g_b.finish()),
+                    Arc::new(from_b.finish()),
+                    Arc::new(to_b.finish()),
+                    Arc::new(flow_b.finish()),
+                ],
+            )
+            .map_err(|e| Status::internal(format!("batch build error: {e}")));
+            if tx.blocking_send(batch).is_err() {
+                return; // client went away — cooperative cancel
+            }
+        }
+        let summary_json = format!(
+            r#"{{"n_pairs":{},"n_unreachable":{},"total_weight_in":{},"total_weight_assigned":{}}}"#,
+            summary.n_pairs,
+            summary.n_unreachable,
+            summary.total_weight_in,
+            summary.total_weight_assigned
+        );
+        let _ = sum_tx.send(summary_json);
+    });
+
+    let batch_stream: BatchStream = Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx));
+    let flight_stream = batches_to_flight_data(schema, batch_stream);
+    // Trailing summary message: empty body, JSON app_metadata.
+    let trailer = futures::stream::once(async move {
+        let json = sum_rx.await.unwrap_or_default();
+        Ok(FlightData {
+            app_metadata: json.into_bytes().into(),
+            ..Default::default()
+        })
+    });
+    Ok(Response::new(Box::pin(flight_stream.chain(trailer))))
+}
+
 async fn do_exchange_catchment(
     state: Arc<ServerState>,
     mode: Mode,
@@ -3343,18 +3505,16 @@ impl FlightService for ButterflyFlight {
         let cmd = std::str::from_utf8(&descriptor_cmd)
             .map_err(|_| Status::invalid_argument("cmd must be UTF-8"))?;
 
-        // Parse: catchment:profile:params_json
+        // Parse: <action>:profile:params_json
         let parts: Vec<&str> = cmd.splitn(3, ':').collect();
-        if parts.is_empty() || parts[0] != "catchment" {
+        if parts.is_empty() || !matches!(parts[0], "catchment" | "edges_flow") {
             return Err(Status::invalid_argument(
-                "do_exchange supports 'catchment:profile[:params_json]'",
+                "do_exchange supports 'catchment:profile[:params_json]' and 'edges_flow:profile'",
             ));
         }
+        let action = parts[0];
         let profile = parts.get(1).copied().unwrap_or("car");
         let params_json = parts.get(2).copied().unwrap_or("{}");
-
-        let cp = super::catchment::parse_exchange_params(params_json)
-            .map_err(Status::invalid_argument)?;
 
         // Decode FlightData into RecordBatches
         let ipc_messages: Vec<FlightData> = all_fds
@@ -3373,19 +3533,49 @@ impl FlightService for ButterflyFlight {
             return Err(Status::invalid_argument("no data received"));
         }
 
-        // #336: snap the first store coordinate to pick the region.
-        // Catchment input schema: (store_id, store_lon, store_lat,
-        // client_lon, client_lat). Mixed-region inputs in a single
-        // batch are a follow-up — for now the first row picks.
-        let (store_lon, store_lat) = first_store_lonlat(&batches).ok_or_else(|| {
-            Status::invalid_argument(
-                "no rows in input batches — need at least one (store_lon, store_lat)",
-            )
-        })?;
-        let (state, _region) = self.dispatch_for_point(store_lon, store_lat, profile)?;
-        let mode = resolve_mode(profile, &state)?;
+        match action {
+            "edges_flow" => {
+                // #336: first src coordinate picks the region.
+                let (lon, lat) = batches
+                    .iter()
+                    .find(|b| b.num_rows() > 0)
+                    .and_then(|b| {
+                        let lon = b
+                            .column_by_name("src_lon")?
+                            .as_any()
+                            .downcast_ref::<Float64Array>()?;
+                        let lat = b
+                            .column_by_name("src_lat")?
+                            .as_any()
+                            .downcast_ref::<Float64Array>()?;
+                        Some((lon.value(0), lat.value(0)))
+                    })
+                    .ok_or_else(|| {
+                        Status::invalid_argument("need at least one row with (src_lon, src_lat)")
+                    })?;
+                let (state, _region) = self.dispatch_for_point(lon, lat, profile)?;
+                let mode = resolve_mode(profile, &state)?;
+                do_exchange_edges_flow(state, mode, &batches).await
+            }
+            _ => {
+                let cp = super::catchment::parse_exchange_params(params_json)
+                    .map_err(Status::invalid_argument)?;
 
-        do_exchange_catchment(state, mode, cp, &batches).await
+                // #336: snap the first store coordinate to pick the region.
+                // Catchment input schema: (store_id, store_lon, store_lat,
+                // client_lon, client_lat). Mixed-region inputs in a single
+                // batch are a follow-up — for now the first row picks.
+                let (store_lon, store_lat) = first_store_lonlat(&batches).ok_or_else(|| {
+                    Status::invalid_argument(
+                        "no rows in input batches — need at least one (store_lon, store_lat)",
+                    )
+                })?;
+                let (state, _region) = self.dispatch_for_point(store_lon, store_lat, profile)?;
+                let mode = resolve_mode(profile, &state)?;
+
+                do_exchange_catchment(state, mode, cp, &batches).await
+            }
+        }
     }
 
     async fn do_action(

--- a/route/src/server/flow.rs
+++ b/route/src/server/flow.rs
@@ -1,0 +1,426 @@
+//! #460 `edges_flow` — server-side weighted flow accumulation on the
+//! predecessor tree.
+//!
+//! `edges_batch` streams every pair's full edge list (~370 rows/pair) only
+//! for the consumer to `GROUP BY (node_from, node_to)` it straight back
+//! down — a measured ~2,000× compression ratio thrown away on the wire.
+//! `edges_flow` keeps the same routing core (snap → source-group → K-lane
+//! restricted tree, #438/#439) but accumulates each pair's `weight` on its
+//! path server-side and emits ONE row per traversed edge per `group`.
+//!
+//! ## Why accumulation runs on CCH arcs, not unpacked EBG edges
+//!
+//! A pair's tree path is ~10-40 CCH arcs (UP\*DOWN\*) but unpacks to ~370
+//! EBG edges — the unpack is the dominant per-pair cost (#436). So:
+//!
+//! 1. **Deposit** each pair's weight on its tagged CCH arcs (cheap chain
+//!    walk via [`tree_lane_path_arcs`]) plus one deposit on the source EBG
+//!    rank (the unpacked path starts with the source node itself).
+//! 2. **Cascade** shortcut flow to its two children once per DISTINCT
+//!    `(group, arc)`: a shortcut `u→v` with middle `m` expands to
+//!    `(u→m, m→v)` exactly as `unpack` does. `rank(middle(child)) <
+//!    rank(middle(parent))` (the child's bypassed node was contracted
+//!    earlier), so popping a max-heap ordered by middle rank processes
+//!    every parent before its children — each arc's flow is final when
+//!    popped, and the cascade is a single pass.
+//! 3. **Flush** base-arc flow to EBG ranks (a base UP/DOWN arc `u→v`
+//!    contributes the rank it appends to the unpacked path: `v`), map
+//!    ranks to OSM endpoints, and merge the fallback rows.
+//!
+//! Pairs the tree can't serve (snap misses, singleton groups, lane
+//! backtrack misses) ride the existing per-pair path and fold their
+//! emitted rows directly into the OSM-keyed accumulator — bit-identical
+//! routing semantics to `edges_batch`, only the aggregation differs.
+//!
+//! Determinism: batches compute in parallel but merge in batch order, the
+//! cascade pops `(middle, arc, group)` tuples (total order), and the final
+//! rows sort by `(group, osm_from, osm_to)` — byte-identical reruns.
+
+use rustc_hash::FxHashMap as HashMap;
+
+use rayon::prelude::*;
+
+use super::flight::{GroupedTarget, PairEdges, PerPairWork};
+use super::state::{ModeData, ServerState};
+use crate::model::types::Mode;
+use crate::range::tree_phast::{
+    ARC_MASK, DOWN_BIT, TREE_LANES, TreeSettle, tree_lane_path_arcs, tree_settle_restricted_batch,
+};
+
+/// Request-level bookkeeping for conservation checks (#460).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct FlowSummary {
+    pub n_pairs: u64,
+    pub n_unreachable: u64,
+    pub total_weight_in: f64,
+    pub total_weight_assigned: f64,
+}
+
+/// One output row: accumulated flow on a directed edge for a class.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FlowRow {
+    pub group: u32,
+    pub osm_from: i64,
+    pub osm_to: i64,
+    pub flow: f64,
+}
+
+/// Per-batch accumulator — merged in batch order for determinism.
+#[derive(Default)]
+struct BatchAcc {
+    /// `(group, tagged CCH arc) → flow` from tree-served pairs.
+    arc_flow: HashMap<(u32, u32), f64>,
+    /// `(group, EBG rank) → flow` — source-rank deposits (the unpacked
+    /// path includes the source EBG node itself).
+    rank_flow: HashMap<(u32, u32), f64>,
+    /// `(group, osm_from, osm_to) → flow` from per-pair fallback rows.
+    row_flow: HashMap<(u32, i64, i64), f64>,
+    n_unreachable: u64,
+    assigned: f64,
+}
+
+impl BatchAcc {
+    fn merge_into(self, total: &mut BatchAcc) {
+        for (k, v) in self.arc_flow {
+            *total.arc_flow.entry(k).or_default() += v;
+        }
+        for (k, v) in self.rank_flow {
+            *total.rank_flow.entry(k).or_default() += v;
+        }
+        for (k, v) in self.row_flow {
+            *total.row_flow.entry(k).or_default() += v;
+        }
+        total.n_unreachable += self.n_unreachable;
+        total.assigned += self.assigned;
+    }
+
+    fn fold_pair_rows(&mut self, group: u32, weight: f64, rows: &[super::flight::EdgeRow]) {
+        if rows.is_empty() {
+            self.n_unreachable += 1;
+            return;
+        }
+        for r in rows {
+            *self
+                .row_flow
+                .entry((group, r.osm_from, r.osm_to))
+                .or_default() += weight;
+        }
+        self.assigned += weight;
+    }
+}
+
+/// One K-lane batch: settle, then deposit every served target's weight on
+/// its CCH arcs + the source rank; misses fall back to the per-pair path
+/// LAST (fallback queries reuse thread-local scratch the lane walk needs).
+fn process_flow_batch(
+    state: &ServerState,
+    mode_data: &ModeData,
+    mode: Mode,
+    batch: &[&(u32, Vec<GroupedTarget>)],
+    weights: &[f64],
+    groups: &[u32],
+) -> BatchAcc {
+    let mut acc = BatchAcc::default();
+    let sources: Vec<u32> = batch.iter().map(|(s, _)| *s).collect();
+    let union_targets: Vec<u32> = batch
+        .iter()
+        .flat_map(|(_, ts)| ts.iter().filter_map(|t| t.dst_rank))
+        .collect();
+
+    let settled = !union_targets.is_empty()
+        && tree_settle_restricted_batch(
+            &mode_data.cch_topo,
+            &mode_data.cch_weights,
+            &mode_data.down_rev_flat,
+            &sources,
+            &union_targets,
+        ) == TreeSettle::Ok;
+
+    let mut fallbacks: Vec<&GroupedTarget> = Vec::new();
+    let mut arc_buf: Vec<u32> = Vec::with_capacity(64);
+    for (k, (src_rank, targets)) in batch.iter().enumerate() {
+        for t in targets {
+            let g = groups[t.query_idx as usize];
+            let w = weights[t.query_idx as usize];
+            let hit = if settled {
+                t.dst_rank.and_then(|dst| {
+                    tree_lane_path_arcs(&mode_data.cch_topo, k, *src_rank, dst, &mut arc_buf)
+                })
+            } else {
+                None
+            };
+            match hit {
+                Some(_dist) => {
+                    for &arc in &arc_buf {
+                        *acc.arc_flow.entry((g, arc)).or_default() += w;
+                    }
+                    *acc.rank_flow.entry((g, *src_rank)).or_default() += w;
+                    acc.assigned += w;
+                }
+                None => fallbacks.push(t),
+            }
+        }
+    }
+    let query = super::query::CchQuery::new(mode_data);
+    for t in fallbacks {
+        let g = groups[t.query_idx as usize];
+        let w = weights[t.query_idx as usize];
+        let pe =
+            super::flight::edges_for_pair(state, mode_data, mode, &query, t.query_idx, &t.pair);
+        acc.fold_pair_rows(g, w, &pe.rows);
+    }
+    acc
+}
+
+/// Middle rank of a tagged shortcut arc (mirrors `unpack`'s relaxed-middle
+/// preference: `CchWeights` middles post-triangle-relaxation, falling back
+/// to the contraction middles).
+#[inline]
+fn arc_middle(mode_data: &ModeData, tagged: u32) -> u32 {
+    let idx = (tagged & ARC_MASK) as usize;
+    if tagged & DOWN_BIT != 0 {
+        if idx < mode_data.cch_weights.down_middle.len() {
+            mode_data.cch_weights.down_middle[idx]
+        } else {
+            mode_data.cch_topo.down_middle.get(idx)
+        }
+    } else if idx < mode_data.cch_weights.up_middle.len() {
+        mode_data.cch_weights.up_middle[idx]
+    } else {
+        mode_data.cch_topo.up_middle.get(idx)
+    }
+}
+
+#[inline]
+fn arc_is_shortcut(mode_data: &ModeData, tagged: u32) -> bool {
+    let idx = (tagged & ARC_MASK) as usize;
+    if tagged & DOWN_BIT != 0 {
+        mode_data.cch_topo.down_is_shortcut.bit(idx)
+    } else {
+        mode_data.cch_topo.up_is_shortcut.bit(idx)
+    }
+}
+
+/// Owner (source node) and target of a tagged arc.
+#[inline]
+fn arc_endpoints(mode_data: &ModeData, tagged: u32) -> (u32, u32) {
+    let idx = (tagged & ARC_MASK) as usize;
+    if tagged & DOWN_BIT != 0 {
+        (
+            crate::range::tree_phast::arc_owner(&mode_data.cch_topo.down_offsets, idx) as u32,
+            mode_data.cch_topo.down_targets[idx],
+        )
+    } else {
+        (
+            crate::range::tree_phast::arc_owner(&mode_data.cch_topo.up_offsets, idx) as u32,
+            mode_data.cch_topo.up_targets[idx],
+        )
+    }
+}
+
+/// Cascade ONE group's shortcut flow down to base arcs, folding base-arc
+/// flow into a fresh per-group rank map. Single pass: max-heap by middle
+/// rank — every parent pops before its children (child middles are
+/// strictly lower-rank), so each arc's flow is final when popped.
+fn cascade_group(mode_data: &ModeData, arc_flow: Vec<(u32, f64)>) -> HashMap<u32, f64> {
+    use std::collections::BinaryHeap;
+
+    let mut rank_flow: HashMap<u32, f64> = HashMap::default();
+    let mut flow: HashMap<u32, f64> = HashMap::default();
+    // (middle, tagged) — total order keeps pop order deterministic.
+    let mut heap: BinaryHeap<(u32, u32)> = BinaryHeap::new();
+
+    let seed = |mode_data: &ModeData,
+                flow: &mut HashMap<u32, f64>,
+                heap: &mut BinaryHeap<(u32, u32)>,
+                rank_flow: &mut HashMap<u32, f64>,
+                tagged: u32,
+                f: f64| {
+        if arc_is_shortcut(mode_data, tagged) {
+            let fresh = {
+                let e = flow.entry(tagged).or_default();
+                let was_zero = *e == 0.0;
+                *e += f;
+                was_zero
+            };
+            if fresh {
+                heap.push((arc_middle(mode_data, tagged), tagged));
+            }
+        } else {
+            let (_, v) = arc_endpoints(mode_data, tagged);
+            *rank_flow.entry(v).or_default() += f;
+        }
+    };
+
+    for (tagged, f) in arc_flow {
+        seed(mode_data, &mut flow, &mut heap, &mut rank_flow, tagged, f);
+    }
+
+    while let Some((_, tagged)) = heap.pop() {
+        let Some(f) = flow.remove(&tagged) else {
+            continue; // duplicate heap entry — already cascaded
+        };
+        let (u, v) = arc_endpoints(mode_data, tagged);
+        let m = arc_middle(mode_data, tagged);
+        // Children exactly as unpack resolves them: DOWN u→m, UP m→v.
+        let down_child = super::unpack::find_down_edge(&mode_data.cch_topo, u as usize, m)
+            .map(|i| i as u32 | DOWN_BIT);
+        let up_child =
+            super::unpack::find_up_edge(&mode_data.cch_topo, m as usize, v).map(|i| i as u32);
+        debug_assert!(
+            down_child.is_some() && up_child.is_some(),
+            "shortcut without resolvable children (arc {tagged:#x}, middle {m})"
+        );
+        for child in [down_child, up_child].into_iter().flatten() {
+            seed(mode_data, &mut flow, &mut heap, &mut rank_flow, child, f);
+        }
+    }
+    rank_flow
+}
+
+/// Cascade shortcut flow down to base arcs per GROUP — groups carry
+/// independent flows, so they cascade in parallel with zero coordination —
+/// then fold every group's base-arc flow into `rank_flow` in ascending
+/// group order (deterministic).
+fn cascade_arc_flow(
+    mode_data: &ModeData,
+    arc_flow: HashMap<(u32, u32), f64>,
+    rank_flow: &mut HashMap<(u32, u32), f64>,
+    parallel: bool,
+) {
+    let mut per_group: HashMap<u32, Vec<(u32, f64)>> = HashMap::default();
+    for ((g, tagged), f) in arc_flow {
+        per_group.entry(g).or_default().push((tagged, f));
+    }
+    let mut group_list: Vec<(u32, Vec<(u32, f64)>)> = per_group.into_iter().collect();
+    group_list.sort_unstable_by_key(|(g, _)| *g);
+
+    let cascaded: Vec<(u32, HashMap<u32, f64>)> = if parallel {
+        group_list
+            .into_par_iter()
+            .map(|(g, arcs)| (g, cascade_group(mode_data, arcs)))
+            .collect()
+    } else {
+        group_list
+            .into_iter()
+            .map(|(g, arcs)| (g, cascade_group(mode_data, arcs)))
+            .collect()
+    };
+    for (g, ranks) in cascaded {
+        for (rank, f) in ranks {
+            *rank_flow.entry((g, rank)).or_default() += f;
+        }
+    }
+}
+
+/// Compute accumulated flow rows for weighted OD `pairs`. `weights` and
+/// `groups` are indexed by pair (`query_idx`). Returns rows sorted by
+/// `(group, osm_from, osm_to)` plus the conservation summary.
+pub fn compute_edges_flow(
+    state: &ServerState,
+    mode_data: &ModeData,
+    mode: Mode,
+    pairs: &[[f64; 4]],
+    weights: &[f64],
+    groups: &[u32],
+    parallel: bool,
+) -> (Vec<FlowRow>, FlowSummary) {
+    assert_eq!(pairs.len(), weights.len());
+    assert_eq!(pairs.len(), groups.len());
+
+    let (group_vec, per_pair_work) =
+        super::flight::group_pairs(state, mode_data, mode, pairs, parallel);
+
+    // Locality batching (#438): rank-sort before chunking keeps each
+    // batch's union selection tight.
+    let mut group_refs: Vec<&(u32, Vec<GroupedTarget>)> = group_vec.iter().collect();
+    group_refs.sort_unstable_by_key(|(src, _)| *src);
+    let batches: Vec<Vec<&(u32, Vec<GroupedTarget>)>> =
+        group_refs.chunks(TREE_LANES).map(|c| c.to_vec()).collect();
+
+    // Parallel compute, DETERMINISTIC merge: collect per-batch accs in
+    // batch order, then fold left.
+    let batch_accs: Vec<BatchAcc> = if parallel {
+        batches
+            .par_iter()
+            .map(|b| process_flow_batch(state, mode_data, mode, b, weights, groups))
+            .collect()
+    } else {
+        batches
+            .iter()
+            .map(|b| process_flow_batch(state, mode_data, mode, b, weights, groups))
+            .collect()
+    };
+    let mut total = BatchAcc::default();
+    for acc in batch_accs {
+        acc.merge_into(&mut total);
+    }
+
+    // Per-pair work (snap misses + singletons): existing per-pair path,
+    // rows folded by query_idx order (deterministic).
+    let pair_results: Vec<PairEdges> = if parallel {
+        per_pair_work
+            .par_iter()
+            .map(|w: &PerPairWork| {
+                let query = super::query::CchQuery::new(mode_data);
+                super::flight::process_per_pair_work(state, mode_data, mode, &query, w)
+            })
+            .collect()
+    } else {
+        let query = super::query::CchQuery::new(mode_data);
+        per_pair_work
+            .iter()
+            .map(|w| super::flight::process_per_pair_work(state, mode_data, mode, &query, w))
+            .collect()
+    };
+    for pe in &pair_results {
+        let g = groups[pe.query_idx as usize];
+        let w = weights[pe.query_idx as usize];
+        total.fold_pair_rows(g, w, &pe.rows);
+    }
+
+    // Cascade CCH-arc flow to EBG ranks.
+    let arc_flow = std::mem::take(&mut total.arc_flow);
+    cascade_arc_flow(mode_data, arc_flow, &mut total.rank_flow, parallel);
+
+    // Flush: rank → EBG node → OSM endpoints, merged with fallback rows.
+    let mut out: HashMap<(u32, i64, i64), f64> = std::mem::take(&mut total.row_flow);
+    for ((g, rank), f) in std::mem::take(&mut total.rank_flow) {
+        let filt_id = mode_data.cch_topo.rank_to_filtered[rank as usize];
+        let ebg_id = mode_data.filtered_to_original[filt_id as usize];
+        let node = &state.ebg_nodes.nodes[ebg_id as usize];
+        let osm_from = state
+            .nbg_node_to_osm
+            .get(node.tail_nbg as usize)
+            .copied()
+            .unwrap_or(0);
+        let osm_to = state
+            .nbg_node_to_osm
+            .get(node.head_nbg as usize)
+            .copied()
+            .unwrap_or(0);
+        *out.entry((g, osm_from, osm_to)).or_default() += f;
+    }
+
+    let mut rows: Vec<FlowRow> = out
+        .into_iter()
+        .map(|((group, osm_from, osm_to), flow)| FlowRow {
+            group,
+            osm_from,
+            osm_to,
+            flow,
+        })
+        .collect();
+    rows.sort_unstable_by(|a, b| {
+        (a.group, a.osm_from, a.osm_to).cmp(&(b.group, b.osm_from, b.osm_to))
+    });
+
+    let total_weight_in: f64 = weights.iter().sum();
+    let summary = FlowSummary {
+        n_pairs: pairs.len() as u64,
+        n_unreachable: total.n_unreachable,
+        total_weight_in,
+        total_weight_assigned: total.assigned,
+    };
+    (rows, summary)
+}

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -44,6 +44,7 @@ pub mod overlay;
 // Every gRPC function returns Result<_, Status>; boxing adds indirection with no benefit.
 #[allow(clippy::result_large_err)]
 pub mod flight;
+pub mod flow;
 pub mod geometry;
 pub mod health_handler;
 pub mod height_handler;
@@ -136,6 +137,19 @@ static IDLE_COMPACT_SECS_OVERRIDE: std::sync::OnceLock<u64> = std::sync::OnceLoc
 
 pub fn set_idle_compact_secs(secs: u64) {
     let _ = IDLE_COMPACT_SECS_OVERRIDE.set(secs);
+}
+
+/// Lean-deploy transit toggle (`--transit off` / `BUTTERFLY_TRANSIT=off`):
+/// when disabled, `transit/` directories are ignored at boot — no feed
+/// parse, no transfer-graph build/load — even with the foot mode loaded.
+static TRANSIT_ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+pub fn set_transit_enabled(on: bool) {
+    let _ = TRANSIT_ENABLED.set(on);
+}
+
+fn transit_enabled() -> bool {
+    *TRANSIT_ENABLED.get().unwrap_or(&true)
 }
 
 fn idle_compact_secs() -> u64 {
@@ -428,7 +442,12 @@ pub async fn serve(
     // origin/destination pairs.
     let mut regions_state = regions_state;
     let mut transit_loaded_count = 0usize;
-    let n_regions = regions_state.regions.len();
+    let n_regions = if transit_enabled() {
+        regions_state.regions.len()
+    } else {
+        tracing::info!("transit disabled (--transit off / BUTTERFLY_TRANSIT) — road-only serve");
+        0
+    };
     for idx in 0..n_regions {
         let region_id_lower = regions_state.regions[idx].id.to_lowercase();
         let per_region_dir = data_dir_for_transit.join(&region_id_lower);

--- a/route/src/server/unpack.rs
+++ b/route/src/server/unpack.rs
@@ -108,7 +108,7 @@ fn unpack_down_edge_into(
 }
 
 /// Find UP edge index from source to target
-fn find_up_edge(topo: &CchTopo, source: usize, target: u32) -> Option<usize> {
+pub(crate) fn find_up_edge(topo: &CchTopo, source: usize, target: u32) -> Option<usize> {
     let start = topo.up_offsets[source] as usize;
     let end = topo.up_offsets[source + 1] as usize;
     let slice = &topo.up_targets[start..end];
@@ -116,7 +116,7 @@ fn find_up_edge(topo: &CchTopo, source: usize, target: u32) -> Option<usize> {
 }
 
 /// Find DOWN edge index from source to target
-fn find_down_edge(topo: &CchTopo, source: usize, target: u32) -> Option<usize> {
+pub(crate) fn find_down_edge(topo: &CchTopo, source: usize, target: u32) -> Option<usize> {
     let start = topo.down_offsets[source] as usize;
     let end = topo.down_offsets[source + 1] as usize;
     let slice = &topo.down_targets[start..end];


### PR DESCRIPTION
Closes #460.

## edges_flow (DoExchange `edges_flow:<profile>`)
Weighted OD pairs in → ONE row per (group, directed edge) with accumulated flow + trailing app_metadata conservation summary. Same routing core as edges_batch (snap → source-group → K-lane restricted tree #438); aggregation:
1. **Deposit** weight on the pair's ~10-40 tagged CCH arcs (commit-on-success buffer — a mid-walk miss can't double-count vs the fallback) + source EBG rank
2. **Cascade** shortcut→children once per distinct (group, arc): max-heap by middle rank (child middles strictly lower ⇒ parents pop first ⇒ single pass); groups cascade in parallel
3. **Flush** base arcs → EBG ranks → OSM endpoints; per-pair fallbacks fold their rows directly

**Oracle (Belgium)**: flow table EXACTLY equals weighted aggregate of tree rows (max rel 0.0e0, B + C shapes); conservation green. **60k pairs: 33.4k pairs/s, 11× wire compression (12.1M → 1.09M rows)** — production 500k chunks project ~100×; the measured production bottleneck is the stream (926k rows/s, #460), which this removes entirely.

**Determinism**: batch-ordered merge, total-order heap, sorted rows — byte-identical reruns.

**Per-OSM-segment expansion**: investigated — intermediate OSM node ids are NOT in the container (step 3 discards them; only junction ids round-trip via nbg.node_map). v1 emits per-NBG-edge rows (same contract as edges_batch). The ~240-600 MB CSR id-chain section + step-3 change is a follow-up tied to the next artifact rebuild.

## --transit on|off (second commit)
Lean road-only deploys (`--modes car,foot --transit off` / `BUTTERFLY_TRANSIT=off`): transit/ ignored at boot — no feed parse, no transfer build. Drop the flag to re-enable multimodal unchanged.

Full clippy 0, 633 tests.