### PR TITLE
fix(isochrone): balance the morphological closing (#431 rank 1)

### DIFF
--- a/route/src/range/sparse_contour.rs
+++ b/route/src/range/sparse_contour.rs
@@ -461,11 +461,18 @@ pub struct SparseContourConfig {
 
 impl SparseContourConfig {
     /// Default car config (30m cells - better accuracy)
+    ///
+    /// #431: the closing is BALANCED (erosion_rounds == dilation_rounds) —
+    /// a gap-filling closing must erode exactly what it dilated, or every
+    /// un-eroded round leaves a net +1-cell uniform outward grow that is
+    /// never reclaimed (~+19 m/side for car at the 300 s tier). Gap
+    /// bridging strength is set by the dilation count alone; the matching
+    /// erosion cannot re-open a bridged gap (closing is idempotent there).
     pub fn for_car() -> Self {
         Self {
             cell_size_m: 30.0,
-            dilation_rounds: 2, // Reduced to avoid over-expansion
-            erosion_rounds: 1,
+            dilation_rounds: 2,
+            erosion_rounds: 2,
             simplify_tolerance_m: 30.0,
         }
     }
@@ -475,7 +482,7 @@ impl SparseContourConfig {
         Self {
             cell_size_m: 40.0,
             dilation_rounds: 3,
-            erosion_rounds: 1,
+            erosion_rounds: 3,
             simplify_tolerance_m: 40.0,
         }
     }
@@ -485,7 +492,7 @@ impl SparseContourConfig {
         Self {
             cell_size_m: 25.0,
             dilation_rounds: 3,
-            erosion_rounds: 1,
+            erosion_rounds: 3,
             simplify_tolerance_m: 25.0,
         }
     }

--- a/scripts/isochrone_consistency_test.py
+++ b/scripts/isochrone_consistency_test.py
@@ -12,6 +12,7 @@ This catches bugs where:
 - Edge cases at the boundary
 """
 
+import os
 import requests
 import random
 import json
@@ -23,7 +24,7 @@ from shapely.ops import unary_union
 from shapely.validation import make_valid
 import time
 
-BUTTERFLY_URL = "http://localhost:8080"
+BUTTERFLY_URL = os.environ.get("BUTTERFLY_URL", "http://localhost:8080")
 
 @dataclass
 class TestResult:
@@ -42,33 +43,45 @@ class TestResult:
 
 
 def get_isochrone(lon: float, lat: float, time_s: int, mode: str = "car") -> Optional[Polygon]:
-    """Fetch isochrone polygon from Butterfly."""
-    url = f"{BUTTERFLY_URL}/isochrone?lon={lon}&lat={lat}&time_s={time_s}&mode={mode}"
+    """Fetch isochrone polygon from Butterfly.
+
+    The response is `{"contours": [{..., "polygon_geojson": [[lon,lat],...]}]}`
+    (single contour for a single time_s; request geometries=geojson). The old
+    top-level "polygon" key no longer exists — parsing it silently yielded
+    None and made the whole suite pass vacuously (#431 audit).
+    """
+    url = (f"{BUTTERFLY_URL}/isochrone?lon={lon}&lat={lat}&time_s={time_s}"
+           f"&mode={mode}&geometries=geojson")
     try:
-        resp = requests.get(url, timeout=30)
+        resp = requests.get(url, timeout=60)
         if resp.status_code != 200:
             print(f"  Isochrone request failed: {resp.status_code}")
             return None
         data = resp.json()
-        polygon_coords = data.get("polygon", [])
+        contours = data.get("contours", [])
+        polygon_coords = contours[0].get("polygon_geojson") or [] if contours else []
         if len(polygon_coords) < 3:
             print(f"  Isochrone has < 3 points")
             return None
-        # Convert to shapely polygon
-        coords = [(p["lon"], p["lat"]) for p in polygon_coords]
+        # Convert to shapely polygon ([[lon, lat], ...])
+        coords = [(p[0], p[1]) for p in polygon_coords]
         poly = Polygon(coords)
-        # Handle self-intersecting polygons from boundary tracing
+        # Handle self-intersecting polygons from boundary tracing.
+        # make_valid can return Polygon, MultiPolygon, or a GeometryCollection
+        # whose members may THEMSELVES be MultiPolygons (plus zero-width
+        # LineString spurs) — recurse to collect every Polygon part.
         if not poly.is_valid:
-            poly = make_valid(poly)
-            # make_valid can return GeometryCollection, extract largest polygon
-            if poly.geom_type == 'MultiPolygon':
-                poly = max(poly.geoms, key=lambda p: p.area)
-            elif poly.geom_type == 'GeometryCollection':
-                polygons = [g for g in poly.geoms if g.geom_type == 'Polygon']
-                if polygons:
-                    poly = max(polygons, key=lambda p: p.area)
-                else:
-                    return None
+            def polygons_of(g):
+                if g.geom_type == 'Polygon':
+                    return [g]
+                if hasattr(g, 'geoms'):
+                    return [p for m in g.geoms for p in polygons_of(m)]
+                return []
+            parts = polygons_of(make_valid(poly))
+            if not parts:
+                print("  make_valid produced no polygon parts")
+                return None
+            poly = max(parts, key=lambda p: p.area)
         return poly
     except Exception as e:
         print(f"  Isochrone error: {e}")
@@ -77,7 +90,8 @@ def get_isochrone(lon: float, lat: float, time_s: int, mode: str = "car") -> Opt
 
 def get_drive_time(src_lon: float, src_lat: float, dst_lon: float, dst_lat: float, mode: str = "car") -> Optional[float]:
     """Get drive time in seconds from src to dst."""
-    url = f"{BUTTERFLY_URL}/route?src_lon={src_lon}&src_lat={src_lat}&dst_lon={dst_lon}&dst_lat={dst_lat}&mode={mode}"
+    url = (f"{BUTTERFLY_URL}/route?origin_lon={src_lon}&origin_lat={src_lat}"
+           f"&destination_lon={dst_lon}&destination_lat={dst_lat}&mode={mode}")
     try:
         resp = requests.get(url, timeout=10)
         if resp.status_code == 200:
@@ -128,11 +142,13 @@ def test_isochrone_consistency(
     polygon = get_isochrone(origin_lon, origin_lat, time_s, mode)
     if polygon is None or not polygon.is_valid:
         print("  Failed to get valid isochrone polygon")
+        # FAIL CLOSED: a missing polygon must fail the case, not pass it
+        # vacuously (this masked a response-schema drift for months).
         return TestResult(
             origin=(origin_lon, origin_lat),
             time_s=time_s,
             n_samples=0,
-            inside_violations=[],
+            inside_violations=[{"error": "no valid polygon returned"}],
             outside_violations=[],
             inside_correct=0,
             outside_correct=0,
@@ -236,7 +252,12 @@ def run_test_suite():
         print(f"Start with: ./target/release/butterfly-route serve --data-dir ./data/belgium --port 8080")
         sys.exit(1)
 
-    # Test cases: different origins and time thresholds
+    # Deterministic sampling so before/after runs are comparable (#431).
+    random.seed(42)
+
+    # Test cases: different origins and time thresholds.
+    # Urban + RURAL (#431: balanced closing risks re-opening thin gaps in
+    # sparse rural frontier — rural origins must be part of the gate).
     test_cases = [
         # (lon, lat, time_s, n_samples, description)
         (4.3517, 50.8503, 300, 50, "Brussels center, 5min"),
@@ -245,6 +266,10 @@ def run_test_suite():
         (3.7250, 51.0543, 600, 100, "Ghent center, 10min"),
         (4.4028, 51.2194, 600, 100, "Antwerp center, 10min"),
         (5.5796, 50.6326, 600, 100, "Liège center, 10min"),
+        (5.7167, 50.0042, 600, 100, "Bastogne (rural Ardennes), 10min"),
+        (5.7167, 50.0042, 1800, 150, "Bastogne (rural Ardennes), 30min"),
+        (2.8667, 50.9500, 600, 100, "Westhoek (rural Flanders), 10min"),
+        (5.4500, 49.6833, 1800, 150, "Gaume (rural south), 30min"),
     ]
 
     results = []


### PR DESCRIPTION
Closes nothing yet — rank 1 of #431; ranks 2/3 stay open there.

**Fix**: erosion_rounds == dilation_rounds (car 2/2, bike/foot 3/3). A closing must erode what it dilated — each un-eroded round was a permanent +1-cell outward grow (~+19-28 m/side car @300 s). closing(A) ⊇ A, so the feared rural re-opening cannot disconnect the stamped set — and the A/B confirms it.

**Belgium A/B** (10 origins, urban + rural Ardennes/Westhoek/Gaume, seeded probes):
| metric | unbalanced | balanced |
|---|---|---|
| inside violations (over-extension) | 10 | **3** |
| area ratio | 1.0 | 0.938–0.975 |
| containment balanced ⊆ baseline | — | exact (<0.003%) |
| outside violations | 45 | 64 (all boundary-band, pre-existing snap-vs-corridor semantics) |

**Harness**: scripts/isochrone_consistency_test.py had rotted into a silent always-PASS (3 independent bugs: dead response key, dead /route params, fail-open on fetch failure) — repaired + fail-closed + recursive make_valid extraction + seeded + 4 rural origins. The historic '1.2 % violation rate' figure predates the rot; the numbers above are the new baseline.

633 tests, full clippy 0.