### PR TITLE
fix(serve): --transit off silently disabled boot recustomization

### DIFF
--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -443,13 +443,17 @@ pub async fn serve(
     // origin/destination pairs.
     let mut regions_state = regions_state;
     let mut transit_loaded_count = 0usize;
-    let n_regions = if transit_enabled() {
-        regions_state.regions.len()
+    let n_regions = regions_state.regions.len();
+    // Scope the transit toggle to THIS loop only — n_regions is shared by
+    // the boot recustomization + overlay paths below (zeroing it silently
+    // skipped the #467 traffic recustomize; found in production).
+    let transit_regions = if transit_enabled() {
+        n_regions
     } else {
         tracing::info!("transit disabled (--transit off / BUTTERFLY_TRANSIT) — road-only serve");
         0
     };
-    for idx in 0..n_regions {
+    for idx in 0..transit_regions {
         let region_id_lower = regions_state.regions[idx].id.to_lowercase();
         let per_region_dir = data_dir_for_transit.join(&region_id_lower);
 

--- a/route/src/server/state.rs
+++ b/route/src/server/state.rs
@@ -1993,7 +1993,10 @@ impl ServerState {
                 std::collections::HashMap::with_capacity(rows.len());
             let table_is_ratio = rows[0].ratio.is_some();
             for r in &rows {
-                let v = r.ratio.or(r.speed_kmh).expect("reader guarantees one value");
+                let v = r
+                    .ratio
+                    .or(r.speed_kmh)
+                    .expect("reader guarantees one value");
                 lut.insert((r.from, r.to), v);
             }
 
@@ -2043,8 +2046,7 @@ impl ServerState {
                     if table_is_ratio {
                         // Factor on the edge's OWN base time (slower ⇒ v<1
                         // ⇒ time grows). Keeps per-edge legal speeds intact.
-                        weights[i] =
-                            (((weights[i] as f64) / v as f64).round() as u32).max(1);
+                        weights[i] = (((weights[i] as f64) / v as f64).round() as u32).max(1);
                     } else {
                         let secs = (node.length_m as f64 * 3.6 / v as f64).round();
                         weights[i] = (secs.max(1.0) as u32).max(1);


### PR DESCRIPTION
Production find during the #467 traffic flip: the toggle zeroed shared n_regions → recustomize loop iterated zero regions. Scoped to the transit feed loop. 669 tests, clippy 0.