### PR TITLE
fix(review): Copilot sweep across #461/#463/#464

### DIFF
--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -2197,10 +2197,12 @@ impl Cli {
                 }
                 // Lean-deploy transit toggle: CLI flag or BUTTERFLY_TRANSIT
                 // env; "off"/"0"/"false"/"no" disables.
-                let transit_off = matches!(transit.to_lowercase().as_str(), "off" | "0" | "false")
-                    || std::env::var("BUTTERFLY_TRANSIT")
-                        .map(|v| matches!(v.to_lowercase().as_str(), "off" | "0" | "false" | "no"))
-                        .unwrap_or(false);
+                let transit_off = matches!(
+                    transit.to_lowercase().as_str(),
+                    "off" | "0" | "false" | "no"
+                ) || std::env::var("BUTTERFLY_TRANSIT")
+                    .map(|v| matches!(v.to_lowercase().as_str(), "off" | "0" | "false" | "no"))
+                    .unwrap_or(false);
                 if transit_off {
                     crate::server::set_transit_enabled(false);
                 }

--- a/route/src/range/sparse_contour.rs
+++ b/route/src/range/sparse_contour.rs
@@ -466,8 +466,10 @@ impl SparseContourConfig {
     /// a gap-filling closing must erode exactly what it dilated, or every
     /// un-eroded round leaves a net +1-cell uniform outward grow that is
     /// never reclaimed (~+19 m/side for car at the 300 s tier). Gap
-    /// bridging strength is set by the dilation count alone; the matching
-    /// erosion cannot re-open a bridged gap (closing is idempotent there).
+    /// bridging strength is set by the dilation count alone; closing is
+    /// extensive (result ⊇ original stamped set), so erosion can thin a
+    /// dilation-created bridge but never disconnect original geometry —
+    /// confirmed empirically on Belgium urban + rural origins (#431).
     pub fn for_car() -> Self {
         Self {
             cell_size_m: 30.0,

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -2312,7 +2312,8 @@ pub fn compute_edges_tree(
 
 /// #438 K-lane: process up to TREE_LANES source groups per task — one union
 /// selection + ONE restricted scan shared by all lanes (the scan was 73% of
-/// tree CPU). Per lane: resweep (UP parents) then backtrack its targets.
+/// tree CPU). Per lane: backtrack its targets off the UP-tree snapshot
+/// taken at settle time (no resweep — PR #461).
 /// Misses fall back to the per-pair path (separate scratch, safe after the
 /// lane work).
 fn process_tree_batch(
@@ -2499,7 +2500,7 @@ pub fn do_edges_batch(
 
         // Phase A: multi-target groups, chunked by accumulated target count so
         // each chunk holds ~CHUNK_PAIRS pairs. flat_map keeps each group's
-        // each group's settle (grouped OR tree, per the adaptive dispatch) +
+        // each group's settle (K-lane tree — the adaptive dispatch is retired) +
         // its targets on one rayon thread (thread-local state stays valid).
         let mut gi = 0usize;
         while gi < group_vec.len() {
@@ -2853,11 +2854,30 @@ async fn do_exchange_edges_flow(
             None => None,
         };
 
+        // Null handling (Copilot review on #463): coordinate columns must
+        // be null-free (Arrow `.value()` on a null slot returns garbage);
+        // a null weight/group falls back to its documented default.
+        for (name, arr) in [
+            ("src_lon", slon),
+            ("src_lat", slat),
+            ("dst_lon", dlon),
+            ("dst_lat", dlat),
+        ] {
+            if arr.null_count() > 0 {
+                return Err(Status::invalid_argument(format!(
+                    "{name} must not contain nulls ({} null rows)",
+                    arr.null_count()
+                )));
+            }
+        }
         for i in 0..batch.num_rows() {
             let pair = [slon.value(i), slat.value(i), dlon.value(i), dlat.value(i)];
             validate_coord(pair[0], pair[1], &format!("row[{i}].src"))?;
             validate_coord(pair[2], pair[3], &format!("row[{i}].dst"))?;
-            let w = weight.map(|a| a.value(i)).unwrap_or(1.0);
+            let w = match weight {
+                Some(a) if !a.is_null(i) => a.value(i),
+                _ => 1.0,
+            };
             if !w.is_finite() || w < 0.0 {
                 return Err(Status::invalid_argument(format!(
                     "row[{i}].weight must be finite and >= 0 (got {w})"
@@ -2865,7 +2885,10 @@ async fn do_exchange_edges_flow(
             }
             pairs.push(pair);
             weights.push(w);
-            groups.push(group.map(|a| a.value(i)).unwrap_or(0));
+            groups.push(match group {
+                Some(a) if !a.is_null(i) => a.value(i),
+                _ => 0,
+            });
         }
         if pairs.len() > MAX_FLOW_PAIRS {
             return Err(Status::invalid_argument(format!(
@@ -3398,9 +3421,10 @@ impl FlightService for ButterflyFlight {
             "catchment" => catchment_schema(),
             "transit_bulk" => transit_bulk_schema(),
             "edges_batch" => edges_batch_schema(),
+            "edges_flow" => edges_flow_schema(),
             other => {
                 return Err(Status::invalid_argument(format!(
-                    "Unknown action '{}'. Available: matrix, route_batch, isochrone, catchment, transit_bulk, edges_batch",
+                    "Unknown action '{}'. Available: matrix, route_batch, isochrone, catchment, transit_bulk, edges_batch, edges_flow",
                     other
                 )));
             }
@@ -3436,9 +3460,10 @@ impl FlightService for ButterflyFlight {
             "catchment" => catchment_schema(),
             "transit_bulk" => transit_bulk_schema(),
             "edges_batch" => edges_batch_schema(),
+            "edges_flow" => edges_flow_schema(),
             other => {
                 return Err(Status::invalid_argument(format!(
-                    "Unknown action '{}'. Available: matrix, route_batch, isochrone, catchment, transit_bulk, edges_batch",
+                    "Unknown action '{}'. Available: matrix, route_batch, isochrone, catchment, transit_bulk, edges_batch, edges_flow",
                     other
                 )));
             }

--- a/route/src/server/flow.rs
+++ b/route/src/server/flow.rs
@@ -138,10 +138,15 @@ fn process_flow_batch(
             };
             match hit {
                 Some(_dist) => {
-                    for &arc in &arc_buf {
-                        *acc.arc_flow.entry((g, arc)).or_default() += w;
+                    // w == 0 pairs are routed (reachability counts) but
+                    // deposit nothing — or_default() would otherwise emit
+                    // zero-flow rows (Copilot review on #463).
+                    if w != 0.0 {
+                        for &arc in &arc_buf {
+                            *acc.arc_flow.entry((g, arc)).or_default() += w;
+                        }
+                        *acc.rank_flow.entry((g, *src_rank)).or_default() += w;
                     }
-                    *acc.rank_flow.entry((g, *src_rank)).or_default() += w;
                     acc.assigned += w;
                 }
                 None => fallbacks.push(t),
@@ -163,8 +168,10 @@ fn process_flow_batch(
                     d,
                     r.meeting_node,
                 );
-                for rank in rank_path {
-                    *acc.rank_flow.entry((g, rank)).or_default() += w;
+                if w != 0.0 {
+                    for rank in rank_path {
+                        *acc.rank_flow.entry((g, rank)).or_default() += w;
+                    }
                 }
                 acc.assigned += w;
             }
@@ -410,8 +417,10 @@ pub fn compute_edges_flow(
         let w = weights[*query_idx as usize];
         match ranks {
             Some(rank_path) => {
-                for &rank in rank_path {
-                    *total.rank_flow.entry((g, rank)).or_default() += w;
+                if w != 0.0 {
+                    for &rank in rank_path {
+                        *total.rank_flow.entry((g, rank)).or_default() += w;
+                    }
                 }
                 total.assigned += w;
             }

--- a/scripts/isochrone_consistency_test.py
+++ b/scripts/isochrone_consistency_test.py
@@ -59,7 +59,7 @@ def get_isochrone(lon: float, lat: float, time_s: int, mode: str = "car") -> Opt
             return None
         data = resp.json()
         contours = data.get("contours", [])
-        polygon_coords = contours[0].get("polygon_geojson") or [] if contours else []
+        polygon_coords = (contours[0].get("polygon_geojson") or []) if contours else []
         if len(polygon_coords) < 3:
             print(f"  Isochrone has < 3 points")
             return None


### PR DESCRIPTION
Null-safe edges_flow input parsing, zero-weight deposit guards, --transit "no" parity, edges_flow schema discovery, stale comments, precise morphology doc. 669 tests, full clippy 0.