### PR TITLE
feat(flow): per-OSM-segment expansion via OSM id chains from graph build (#460)

### DIFF
--- a/route/src/formats/butterfly_dat.rs
+++ b/route/src/formats/butterfly_dat.rs
@@ -213,6 +213,13 @@ pub enum SectionKind {
     /// geometry (#155). `[i32; 2 * n_points]`. Indexed via
     /// `EdgeGeomOffsets`.
     EdgeGeomPoints = 0x000C_0002,
+    /// CSR offsets over per-NBG-edge OSM node ID chains (#460).
+    /// `[u32; n_edges + 1]`, same edge indexing space (and identical
+    /// per-edge counts) as `EdgeGeomOffsets`.
+    EdgeOsmOffsets = 0x000C_0003,
+    /// Flat per-vertex OSM node IDs (#460). `[i64; n_ids]`, canonical
+    /// u→v direction. Indexed via `EdgeOsmOffsets`.
+    EdgeOsmIds = 0x000C_0004,
 
     /// Cross-region overlay manifest (#91 Phase 2). JSON metadata:
     /// region order, mode list, border-crossing count, build provenance.
@@ -318,6 +325,8 @@ impl SectionKind {
 
             0x000C_0001 => Self::EdgeGeomOffsets,
             0x000C_0002 => Self::EdgeGeomPoints,
+            0x000C_0003 => Self::EdgeOsmOffsets,
+            0x000C_0004 => Self::EdgeOsmIds,
 
             0x000D_0001 => Self::OverlayManifest,
             0x000D_0002 => Self::OverlayBorderNodes,
@@ -371,6 +380,8 @@ impl SectionKind {
             Self::SnapModeMask => "mode/snap_mask",
             Self::EdgeGeomOffsets => "shared/edge_geom_offsets",
             Self::EdgeGeomPoints => "shared/edge_geom_points",
+            Self::EdgeOsmOffsets => "shared/edge_osm_offsets",
+            Self::EdgeOsmIds => "shared/edge_osm_ids",
             Self::OverlayManifest => "overlay/manifest.json",
             Self::OverlayBorderNodes => "overlay/border_nodes",
             Self::OverlayMatrix => "overlay/matrix",

--- a/route/src/formats/edge_osm.rs
+++ b/route/src/formats/edge_osm.rs
@@ -1,0 +1,486 @@
+//! Flat mmap-friendly per-edge OSM node ID chains (#460 follow-up).
+//!
+//! Companion to [`super::edge_geom`]: where `edge_geom_*` stores each NBG
+//! edge's polyline *coordinates*, these sections store the same edge's OSM
+//! node *IDs* — every intermediate geometry node along the underlying OSM
+//! way, in the edge's canonical (u→v) direction. They are produced in step
+//! 3 (`emit_edges` has the full per-way node chain in scope — the only
+//! place the coord→id association is unambiguous) and carried through the
+//! container so the serve path can expand any NBG edge to per-OSM-segment
+//! `(osm_node_from, osm_node_to)` rows. Production motivation: at NBG
+//! granularity ~49% of `edges_flow` mass keyed to node pairs absent from
+//! per-segment reference tables (#460).
+//!
+//! Two section types, both CRC-validated, magic+version-checked, zero-copy
+//! readable via `bytemuck::cast_slice`:
+//!
+//! - [`EdgeOsmOffsetsFile`] — `shared/edge_osm_offsets`. CSR-style
+//!   `[u32; n_edges + 1]` of cumulative ID counts indexing into the ids
+//!   body. `offsets[i]..offsets[i+1]` is the half-open range of id
+//!   indices for edge `i`. Indexing space: NBG undirected edge ids — the
+//!   SAME space as `edge_geom` (`EbgNode.geom_idx`), and per-edge counts
+//!   are identical to the polyline's point counts (one id per vertex).
+//! - [`EdgeOsmIdsFile`] — `shared/edge_osm_ids`. Flat `[i64; n_ids]` of
+//!   OSM node IDs.
+//!
+//! The same encodings double as step-3 output files
+//! (`nbg.edge_osm.offsets` / `nbg.edge_osm.ids`) which `pack` reads.
+//!
+//! # On-disk layout
+//!
+//! Headers are 32 bytes (u64-aligned). Footers are 16 bytes:
+//! `body_crc : u64 || file_crc : u64`. All fields little-endian.
+
+use anyhow::Result;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use super::crc::Digest;
+use super::mmap::ArcCow;
+
+// ---------- Constants -------------------------------------------------------
+
+/// Magic for `shared/edge_osm_offsets`. ASCII "EOOF" (LE byte-order).
+pub const EDGE_OSM_OFFSETS_MAGIC: u32 = 0x464F_4F45;
+/// Magic for `shared/edge_osm_ids`. ASCII "EOID" (LE byte-order).
+pub const EDGE_OSM_IDS_MAGIC: u32 = 0x4449_4F45;
+
+const EDGE_OSM_VERSION: u16 = 1;
+const HEADER_SIZE: usize = 32;
+const FOOTER_SIZE: usize = 16;
+
+// ---------- edge_osm_offsets ------------------------------------------------
+
+/// Parsed `shared/edge_osm_offsets` section.
+#[derive(Debug, Clone)]
+pub struct EdgeOsmOffsets {
+    pub n_edges: u32,
+    pub n_ids: u32,
+    /// Cumulative ID counts. `offsets[edge_id]..offsets[edge_id + 1]`
+    /// indexes the half-open id range for NBG edge `edge_id` in the ids
+    /// body. Length is `n_edges + 1`; `offsets[0] = 0`,
+    /// `offsets[n_edges] = n_ids`.
+    pub offsets: ArcCow<u32>,
+}
+
+pub struct EdgeOsmOffsetsFile;
+
+impl EdgeOsmOffsetsFile {
+    pub fn encode(o: &EdgeOsmOffsets) -> Vec<u8> {
+        let expected = (o.n_edges as usize)
+            .checked_add(1)
+            .expect("edge_osm_offsets length overflow");
+        assert_eq!(
+            o.offsets.len(),
+            expected,
+            "edge_osm_offsets length must be n_edges + 1 (got {} for n_edges={})",
+            o.offsets.len(),
+            o.n_edges
+        );
+        let body_len = expected
+            .checked_mul(4)
+            .expect("edge_osm_offsets body byte count overflow");
+        let mut out = Vec::with_capacity(HEADER_SIZE + body_len + FOOTER_SIZE);
+
+        // Header
+        out.extend_from_slice(&EDGE_OSM_OFFSETS_MAGIC.to_le_bytes());
+        out.extend_from_slice(&EDGE_OSM_VERSION.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes()); // _pad0
+        out.extend_from_slice(&o.n_edges.to_le_bytes());
+        out.extend_from_slice(&o.n_ids.to_le_bytes());
+        out.extend_from_slice(&[0u8; 16]); // _pad1 — pads to 32-byte HEADER_SIZE
+        debug_assert_eq!(out.len(), HEADER_SIZE);
+
+        // Body — LE bytes (bytemuck cast assumes host endian on read).
+        for &v in o.offsets.as_slice() {
+            out.extend_from_slice(&v.to_le_bytes());
+        }
+
+        // Footer
+        let mut body_d = Digest::new();
+        body_d.update(&out[HEADER_SIZE..HEADER_SIZE + body_len]);
+        let body_crc = body_d.finalize();
+        let mut file_d = Digest::new();
+        file_d.update(&out[..HEADER_SIZE + body_len]);
+        let file_crc = file_d.finalize();
+        out.extend_from_slice(&body_crc.to_le_bytes());
+        out.extend_from_slice(&file_crc.to_le_bytes());
+        out
+    }
+
+    pub fn write<P: AsRef<Path>>(path: P, o: &EdgeOsmOffsets) -> Result<()> {
+        let bytes = Self::encode(o);
+        let mut w = BufWriter::new(File::create(path.as_ref())?);
+        w.write_all(&bytes)?;
+        w.flush()?;
+        Ok(())
+    }
+
+    /// Owning reader: copies the body into a `Vec<u32>`.
+    pub fn read_from_bytes(bytes: &[u8]) -> Result<EdgeOsmOffsets> {
+        let parsed = parse_offsets_header_and_check(bytes, true)?;
+        let mut offsets = Vec::with_capacity(parsed.expected_entries);
+        for chunk in parsed.body.chunks_exact(4) {
+            offsets.push(u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+        }
+        sanity_check_offsets(&offsets, parsed.n_ids)?;
+        Ok(EdgeOsmOffsets {
+            n_edges: parsed.n_edges,
+            n_ids: parsed.n_ids,
+            offsets: ArcCow::from_vec(offsets),
+        })
+    }
+
+    pub fn read<P: AsRef<Path>>(path: P) -> Result<EdgeOsmOffsets> {
+        let bytes = std::fs::read(path.as_ref())?;
+        Self::read_from_bytes(&bytes)
+    }
+
+    /// Production mmap-backed reader. CRC walking is the caller's
+    /// responsibility (driven through the lazy CRC layer).
+    pub fn read_from_mmap_unverified(
+        mmap: Arc<memmap2::Mmap>,
+        byte_offset: usize,
+        byte_len: usize,
+    ) -> Result<EdgeOsmOffsets> {
+        anyhow::ensure!(
+            byte_offset.saturating_add(byte_len) <= mmap.len(),
+            "edge_osm_offsets section out of bounds: off={byte_offset} len={byte_len} mmap_len={}",
+            mmap.len()
+        );
+        let (n_edges, n_ids, expected_entries) = {
+            let bytes = &mmap[byte_offset..byte_offset + byte_len];
+            let parsed = parse_offsets_header_and_check(bytes, false)?;
+            let off_slice: &[u32] = bytemuck::cast_slice(parsed.body);
+            sanity_check_offsets(off_slice, parsed.n_ids)?;
+            (parsed.n_edges, parsed.n_ids, parsed.expected_entries)
+        };
+        let body_byte_offset = byte_offset + HEADER_SIZE;
+        let offsets = ArcCow::<u32>::from_mmap(mmap, body_byte_offset, expected_entries)?;
+        Ok(EdgeOsmOffsets {
+            n_edges,
+            n_ids,
+            offsets,
+        })
+    }
+}
+
+struct ParsedOffsets<'a> {
+    n_edges: u32,
+    n_ids: u32,
+    expected_entries: usize,
+    body: &'a [u8],
+}
+
+fn parse_offsets_header_and_check(bytes: &[u8], verify_crc: bool) -> Result<ParsedOffsets<'_>> {
+    anyhow::ensure!(
+        bytes.len() >= HEADER_SIZE + FOOTER_SIZE,
+        "edge_osm_offsets too short: {} bytes",
+        bytes.len()
+    );
+    let magic = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    anyhow::ensure!(
+        magic == EDGE_OSM_OFFSETS_MAGIC,
+        "edge_osm_offsets bad magic: {magic:#010x}"
+    );
+    let version = u16::from_le_bytes([bytes[4], bytes[5]]);
+    anyhow::ensure!(
+        version == EDGE_OSM_VERSION,
+        "edge_osm_offsets unsupported version: {version}"
+    );
+    let n_edges = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+    let n_ids = u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]);
+    let expected_entries = (n_edges as usize)
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("edge_osm_offsets n_edges overflow"))?;
+    let body_len = expected_entries
+        .checked_mul(4)
+        .ok_or_else(|| anyhow::anyhow!("edge_osm_offsets body length overflow"))?;
+    anyhow::ensure!(
+        bytes.len() == HEADER_SIZE + body_len + FOOTER_SIZE,
+        "edge_osm_offsets size mismatch: {} bytes, expected {}",
+        bytes.len(),
+        HEADER_SIZE + body_len + FOOTER_SIZE
+    );
+    let body = &bytes[HEADER_SIZE..HEADER_SIZE + body_len];
+    if verify_crc {
+        verify_footer(bytes, body_len, "edge_osm_offsets")?;
+    }
+    Ok(ParsedOffsets {
+        n_edges,
+        n_ids,
+        expected_entries,
+        body,
+    })
+}
+
+fn sanity_check_offsets(offsets: &[u32], n_ids: u32) -> Result<()> {
+    anyhow::ensure!(
+        offsets.first() == Some(&0),
+        "edge_osm_offsets must start at 0"
+    );
+    anyhow::ensure!(
+        offsets.last() == Some(&n_ids),
+        "edge_osm_offsets must end at n_ids ({n_ids})"
+    );
+    anyhow::ensure!(
+        offsets.windows(2).all(|w| w[0] <= w[1]),
+        "edge_osm_offsets must be non-decreasing"
+    );
+    Ok(())
+}
+
+// ---------- edge_osm_ids ----------------------------------------------------
+
+/// Parsed `shared/edge_osm_ids` section.
+#[derive(Debug, Clone)]
+pub struct EdgeOsmIds {
+    pub n_ids: u32,
+    /// Flat OSM node IDs, one per polyline vertex, in each edge's
+    /// canonical (u→v) direction.
+    pub ids: ArcCow<i64>,
+}
+
+pub struct EdgeOsmIdsFile;
+
+impl EdgeOsmIdsFile {
+    pub fn encode(o: &EdgeOsmIds) -> Vec<u8> {
+        assert_eq!(
+            o.ids.len(),
+            o.n_ids as usize,
+            "edge_osm_ids length must equal n_ids"
+        );
+        let body_len = (o.n_ids as usize)
+            .checked_mul(8)
+            .expect("edge_osm_ids body byte count overflow");
+        let mut out = Vec::with_capacity(HEADER_SIZE + body_len + FOOTER_SIZE);
+
+        // Header
+        out.extend_from_slice(&EDGE_OSM_IDS_MAGIC.to_le_bytes());
+        out.extend_from_slice(&EDGE_OSM_VERSION.to_le_bytes());
+        out.extend_from_slice(&0u16.to_le_bytes()); // _pad0
+        out.extend_from_slice(&o.n_ids.to_le_bytes());
+        out.extend_from_slice(&[0u8; 20]); // _pad1 — pads to 32-byte HEADER_SIZE
+        debug_assert_eq!(out.len(), HEADER_SIZE);
+
+        // Body
+        for &v in o.ids.as_slice() {
+            out.extend_from_slice(&v.to_le_bytes());
+        }
+
+        // Footer
+        let mut body_d = Digest::new();
+        body_d.update(&out[HEADER_SIZE..HEADER_SIZE + body_len]);
+        let body_crc = body_d.finalize();
+        let mut file_d = Digest::new();
+        file_d.update(&out[..HEADER_SIZE + body_len]);
+        let file_crc = file_d.finalize();
+        out.extend_from_slice(&body_crc.to_le_bytes());
+        out.extend_from_slice(&file_crc.to_le_bytes());
+        out
+    }
+
+    pub fn write<P: AsRef<Path>>(path: P, o: &EdgeOsmIds) -> Result<()> {
+        let bytes = Self::encode(o);
+        let mut w = BufWriter::new(File::create(path.as_ref())?);
+        w.write_all(&bytes)?;
+        w.flush()?;
+        Ok(())
+    }
+
+    /// Owning reader: copies the body into a `Vec<i64>`.
+    pub fn read_from_bytes(bytes: &[u8]) -> Result<EdgeOsmIds> {
+        let parsed = parse_ids_header_and_check(bytes, true)?;
+        let mut ids = Vec::with_capacity(parsed.n_ids as usize);
+        for chunk in parsed.body.chunks_exact(8) {
+            ids.push(i64::from_le_bytes([
+                chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6], chunk[7],
+            ]));
+        }
+        Ok(EdgeOsmIds {
+            n_ids: parsed.n_ids,
+            ids: ArcCow::from_vec(ids),
+        })
+    }
+
+    pub fn read<P: AsRef<Path>>(path: P) -> Result<EdgeOsmIds> {
+        let bytes = std::fs::read(path.as_ref())?;
+        Self::read_from_bytes(&bytes)
+    }
+
+    /// Production mmap-backed reader. CRC walking is the caller's
+    /// responsibility (driven through the lazy CRC layer). The ids body
+    /// sits at `byte_offset + 32` — container sections are 8-aligned, so
+    /// the `&[i64]` alignment requirement holds (checked again inside
+    /// [`ArcCow::from_mmap`]).
+    pub fn read_from_mmap_unverified(
+        mmap: Arc<memmap2::Mmap>,
+        byte_offset: usize,
+        byte_len: usize,
+    ) -> Result<EdgeOsmIds> {
+        anyhow::ensure!(
+            byte_offset.saturating_add(byte_len) <= mmap.len(),
+            "edge_osm_ids section out of bounds: off={byte_offset} len={byte_len} mmap_len={}",
+            mmap.len()
+        );
+        let n_ids = {
+            let bytes = &mmap[byte_offset..byte_offset + byte_len];
+            let parsed = parse_ids_header_and_check(bytes, false)?;
+            parsed.n_ids
+        };
+        let body_byte_offset = byte_offset + HEADER_SIZE;
+        let ids = ArcCow::<i64>::from_mmap(mmap, body_byte_offset, n_ids as usize)?;
+        Ok(EdgeOsmIds { n_ids, ids })
+    }
+}
+
+struct ParsedIds<'a> {
+    n_ids: u32,
+    body: &'a [u8],
+}
+
+fn parse_ids_header_and_check(bytes: &[u8], verify_crc: bool) -> Result<ParsedIds<'_>> {
+    anyhow::ensure!(
+        bytes.len() >= HEADER_SIZE + FOOTER_SIZE,
+        "edge_osm_ids too short: {} bytes",
+        bytes.len()
+    );
+    let magic = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+    anyhow::ensure!(
+        magic == EDGE_OSM_IDS_MAGIC,
+        "edge_osm_ids bad magic: {magic:#010x}"
+    );
+    let version = u16::from_le_bytes([bytes[4], bytes[5]]);
+    anyhow::ensure!(
+        version == EDGE_OSM_VERSION,
+        "edge_osm_ids unsupported version: {version}"
+    );
+    let n_ids = u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]);
+    let body_len = (n_ids as usize)
+        .checked_mul(8)
+        .ok_or_else(|| anyhow::anyhow!("edge_osm_ids body length overflow"))?;
+    anyhow::ensure!(
+        bytes.len() == HEADER_SIZE + body_len + FOOTER_SIZE,
+        "edge_osm_ids size mismatch: {} bytes, expected {}",
+        bytes.len(),
+        HEADER_SIZE + body_len + FOOTER_SIZE
+    );
+    let body = &bytes[HEADER_SIZE..HEADER_SIZE + body_len];
+    if verify_crc {
+        verify_footer(bytes, body_len, "edge_osm_ids")?;
+    }
+    Ok(ParsedIds { n_ids, body })
+}
+
+// ---------- shared footer verification --------------------------------------
+
+fn verify_footer(bytes: &[u8], body_len: usize, what: &str) -> Result<()> {
+    let footer = &bytes[HEADER_SIZE + body_len..];
+    let stored_body_crc = u64::from_le_bytes(footer[0..8].try_into().unwrap());
+    let stored_file_crc = u64::from_le_bytes(footer[8..16].try_into().unwrap());
+    let mut body_d = Digest::new();
+    body_d.update(&bytes[HEADER_SIZE..HEADER_SIZE + body_len]);
+    anyhow::ensure!(
+        body_d.finalize() == stored_body_crc,
+        "{what} body CRC mismatch"
+    );
+    let mut file_d = Digest::new();
+    file_d.update(&bytes[..HEADER_SIZE + body_len]);
+    anyhow::ensure!(
+        file_d.finalize() == stored_file_crc,
+        "{what} file CRC mismatch"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> (EdgeOsmOffsets, EdgeOsmIds) {
+        // 3 edges: [10,11,12], [12,13], [20,21,22,23]
+        let offsets = EdgeOsmOffsets {
+            n_edges: 3,
+            n_ids: 9,
+            offsets: ArcCow::from_vec(vec![0, 3, 5, 9]),
+        };
+        let ids = EdgeOsmIds {
+            n_ids: 9,
+            ids: ArcCow::from_vec(vec![10, 11, 12, 12, 13, 20, 21, 22, 23]),
+        };
+        (offsets, ids)
+    }
+
+    #[test]
+    fn offsets_roundtrip() {
+        let (o, _) = sample();
+        let bytes = EdgeOsmOffsetsFile::encode(&o);
+        let back = EdgeOsmOffsetsFile::read_from_bytes(&bytes).unwrap();
+        assert_eq!(back.n_edges, 3);
+        assert_eq!(back.n_ids, 9);
+        assert_eq!(back.offsets.as_slice(), &[0, 3, 5, 9]);
+    }
+
+    #[test]
+    fn ids_roundtrip() {
+        let (_, i) = sample();
+        let bytes = EdgeOsmIdsFile::encode(&i);
+        let back = EdgeOsmIdsFile::read_from_bytes(&bytes).unwrap();
+        assert_eq!(back.n_ids, 9);
+        assert_eq!(back.ids.as_slice(), &[10, 11, 12, 12, 13, 20, 21, 22, 23]);
+    }
+
+    #[test]
+    fn offsets_rejects_corruption() {
+        let (o, _) = sample();
+        let mut bytes = EdgeOsmOffsetsFile::encode(&o);
+        let mid = HEADER_SIZE + 4;
+        bytes[mid] ^= 0xFF;
+        assert!(EdgeOsmOffsetsFile::read_from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn ids_rejects_bad_magic() {
+        let (_, i) = sample();
+        let mut bytes = EdgeOsmIdsFile::encode(&i);
+        bytes[0] ^= 0xFF;
+        assert!(EdgeOsmIdsFile::read_from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn ids_rejects_truncation() {
+        let (_, i) = sample();
+        let bytes = EdgeOsmIdsFile::encode(&i);
+        assert!(EdgeOsmIdsFile::read_from_bytes(&bytes[..bytes.len() - 1]).is_err());
+    }
+
+    #[test]
+    fn offsets_rejects_non_monotonic() {
+        let o = EdgeOsmOffsets {
+            n_edges: 2,
+            n_ids: 4,
+            offsets: ArcCow::from_vec(vec![0, 3, 4]),
+        };
+        let mut bytes = EdgeOsmOffsetsFile::encode(&o);
+        // Swap entries 1 and 2 (3↔4 → [0,4,3] not non-decreasing… but
+        // also recompute CRCs so the monotonicity check is what trips).
+        let b = HEADER_SIZE;
+        bytes[b + 4..b + 8].copy_from_slice(&4u32.to_le_bytes());
+        bytes[b + 8..b + 12].copy_from_slice(&3u32.to_le_bytes());
+        // Recompute footer
+        let body_len = 3 * 4;
+        let mut body_d = Digest::new();
+        body_d.update(&bytes[HEADER_SIZE..HEADER_SIZE + body_len]);
+        let body_crc = body_d.finalize();
+        let mut file_d = Digest::new();
+        file_d.update(&bytes[..HEADER_SIZE + body_len]);
+        let file_crc = file_d.finalize();
+        let f = HEADER_SIZE + body_len;
+        bytes[f..f + 8].copy_from_slice(&body_crc.to_le_bytes());
+        bytes[f + 8..f + 16].copy_from_slice(&file_crc.to_le_bytes());
+        let err = EdgeOsmOffsetsFile::read_from_bytes(&bytes);
+        assert!(err.is_err(), "non-monotonic offsets must be rejected");
+    }
+}

--- a/route/src/formats/mod.rs
+++ b/route/src/formats/mod.rs
@@ -44,6 +44,7 @@ pub mod snap_index;
 
 // Server-only flat edge geometry sections (#155)
 pub mod edge_geom;
+pub mod edge_osm;
 
 // Multi-region coarse tile coverage set (#142)
 pub mod region_tiles;
@@ -68,6 +69,7 @@ pub use ebg_csr::{EbgCsr, EbgCsrFile};
 pub use ebg_nodes::{EbgNode, EbgNodes, EbgNodesFile};
 pub use ebg_turn_table::{TurnEntry, TurnKind, TurnTable, TurnTableFile};
 pub use edge_geom::{EdgeGeomOffsets, EdgeGeomOffsetsFile, EdgeGeomPoints, EdgeGeomPointsFile};
+pub use edge_osm::{EdgeOsmIds, EdgeOsmIdsFile, EdgeOsmOffsets, EdgeOsmOffsetsFile};
 pub use filtered_ebg::{FilteredEbg, FilteredEbgFile};
 pub use hybrid_state::{HybridState, HybridStateFile};
 pub use mmap::ArcCow;

--- a/route/src/nbg/mod.rs
+++ b/route/src/nbg/mod.rs
@@ -160,6 +160,48 @@ pub fn build_nbg(config: NbgConfig) -> Result<NbgResult> {
     NbgNodeMapFile::write(&node_map_path, &node_map)?;
     println!("  ✓ Wrote {}", node_map_path.display());
 
+    // #460: persist the per-edge OSM id chains (1:1 with polyline
+    // vertices, canonical u→v direction) BEFORE build_geo_structure
+    // consumes `edges`. Same CSR shape as the geometry sections.
+    {
+        use crate::formats::edge_osm::{
+            EdgeOsmIds, EdgeOsmIdsFile, EdgeOsmOffsets, EdgeOsmOffsetsFile,
+        };
+        let n_edges = edges.len();
+        let mut offsets: Vec<u32> = Vec::with_capacity(n_edges + 1);
+        let total_ids: usize = edges.iter().map(|e| e.osm_ids.len()).sum();
+        let mut ids: Vec<i64> = Vec::with_capacity(total_ids);
+        let mut cumulative: u32 = 0;
+        for e in &edges {
+            offsets.push(cumulative);
+            debug_assert_eq!(
+                e.osm_ids.len(),
+                e.polyline.lat_fxp.len(),
+                "edge OSM id chain must be 1:1 with polyline vertices"
+            );
+            ids.extend_from_slice(&e.osm_ids);
+            cumulative = cumulative
+                .checked_add(e.osm_ids.len() as u32)
+                .ok_or_else(|| anyhow::anyhow!("edge_osm id count overflows u32"))?;
+        }
+        offsets.push(cumulative);
+        let off = EdgeOsmOffsets {
+            n_edges: n_edges as u32,
+            n_ids: cumulative,
+            offsets: crate::formats::mmap::ArcCow::from_vec(offsets),
+        };
+        let ids = EdgeOsmIds {
+            n_ids: cumulative,
+            ids: crate::formats::mmap::ArcCow::from_vec(ids),
+        };
+        let off_path = config.outdir.join("nbg.edge_osm.offsets");
+        EdgeOsmOffsetsFile::write(&off_path, &off)?;
+        println!("  ✓ Wrote {}", off_path.display());
+        let ids_path = config.outdir.join("nbg.edge_osm.ids");
+        EdgeOsmIdsFile::write(&ids_path, &ids)?;
+        println!("  ✓ Wrote {}", ids_path.display());
+    }
+
     let geo = build_geo_structure(edges)?;
     let geo_path = config.outdir.join("nbg.geo");
     NbgGeoFile::write(&geo_path, &geo)?;
@@ -341,6 +383,12 @@ struct EdgeInfo {
     length_mm: u32,
     bearing_deci_deg: u16,
     polyline: PolyLine,
+    /// OSM node IDs of every polyline vertex, 1:1 with the polyline's
+    /// points (same canonical u→v direction, same coord-missing skips).
+    /// Persisted to `nbg.edge_osm.*` so the serve path can expand NBG
+    /// edges to per-OSM-segment rows (#460) — this loop is the only
+    /// place the coord↔id association is unambiguous.
+    osm_ids: Vec<i64>,
     first_osm_way_id: i64,
     flags: u32,
 }
@@ -379,9 +427,13 @@ fn emit_edges(
                 if let (Some(&u_compact), Some(&v_compact)) =
                     (osm_to_compact.get(&start_osm), osm_to_compact.get(&end_osm))
                 {
-                    // Collect polyline
+                    // Collect polyline + the 1:1 OSM id chain (#460). The
+                    // id push sits INSIDE the coord guard so ids stay
+                    // exactly parallel to the vertices when a node's
+                    // coords are missing.
                     let mut lat_fxp = Vec::new();
                     let mut lon_fxp = Vec::new();
+                    let mut osm_ids: Vec<i64> = Vec::new();
                     let mut length_m = 0.0;
 
                     for j in seg_start_idx..=i {
@@ -389,6 +441,7 @@ fn emit_edges(
                         if let Some((lat, lon)) = node_coords.get(osm_id) {
                             lat_fxp.push((lat * 1e7).round() as i32);
                             lon_fxp.push((lon * 1e7).round() as i32);
+                            osm_ids.push(osm_id);
 
                             if j > seg_start_idx {
                                 let prev_osm = nodes[j - 1];
@@ -417,6 +470,7 @@ fn emit_edges(
                             length_mm,
                             bearing_deci_deg: bearing,
                             polyline: PolyLine { lat_fxp, lon_fxp },
+                            osm_ids,
                             first_osm_way_id: way_id,
                             flags: 0, // Reserved for future use (roundabout, ferry, tunnel, bridge); see NbgEdge definition in formats/nbg_geo.rs
                         };

--- a/route/src/pack.rs
+++ b/route/src/pack.rs
@@ -847,6 +847,17 @@ pub fn pack_with_options(
         );
     }
 
+    // ---- Per-edge OSM node ID chains (#460) -------------------------
+    // Carried from step 3 so the serve path can expand NBG edges to
+    // per-OSM-segment rows. Absent in pre-#460 step3 dirs — skip with a
+    // notice; edges_flow then falls back to NBG-endpoint rows.
+    if let Err(e) = pack_edge_osm(&mut w, &step3) {
+        eprintln!(
+            "  ! [skip edge_osm] {}; edges_flow will emit NBG-endpoint rows (re-run step3 to enable per-OSM-segment expansion)",
+            e
+        );
+    }
+
     // ---- Way-name lookup index (#282) ------------------------------
     // Build a compact mmap-able way-name table from `step1/ways.raw`.
     // Saves ~30 MB heap on Belgium vs the HashMap<i64, String> path
@@ -1244,6 +1255,65 @@ fn pack_edge_geometry(w: &mut ContainerWriter, step3: &Path) -> Result<()> {
         &pts_bytes,
     )
     .with_context(|| "packing shared/edge_geom_points".to_string())?;
+
+    Ok(())
+}
+
+/// #460: carry the step-3 per-edge OSM node ID chains into the container
+/// as `shared/edge_osm_offsets` + `shared/edge_osm_ids`. The step-3 files
+/// already use the section encodings, so this validates (full CRC +
+/// header parse + monotonicity) and re-emits the verified bytes.
+fn pack_edge_osm(w: &mut ContainerWriter, step3: &Path) -> Result<()> {
+    use crate::formats::edge_osm::{EdgeOsmIdsFile, EdgeOsmOffsetsFile};
+
+    let off_path = step3.join("nbg.edge_osm.offsets");
+    let ids_path = step3.join("nbg.edge_osm.ids");
+    if !off_path.exists() || !ids_path.exists() {
+        anyhow::bail!(
+            "nbg.edge_osm.{{offsets,ids}} missing under {} (pre-#460 step3 output)",
+            step3.display()
+        );
+    }
+
+    let off_bytes =
+        std::fs::read(&off_path).with_context(|| format!("reading {}", off_path.display()))?;
+    let ids_bytes =
+        std::fs::read(&ids_path).with_context(|| format!("reading {}", ids_path.display()))?;
+
+    // Full validation before emission (CRC, header, monotonic offsets,
+    // cross-file n_ids agreement).
+    let off = EdgeOsmOffsetsFile::read_from_bytes(&off_bytes)
+        .with_context(|| format!("validating {}", off_path.display()))?;
+    let ids = EdgeOsmIdsFile::read_from_bytes(&ids_bytes)
+        .with_context(|| format!("validating {}", ids_path.display()))?;
+    anyhow::ensure!(
+        off.n_ids == ids.n_ids,
+        "edge_osm n_ids mismatch: offsets say {}, ids say {}",
+        off.n_ids,
+        ids.n_ids
+    );
+
+    println!(
+        "  + [{:>5} MiB] {:<28} <- (edge_osm_offsets, n_edges={})",
+        off_bytes.len() / (1024 * 1024),
+        "shared/edge_osm_offsets",
+        off.n_edges,
+    );
+    w.append_bytes(
+        SectionKind::EdgeOsmOffsets,
+        "shared/edge_osm_offsets",
+        &off_bytes,
+    )
+    .with_context(|| "packing shared/edge_osm_offsets".to_string())?;
+
+    println!(
+        "  + [{:>5} MiB] {:<28} <- (edge_osm_ids, n_ids={})",
+        ids_bytes.len() / (1024 * 1024),
+        "shared/edge_osm_ids",
+        ids.n_ids,
+    );
+    w.append_bytes(SectionKind::EdgeOsmIds, "shared/edge_osm_ids", &ids_bytes)
+        .with_context(|| "packing shared/edge_osm_ids".to_string())?;
 
     Ok(())
 }

--- a/route/src/server/edge_osm.rs
+++ b/route/src/server/edge_osm.rs
@@ -1,0 +1,201 @@
+//! #460: per-NBG-edge OSM node ID chains on the serve path.
+//!
+//! Wraps the `shared/edge_osm_offsets` + `shared/edge_osm_ids` sections
+//! (see [`crate::formats::edge_osm`]) and resolves any **EBG node**
+//! (a directed NBG edge) to its **per-OSM-segment** `(from, to)` id
+//! pairs — the granularity per-segment reference tables join on. At NBG
+//! granularity ~49% of `edges_flow` mass keyed to junction pairs absent
+//! from such tables; this is the server-side expansion that closes it.
+//!
+//! Direction handling mirrors the geometry subsystem: the stored chain
+//! is in the NBG edge's canonical u→v order, both directed EBG twins
+//! share the same `geom_idx`, and direction is resolved by comparing the
+//! chain's endpoints against the EBG node's tail OSM id — no extra
+//! per-EBG storage.
+
+use crate::formats::edge_osm::{EdgeOsmIds, EdgeOsmOffsets};
+use crate::formats::mmap::ArcCow;
+
+/// Per-edge OSM id chains, CSR over the same NBG undirected edge space as
+/// [`super::edge_geom::EdgeGeometry`] (`EbgNode.geom_idx`).
+pub struct EdgeOsmChains {
+    /// Length `n_edges + 1`; empty (len 0) ⇒ chains absent.
+    offsets: ArcCow<u32>,
+    ids: ArcCow<i64>,
+}
+
+impl EdgeOsmChains {
+    /// The "absent" sentinel — old containers without the sections.
+    pub fn empty() -> Self {
+        Self {
+            offsets: ArcCow::from_vec(Vec::new()),
+            ids: ArcCow::from_vec(Vec::new()),
+        }
+    }
+
+    pub fn from_sections(off: EdgeOsmOffsets, ids: EdgeOsmIds) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            off.n_ids == ids.n_ids,
+            "edge_osm_offsets.n_ids ({}) != edge_osm_ids.n_ids ({})",
+            off.n_ids,
+            ids.n_ids
+        );
+        anyhow::ensure!(
+            ids.ids.len() == ids.n_ids as usize,
+            "edge_osm_ids body length {} != n_ids {}",
+            ids.ids.len(),
+            ids.n_ids
+        );
+        anyhow::ensure!(
+            off.offsets.len() == off.n_edges as usize + 1,
+            "edge_osm_offsets length {} != n_edges + 1 ({})",
+            off.offsets.len(),
+            off.n_edges as usize + 1
+        );
+        Ok(Self {
+            offsets: off.offsets,
+            ids: ids.ids,
+        })
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.offsets.as_slice().is_empty()
+    }
+
+    /// The id chain for NBG undirected edge `geom_idx`, canonical u→v
+    /// order. `None` when chains are absent or the index is out of range.
+    #[inline]
+    pub fn chain(&self, geom_idx: u32) -> Option<&[i64]> {
+        let off = self.offsets.as_slice();
+        let i = geom_idx as usize;
+        if i + 1 >= off.len() {
+            return None;
+        }
+        let (s, e) = (off[i] as usize, off[i + 1] as usize);
+        self.ids.as_slice().get(s..e)
+    }
+
+    /// Resolve a DIRECTED traversal of NBG edge `geom_idx` to its OSM
+    /// segment pairs, oriented so the first pair starts at `osm_tail`
+    /// (the traversal's entry junction).
+    ///
+    /// Returns `None` when chains are absent, the chain is shorter than
+    /// 2 ids, or `osm_tail` matches neither chain endpoint (defensive —
+    /// indicates id/geometry disagreement; callers fall back to
+    /// NBG-endpoint emission). The forward case yields
+    /// `(chain[i], chain[i+1])`; the reverse case yields
+    /// `(chain[i+1], chain[i])` walking from the chain's end.
+    pub fn directed_segments(&self, geom_idx: u32, osm_tail: i64) -> Option<DirectedSegments<'_>> {
+        let chain = self.chain(geom_idx)?;
+        if chain.len() < 2 {
+            return None;
+        }
+        let forward = if chain[0] == osm_tail {
+            true
+        } else if chain[chain.len() - 1] == osm_tail {
+            false
+        } else {
+            return None;
+        };
+        Some(DirectedSegments {
+            chain,
+            forward,
+            i: 0,
+        })
+    }
+}
+
+/// Iterator over a directed edge's per-OSM-segment `(from, to)` pairs.
+pub struct DirectedSegments<'a> {
+    chain: &'a [i64],
+    forward: bool,
+    i: usize,
+}
+
+impl Iterator for DirectedSegments<'_> {
+    type Item = (i64, i64);
+
+    #[inline]
+    fn next(&mut self) -> Option<(i64, i64)> {
+        let n = self.chain.len();
+        if self.i + 1 >= n {
+            return None;
+        }
+        let out = if self.forward {
+            (self.chain[self.i], self.chain[self.i + 1])
+        } else {
+            (self.chain[n - 1 - self.i], self.chain[n - 2 - self.i])
+        };
+        self.i += 1;
+        Some(out)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let left = (self.chain.len() - 1).saturating_sub(self.i);
+        (left, Some(left))
+    }
+}
+
+impl ExactSizeIterator for DirectedSegments<'_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chains() -> EdgeOsmChains {
+        // edge 0: [10, 11, 12]; edge 1: [12, 13]; edge 2: [20] (degenerate)
+        EdgeOsmChains {
+            offsets: ArcCow::from_vec(vec![0, 3, 5, 6]),
+            ids: ArcCow::from_vec(vec![10, 11, 12, 12, 13, 20]),
+        }
+    }
+
+    #[test]
+    fn forward_segments() {
+        let c = chains();
+        let segs: Vec<_> = c.directed_segments(0, 10).unwrap().collect();
+        assert_eq!(segs, vec![(10, 11), (11, 12)]);
+    }
+
+    #[test]
+    fn reverse_segments() {
+        let c = chains();
+        let segs: Vec<_> = c.directed_segments(0, 12).unwrap().collect();
+        assert_eq!(segs, vec![(12, 11), (11, 10)]);
+    }
+
+    #[test]
+    fn tail_mismatch_is_none() {
+        let c = chains();
+        assert!(c.directed_segments(0, 99).is_none());
+    }
+
+    #[test]
+    fn degenerate_chain_is_none() {
+        let c = chains();
+        assert!(c.directed_segments(2, 20).is_none());
+    }
+
+    #[test]
+    fn out_of_range_is_none() {
+        let c = chains();
+        assert!(c.chain(3).is_none());
+        assert!(c.directed_segments(3, 10).is_none());
+    }
+
+    #[test]
+    fn empty_sentinel() {
+        let c = EdgeOsmChains::empty();
+        assert!(c.is_empty());
+        assert!(c.chain(0).is_none());
+    }
+
+    #[test]
+    fn exact_size() {
+        let c = chains();
+        let it = c.directed_segments(0, 10).unwrap();
+        assert_eq!(it.len(), 2);
+    }
+}

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -1755,11 +1755,32 @@ pub(crate) fn edges_for_pair(
     query_idx: u32,
     pair: &[f64; 4],
 ) -> PairEdges {
+    match route_for_pair(state, mode_data, mode, query, pair) {
+        Some((src_rank, dst_rank, result)) => {
+            emit_pair_rows(state, mode_data, src_rank, dst_rank, &result, query_idx)
+        }
+        None => PairEdges {
+            query_idx,
+            rows: Vec::new(),
+        },
+    }
+}
+
+/// #460: the routing core of [`edges_for_pair`] WITHOUT row emission —
+/// K=1 fast path + K=64/16-combo escalation, returning the raw
+/// `(src_rank, dst_rank, QueryResult)` so flow accumulation can fold
+/// ranks instead of materialized rows. `None` ⇒ unreachable.
+pub(crate) fn route_for_pair(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    query: &super::query::CchQuery<'_>,
+    pair: &[f64; 4],
+) -> Option<(u32, u32, super::query::QueryResult)> {
     use super::types::SnapRole;
     let (slon, slat, dlon, dlat) = (pair[0], pair[1], pair[2], pair[3]);
 
     // K=1 fast path (same shape as compute_route_pair).
-    let mut p2p: Option<(u32, u32, super::query::QueryResult)> = None;
     let src_role = SnapRole::Src.role_filter(mode_data);
     let dst_role = SnapRole::Dst.role_filter(mode_data);
     if let (Some(src_id), Some(dst_id)) = (
@@ -1776,32 +1797,28 @@ pub(crate) fn edges_for_pair(
         && d != u32::MAX
         && let Some(r) = query.query(s, d)
     {
-        p2p = Some((s, d, r));
-    }
-
-    if let Some((src_rank, dst_rank, result)) = p2p {
-        return emit_pair_rows(state, mode_data, src_rank, dst_rank, &result, query_idx);
+        return Some((s, d, r));
     }
     // K=1 didn't connect → K=64 escalation.
-    escalate_pair(state, mode_data, mode, query, query_idx, pair)
+    escalate_route(state, mode_data, mode, query, pair)
 }
 
 /// #438: K=64 + 16-combo escalation for a pair the K=1 fast path could not
 /// connect. Snaps both ends to 64 candidates and tries the closest-sum-first
-/// combos; emits the path or one unreachable null row.
+/// combos. Routing only (#460 split — callers emit rows via
+/// [`emit_pair_rows`] or fold ranks); `None` ⇒ unreachable.
 ///
 /// Split out of `edges_for_pair` so the source-grouped per-pair path
 /// (`process_per_pair_work`) can escalate WITHOUT re-doing the K=1 snap+query
 /// it already attempted with the precomputed ranks (#438-review: avoids the
 /// redundant K=1 work that made the all-singleton workload regress).
-fn escalate_pair(
+fn escalate_route(
     state: &ServerState,
     mode_data: &super::state::ModeData,
     mode: Mode,
     query: &super::query::CchQuery<'_>,
-    query_idx: u32,
     pair: &[f64; 4],
-) -> PairEdges {
+) -> Option<(u32, u32, super::query::QueryResult)> {
     use super::types::SnapRole;
     let (slon, slat, dlon, dlat) = (pair[0], pair[1], pair[2], pair[3]);
     const SNAP_K: usize = 64;
@@ -1836,20 +1853,16 @@ fn escalate_pair(
         // (reachable count identical at 8 / 16 / 200) while bounding the
         // worst-case cost of a pair whose K=64 candidates don't connect.
         const EDGES_BATCH_MAX_COMBOS: usize = 16;
-        if let Some((src_rank, dst_rank, result)) = super::snap_kbest::p2p_with_kbest_fallback(
+        if let Some(hit) = super::snap_kbest::p2p_with_kbest_fallback(
             query,
             &src_snap.ranks,
             &dst_snap.ranks,
             EDGES_BATCH_MAX_COMBOS,
         ) {
-            return emit_pair_rows(state, mode_data, src_rank, dst_rank, &result, query_idx);
+            return Some(hit);
         }
     }
-    // Unreachable.
-    PairEdges {
-        query_idx,
-        rows: Vec::new(),
-    }
+    None // unreachable
 }
 
 /// #438: shared unpack + per-edge row emit. Used by BOTH the per-pair
@@ -2025,21 +2038,39 @@ pub(crate) fn process_per_pair_work(
     query: &super::query::CchQuery<'_>,
     work: &PerPairWork,
 ) -> PairEdges {
-    if let (Some(src_rank), Some(dst_rank)) = (work.src_rank, work.dst_rank)
-        && let Some(result) = query.query(src_rank, dst_rank)
-    {
-        return emit_pair_rows(
+    match route_per_pair_work(state, mode_data, mode, query, work) {
+        Some((src_rank, dst_rank, result)) => emit_pair_rows(
             state,
             mode_data,
             src_rank,
             dst_rank,
             &result,
             work.query_idx,
-        );
+        ),
+        None => PairEdges {
+            query_idx: work.query_idx,
+            rows: Vec::new(),
+        },
+    }
+}
+
+/// #460: routing core of [`process_per_pair_work`] WITHOUT row emission —
+/// carried-K=1-ranks query, then K=64 escalation. `None` ⇒ unreachable.
+pub(crate) fn route_per_pair_work(
+    state: &ServerState,
+    mode_data: &super::state::ModeData,
+    mode: Mode,
+    query: &super::query::CchQuery<'_>,
+    work: &PerPairWork,
+) -> Option<(u32, u32, super::query::QueryResult)> {
+    if let (Some(src_rank), Some(dst_rank)) = (work.src_rank, work.dst_rank)
+        && let Some(result) = query.query(src_rank, dst_rank)
+    {
+        return Some((src_rank, dst_rank, result));
     }
     // K=1 missed (or didn't connect) → escalate WITHOUT re-doing the K=1 that
     // the precomputed-rank query above already covered.
-    escalate_pair(state, mode_data, mode, query, work.query_idx, &work.pair)
+    escalate_route(state, mode_data, mode, query, &work.pair)
 }
 
 /// #438: resolve each pair's K=1 source/dest rank and partition into

--- a/route/src/server/flow.rs
+++ b/route/src/server/flow.rs
@@ -24,13 +24,17 @@
 //!    every parent before its children — each arc's flow is final when
 //!    popped, and the cascade is a single pass.
 //! 3. **Flush** base-arc flow to EBG ranks (a base UP/DOWN arc `u→v`
-//!    contributes the rank it appends to the unpacked path: `v`), map
-//!    ranks to OSM endpoints, and merge the fallback rows.
+//!    contributes the rank it appends to the unpacked path: `v`), then
+//!    expand each DISTINCT rank to **per-OSM-segment** rows via the
+//!    [`crate::server::edge_osm::EdgeOsmChains`] id chains (#460 —
+//!    NBG-junction granularity left ~49% of flow mass on node pairs
+//!    absent from per-segment reference tables). Old containers without
+//!    the chains fall back to NBG-endpoint rows.
 //!
 //! Pairs the tree can't serve (snap misses, singleton groups, lane
-//! backtrack misses) ride the existing per-pair path and fold their
-//! emitted rows directly into the OSM-keyed accumulator — bit-identical
-//! routing semantics to `edges_batch`, only the aggregation differs.
+//! backtrack misses) ride the same routing core per-pair and fold their
+//! unpacked RANK paths into the same accumulator — identical routing
+//! semantics to `edges_batch`, identical expansion at flush.
 //!
 //! Determinism: batches compute in parallel but merge in batch order, the
 //! cascade pops `(middle, arc, group)` tuples (total order), and the final
@@ -40,7 +44,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use rayon::prelude::*;
 
-use super::flight::{GroupedTarget, PairEdges, PerPairWork};
+use super::flight::{GroupedTarget, PerPairWork};
 use super::state::{ModeData, ServerState};
 use crate::model::types::Mode;
 use crate::range::tree_phast::{
@@ -71,10 +75,10 @@ struct BatchAcc {
     /// `(group, tagged CCH arc) → flow` from tree-served pairs.
     arc_flow: HashMap<(u32, u32), f64>,
     /// `(group, EBG rank) → flow` — source-rank deposits (the unpacked
-    /// path includes the source EBG node itself).
+    /// path includes the source EBG node itself) plus per-pair fallback
+    /// rank paths. EVERYTHING converges here so the per-OSM-segment
+    /// expansion at flush covers every pair uniformly (#460).
     rank_flow: HashMap<(u32, u32), f64>,
-    /// `(group, osm_from, osm_to) → flow` from per-pair fallback rows.
-    row_flow: HashMap<(u32, i64, i64), f64>,
     n_unreachable: u64,
     assigned: f64,
 }
@@ -87,25 +91,8 @@ impl BatchAcc {
         for (k, v) in self.rank_flow {
             *total.rank_flow.entry(k).or_default() += v;
         }
-        for (k, v) in self.row_flow {
-            *total.row_flow.entry(k).or_default() += v;
-        }
         total.n_unreachable += self.n_unreachable;
         total.assigned += self.assigned;
-    }
-
-    fn fold_pair_rows(&mut self, group: u32, weight: f64, rows: &[super::flight::EdgeRow]) {
-        if rows.is_empty() {
-            self.n_unreachable += 1;
-            return;
-        }
-        for r in rows {
-            *self
-                .row_flow
-                .entry((group, r.osm_from, r.osm_to))
-                .or_default() += weight;
-        }
-        self.assigned += weight;
     }
 }
 
@@ -165,9 +152,24 @@ fn process_flow_batch(
     for t in fallbacks {
         let g = groups[t.query_idx as usize];
         let w = weights[t.query_idx as usize];
-        let pe =
-            super::flight::edges_for_pair(state, mode_data, mode, &query, t.query_idx, &t.pair);
-        acc.fold_pair_rows(g, w, &pe.rows);
+        match super::flight::route_for_pair(state, mode_data, mode, &query, &t.pair) {
+            Some((s, d, r)) => {
+                let rank_path = super::unpack::unpack_path(
+                    &mode_data.cch_topo,
+                    &mode_data.cch_weights,
+                    &r.forward_parent,
+                    &r.backward_parent,
+                    s,
+                    d,
+                    r.meeting_node,
+                );
+                for rank in rank_path {
+                    *acc.rank_flow.entry((g, rank)).or_default() += w;
+                }
+                acc.assigned += w;
+            }
+            None => acc.n_unreachable += 1,
+        }
     }
     acc
 }
@@ -356,35 +358,79 @@ pub fn compute_edges_flow(
         acc.merge_into(&mut total);
     }
 
-    // Per-pair work (snap misses + singletons): existing per-pair path,
-    // rows folded by query_idx order (deterministic).
-    let pair_results: Vec<PairEdges> = if parallel {
+    // Per-pair work (snap misses + singletons): routing core only — the
+    // unpacked RANK paths fold into the same rank accumulator as the
+    // tree path, so the per-OSM-segment expansion at flush covers every
+    // pair uniformly (#460: NBG-granularity leakage through the fallback
+    // would re-create phantom rows). query_idx order keeps the merge
+    // deterministic.
+    let pair_ranks: Vec<(u32, Option<Vec<u32>>)> = if parallel {
         per_pair_work
             .par_iter()
             .map(|w: &PerPairWork| {
                 let query = super::query::CchQuery::new(mode_data);
-                super::flight::process_per_pair_work(state, mode_data, mode, &query, w)
+                let ranks = super::flight::route_per_pair_work(state, mode_data, mode, &query, w)
+                    .map(|(s, d, r)| {
+                        super::unpack::unpack_path(
+                            &mode_data.cch_topo,
+                            &mode_data.cch_weights,
+                            &r.forward_parent,
+                            &r.backward_parent,
+                            s,
+                            d,
+                            r.meeting_node,
+                        )
+                    });
+                (w.query_idx, ranks)
             })
             .collect()
     } else {
         let query = super::query::CchQuery::new(mode_data);
         per_pair_work
             .iter()
-            .map(|w| super::flight::process_per_pair_work(state, mode_data, mode, &query, w))
+            .map(|w| {
+                let ranks = super::flight::route_per_pair_work(state, mode_data, mode, &query, w)
+                    .map(|(s, d, r)| {
+                        super::unpack::unpack_path(
+                            &mode_data.cch_topo,
+                            &mode_data.cch_weights,
+                            &r.forward_parent,
+                            &r.backward_parent,
+                            s,
+                            d,
+                            r.meeting_node,
+                        )
+                    });
+                (w.query_idx, ranks)
+            })
             .collect()
     };
-    for pe in &pair_results {
-        let g = groups[pe.query_idx as usize];
-        let w = weights[pe.query_idx as usize];
-        total.fold_pair_rows(g, w, &pe.rows);
+    for (query_idx, ranks) in &pair_ranks {
+        let g = groups[*query_idx as usize];
+        let w = weights[*query_idx as usize];
+        match ranks {
+            Some(rank_path) => {
+                for &rank in rank_path {
+                    *total.rank_flow.entry((g, rank)).or_default() += w;
+                }
+                total.assigned += w;
+            }
+            None => total.n_unreachable += 1,
+        }
     }
 
     // Cascade CCH-arc flow to EBG ranks.
     let arc_flow = std::mem::take(&mut total.arc_flow);
     cascade_arc_flow(mode_data, arc_flow, &mut total.rank_flow, parallel);
 
-    // Flush: rank → EBG node → OSM endpoints, merged with fallback rows.
-    let mut out: HashMap<(u32, i64, i64), f64> = std::mem::take(&mut total.row_flow);
+    // Flush: rank → EBG node → per-OSM-segment rows via the id chains
+    // (#460). Each DISTINCT rank expands exactly once; direction is
+    // resolved by matching the chain endpoint against the EBG tail's
+    // OSM id. Containers without the sections (and the rare
+    // id/geometry-disagreement edge) fall back to one NBG-endpoint row.
+    let chains = &state.edge_osm;
+    let mut nbg_fallback_edges = 0u64;
+    let mut out: HashMap<(u32, i64, i64), f64> = HashMap::default();
     for ((g, rank), f) in std::mem::take(&mut total.rank_flow) {
         let filt_id = mode_data.cch_topo.rank_to_filtered[rank as usize];
         let ebg_id = mode_data.filtered_to_original[filt_id as usize];
@@ -394,12 +440,27 @@ pub fn compute_edges_flow(
             .get(node.tail_nbg as usize)
             .copied()
             .unwrap_or(0);
-        let osm_to = state
-            .nbg_node_to_osm
-            .get(node.head_nbg as usize)
-            .copied()
-            .unwrap_or(0);
-        *out.entry((g, osm_from, osm_to)).or_default() += f;
+        if let Some(segments) = chains.directed_segments(node.geom_idx, osm_from) {
+            for (a, b) in segments {
+                *out.entry((g, a, b)).or_default() += f;
+            }
+        } else {
+            let osm_to = state
+                .nbg_node_to_osm
+                .get(node.head_nbg as usize)
+                .copied()
+                .unwrap_or(0);
+            *out.entry((g, osm_from, osm_to)).or_default() += f;
+            nbg_fallback_edges += 1;
+        }
+    }
+    if nbg_fallback_edges > 0 && !chains.is_empty() {
+        // With chains PRESENT a fallback means id/geometry disagreement —
+        // rare and worth surfacing (absent chains already warned at boot).
+        tracing::warn!(
+            nbg_fallback_edges,
+            "edges_flow: some edges expanded as NBG endpoints despite id chains being loaded"
+        );
     }
 
     let mut rows: Vec<FlowRow> = out

--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -36,6 +36,7 @@ pub mod border;
 pub mod catchment;
 pub mod cross_region;
 pub mod edge_geom;
+pub mod edge_osm;
 pub mod elevation;
 pub mod evictable;
 pub mod exclude;

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -284,6 +284,11 @@ pub struct ServerState {
     /// `EdgeGeometry::from_legacy_polylines` at boot. The accessors are
     /// identical either way.
     pub edge_geom: EdgeGeometry,
+    /// #460: per-NBG-edge OSM node id chains (same `geom_idx` space as
+    /// `edge_geom`). Empty when the container pre-dates the sections —
+    /// `edges_flow` then emits NBG-endpoint rows instead of
+    /// per-OSM-segment rows.
+    pub edge_osm: crate::server::edge_osm::EdgeOsmChains,
     /// NBG compact node id → OSM node id. Indexed by `compact_id`,
     /// loaded once at startup from `step3*/nbg.node_map`. Used by the
     /// Flight `edges_batch` action (#125) to expose per-edge OSM node
@@ -643,6 +648,9 @@ impl ServerState {
             ebg_csr,
             nbg_geo,
             edge_geom,
+            // #460: chains only ship in containers; the dir-tree boot
+            // path serves NBG-endpoint rows.
+            edge_osm: crate::server::edge_osm::EdgeOsmChains::empty(),
             nbg_node_to_osm,
             modes: modes_slots,
             mode_names,
@@ -1526,6 +1534,24 @@ impl ServerState {
         };
         crate::server::rss::checkpoint("load.edge_geom");
 
+        // #460: per-edge OSM node id chains — optional sections (absent
+        // in pre-#460 containers; edges_flow then emits NBG-endpoint
+        // rows and logs once).
+        let edge_osm = match try_load_edge_osm(&container, &mmap_for_bytes, &lazy_arc)? {
+            Some(chains) => {
+                tracing::info!("loaded per-edge OSM id chains zero-copy (#460)");
+                chains
+            }
+            None => {
+                tracing::warn!(
+                    "edge_osm sections missing — edges_flow emits NBG-endpoint rows \
+                     (re-run step3 + pack for per-OSM-segment expansion, #460)"
+                );
+                crate::server::edge_osm::EdgeOsmChains::empty()
+            }
+        };
+        crate::server::rss::checkpoint("load.edge_osm");
+
         // #160: optionally schedule a background warmup pass to walk
         // every still-`Unverified` section's CRC in parallel. This
         // matches pre-#160 total-coverage at the cost of a transient
@@ -1581,6 +1607,7 @@ impl ServerState {
             ebg_csr,
             nbg_geo,
             edge_geom,
+            edge_osm,
             nbg_node_to_osm,
             modes: modes_slots,
             mode_names,
@@ -3801,6 +3828,44 @@ fn try_load_packed_snap_index(
 /// falls back to building from the heap polylines.
 ///
 /// #160: per-section CRC verification is gated by [`LazyContainer`].
+/// #460: load the optional per-edge OSM id chain sections. `Ok(None)`
+/// when the container pre-dates them.
+fn try_load_edge_osm(
+    container: &crate::formats::butterfly_dat::Container,
+    mmap: &std::sync::Arc<memmap2::Mmap>,
+    lazy: &std::sync::Arc<crate::formats::lazy_verify::LazyContainer>,
+) -> Result<Option<crate::server::edge_osm::EdgeOsmChains>> {
+    use crate::formats::edge_osm::{EdgeOsmIdsFile, EdgeOsmOffsetsFile};
+
+    let off_entry = match container.get("shared/edge_osm_offsets") {
+        Some(e) => e,
+        None => return Ok(None),
+    };
+    let ids_entry = match container.get("shared/edge_osm_ids") {
+        Some(e) => e,
+        None => return Ok(None),
+    };
+    lazy.verify_now("shared/edge_osm_offsets")?;
+    lazy.verify_now("shared/edge_osm_ids")?;
+
+    let off = EdgeOsmOffsetsFile::read_from_mmap_unverified(
+        std::sync::Arc::clone(mmap),
+        off_entry.offset as usize,
+        off_entry.len as usize,
+    )
+    .with_context(|| "reading shared/edge_osm_offsets zero-copy")?;
+    let ids = EdgeOsmIdsFile::read_from_mmap_unverified(
+        std::sync::Arc::clone(mmap),
+        ids_entry.offset as usize,
+        ids_entry.len as usize,
+    )
+    .with_context(|| "reading shared/edge_osm_ids zero-copy")?;
+
+    let chains = crate::server::edge_osm::EdgeOsmChains::from_sections(off, ids)
+        .with_context(|| "stitching edge_osm sections")?;
+    Ok(Some(chains))
+}
+
 fn try_load_edge_geometry(
     container: &crate::formats::butterfly_dat::Container,
     mmap: &std::sync::Arc<memmap2::Mmap>,


### PR DESCRIPTION
Closes the #460 production blocker: 49.2% of flow mass keyed to phantom NBG node pairs. Chains carried from step 3 (the only unambiguous source), CRC'd container sections mirroring edge_geom, direction-aware serve resolver, uniform expansion at flush (tree + fallback paths both fold ranks). Old containers: NBG fallback + boot warning. 669 tests, full clippy 0. Activation needs an artifact rebuild (step3+pack) — running tonight; consumer re-validates the national workload (gate: phantom <10%, expected ~0%).