### PR TITLE
fix(bench): #468 — edges_batch oracle asserts on the CCH metric; row-sum demoted to tie-tolerant canary

### DIFF
--- a/route/src/bench/main.rs
+++ b/route/src/bench/main.rs
@@ -4685,8 +4685,11 @@ fn run_p2p_bench(
 /// equivalence oracle. Builds n_sources × targets_per_source pairs (the
 /// source-sharing shape of the real traffic-flow workload), runs both
 /// `compute_edges_flat` and `compute_edges_grouped` in-process, asserts they
-/// agree (reachability + per-pair total duration), reports byte-identity, and
-/// times them. The grouped path shares one forward CCH search per source.
+/// agree (reachability + per-pair CCH distance — the OPTIMIZED metric, #468),
+/// reports byte-identity, and times them. The summed row-duration comparison
+/// (post-unpack `node_weights` basis) is a tie-tolerant WARNING only:
+/// equal-CCH-cost alternative paths legitimately differ on it. The grouped
+/// path shares one forward CCH search per source.
 fn run_edges_batch_bench(
     data: &Path,
     mode_name: &str,
@@ -4770,6 +4773,7 @@ fn run_edges_batch_bench(
     let grouped = compute_edges_grouped(&state, &mode_data, mode, &pairs, true);
     assert_eq!(flat.len(), grouped.len(), "pair count mismatch");
     let mut reach_mismatch = 0usize;
+    let mut cch_mismatch = 0usize;
     let mut dur_mismatch = 0usize;
     let mut byte_identical = 0usize;
     let mut reachable = 0usize;
@@ -4782,6 +4786,16 @@ fn run_edges_batch_bench(
         }
         if f_reach != g_reach {
             reach_mismatch += 1;
+        }
+        // #468 CCH-METRIC oracle: compare the variants on the metric the
+        // searches actually OPTIMIZE (`QueryResult::distance`). This is the
+        // hard correctness gate — equal here means both found a shortest path.
+        if f.cch_distance != g.cch_distance {
+            cch_mismatch += 1;
+            println!(
+                "    CCH MISMATCH q{}: flat {:?} vs grouped {:?}, pair {:?}",
+                f.query_idx, f.cch_distance, g.cch_distance, pairs[f.query_idx as usize]
+            );
         }
         let f_dur: u64 = f.rows.iter().map(|r| r.dur_ms as u64).sum();
         let g_dur: u64 = g.rows.iter().map(|r| r.dur_ms as u64).sum();
@@ -4813,8 +4827,8 @@ fn run_edges_batch_bench(
     println!();
     println!("  EQUIVALENCE:");
     println!(
-        "    reachable {}/{}  | reachability mismatches: {}  | total-duration mismatches: {}",
-        reachable, n_pairs, reach_mismatch, dur_mismatch
+        "    reachable {}/{}  | reachability mismatches: {}  | CCH-distance mismatches: {}  | row-duration-sum mismatches: {}",
+        reachable, n_pairs, reach_mismatch, cch_mismatch, dur_mismatch
     );
     println!(
         "    byte-identical pairs: {}/{} ({:.2}%)  [equal-cost ties may differ]",
@@ -4826,30 +4840,48 @@ fn run_edges_batch_bench(
         reach_mismatch, 0,
         "CORRECTNESS: grouped path changed reachability for {reach_mismatch} pairs"
     );
+    // #468: HARD assert on the optimized metric — flat and grouped must find
+    // the same shortest-path COST. (The row-duration sum below is NOT asserted:
+    // it is computed from post-unpack `node_weights`, a different basis than
+    // the CCH weights the searches optimize, so equal-CCH-cost ties
+    // legitimately differ on it.)
+    assert_eq!(
+        cch_mismatch, 0,
+        "CORRECTNESS: flat vs grouped disagree on CCH distance for {cch_mismatch} pairs"
+    );
     if dur_mismatch > 0 {
-        // Known latent divergence (#468-to-be): flat's early-terminated
-        // bidirectional vs grouped's exhaustive-forward meet pick different
-        // snap/path combos on rare weight configurations (3/6000 on the
-        // 2026-06-10 rebuild, deltas 0.14-1.6%). The production edges_flow
-        // path is TREE+escalation, asserted hard below. Investigate before
-        // re-tightening.
+        // #468: tie-tolerant drift canary, NOT a correctness gate. With CCH
+        // distances asserted equal above, a row-sum delta means the variants
+        // picked different equal-CCH-cost paths whose node_weights sums differ
+        // (expected on rare weight vintages, 3-48/6000 on the 2026-06-10
+        // rebuild). A sudden JUMP in this count without a CCH mismatch still
+        // signals weight-basis drift worth a look — keep printing it.
         println!(
-            "    ⚠ flat-vs-grouped duration mismatches: {dur_mismatch} (latent bidirectional/meet divergence — see ticket)"
+            "    ⚠ flat-vs-grouped row-duration-sum mismatches: {dur_mismatch} (equal-CCH-cost ties — drift canary, see #468)"
         );
     } else {
-        println!("    ✓ reachability + total-duration IDENTICAL (correctness verified)");
+        println!("    ✓ reachability + CCH distance + row-duration sums IDENTICAL");
     }
 
     // ---- TREE variant (#438 Phase 1) oracle ----
     let tree = compute_edges_tree(&state, &mode_data, mode, &pairs, true);
     assert_eq!(tree.len(), flat.len(), "tree pair count mismatch");
     let mut t_reach_mismatch = 0usize;
+    let mut t_cch_mismatch = 0usize;
     let mut t_dur_mismatch = 0usize;
     let mut t_byte_identical = 0usize;
     for (f, g) in flat.iter().zip(tree.iter()) {
         assert_eq!(f.query_idx, g.query_idx, "tree query_idx order mismatch");
         if f.rows.is_empty() != g.rows.is_empty() {
             t_reach_mismatch += 1;
+        }
+        // #468 CCH-METRIC oracle (same as flat-vs-grouped above).
+        if f.cch_distance != g.cch_distance {
+            t_cch_mismatch += 1;
+            println!(
+                "    TREE CCH MISMATCH q{}: flat {:?} vs tree {:?}, pair {:?}",
+                f.query_idx, f.cch_distance, g.cch_distance, pairs[f.query_idx as usize]
+            );
         }
         let f_dur: u64 = f.rows.iter().map(|r| r.dur_ms as u64).sum();
         let g_dur: u64 = g.rows.iter().map(|r| r.dur_ms as u64).sum();
@@ -4875,22 +4907,28 @@ fn run_edges_batch_bench(
         }
     }
     println!(
-        "  TREE EQUIVALENCE: reach mismatches {} | duration mismatches {} | byte-identical {}/{} ({:.2}%)",
+        "  TREE EQUIVALENCE: reach mismatches {} | CCH mismatches {} | row-duration-sum mismatches {} | byte-identical {}/{} ({:.2}%)",
         t_reach_mismatch,
+        t_cch_mismatch,
         t_dur_mismatch,
         t_byte_identical,
         n_pairs,
         100.0 * t_byte_identical as f64 / n_pairs.max(1) as f64
     );
     assert_eq!(t_reach_mismatch, 0, "TREE changed reachability");
+    // #468: HARD assert on the optimized metric (see flat-vs-grouped above).
+    assert_eq!(
+        t_cch_mismatch, 0,
+        "CORRECTNESS: flat vs tree disagree on CCH distance for {t_cch_mismatch} pairs"
+    );
     if t_dur_mismatch > 0 {
-        // #468: flat's early-terminated bidirectional misses optima by
-        // ~1-2 s on ~0.8% of pairs (tree is CHEAPER in most exemplars) —
-        // the tree side is the likely-correct one. Re-tighten to
-        // assert_eq!(t_dur_mismatch, 0) when #468 closes.
-        println!("    ⚠ flat-vs-tree duration mismatches: {t_dur_mismatch} (#468 — flat suspect)");
+        // #468: equal-CCH-cost ties on the node_weights basis — drift canary
+        // only (48/6000 on the 2026-06-10 rebuild, all tie-class).
+        println!(
+            "    ⚠ flat-vs-tree row-duration-sum mismatches: {t_dur_mismatch} (equal-CCH-cost ties — drift canary, see #468)"
+        );
     } else {
-        println!("    ✓ TREE reachability + total-duration IDENTICAL");
+        println!("    ✓ TREE reachability + CCH distance + row-duration sums IDENTICAL");
     }
 
     // Codex audit: row-chain continuity (osm_to[i] == osm_from[i+1]) on every

--- a/route/src/server/flight.rs
+++ b/route/src/server/flight.rs
@@ -1735,6 +1735,14 @@ pub struct EdgeRow {
 pub struct PairEdges {
     pub query_idx: u32,
     pub rows: Vec<EdgeRow>,
+    /// #468: the OPTIMIZED CCH metric (`QueryResult::distance` /
+    /// `TreePath::distance`) for this pair; `None` ⇒ unreachable. Bench /
+    /// internal only — the searches optimize CCH weights while the row
+    /// `dur_ms` values come from post-unpack `node_weights`, so equal-CCH-cost
+    /// ties can legitimately differ in summed row durations. The equivalence
+    /// oracle asserts on THIS field. NOT part of the `edges_batch` wire
+    /// schema; the Arrow emission never reads it.
+    pub cch_distance: Option<u32>,
 }
 
 /// Compute the unpacked edge sequence for a single (src,dst) pair.
@@ -1762,6 +1770,7 @@ pub(crate) fn edges_for_pair(
         None => PairEdges {
             query_idx,
             rows: Vec::new(),
+            cch_distance: None,
         },
     }
 }
@@ -1922,7 +1931,11 @@ fn emit_pair_rows(
             dist_m: node.length_m,
         });
     }
-    PairEdges { query_idx, rows }
+    PairEdges {
+        query_idx,
+        rows,
+        cch_distance: Some(result.distance),
+    }
 }
 
 /// #438: resolve a coordinate to its K=1 (closest, role-filtered) CCH rank —
@@ -2050,6 +2063,7 @@ pub(crate) fn process_per_pair_work(
         None => PairEdges {
             query_idx: work.query_idx,
             rows: Vec::new(),
+            cch_distance: None,
         },
     }
 }
@@ -3653,9 +3667,11 @@ mod edges_batch_grouping_tests {
 
     /// #438: equivalence oracle — the source-GROUPED edges path must produce
     /// the SAME result as the per-pair FLAT path: identical reachability and
-    /// identical per-pair total duration (the optimised metric). Equal-cost
-    /// ties may pick a different (still-shortest) edge sequence, so byte-
-    /// identity is asserted as a high rate, not 100%.
+    /// identical per-pair CCH distance (the optimised metric, #468). Equal-cost
+    /// ties may pick a different (still-shortest) edge sequence — so byte-
+    /// identity is asserted as a high rate, not 100%, and the summed row
+    /// durations (post-unpack `node_weights` basis) are NOT asserted at all:
+    /// equal-CCH-cost alternatives legitimately differ on them (#468).
     ///
     /// Skipped unless `BT_EDGES_CONTAINER` points at a Belgium `.butterfly`
     /// (the step4-7 CCH is large and not committed). Run with:
@@ -3726,11 +3742,11 @@ mod edges_batch_grouping_tests {
                     "reachability for query_idx {} (parallel={parallel})",
                     f.query_idx
                 );
-                let f_dur: u64 = f.rows.iter().map(|r| r.dur_ms as u64).sum();
-                let g_dur: u64 = g.rows.iter().map(|r| r.dur_ms as u64).sum();
+                // #468: assert on the OPTIMIZED metric (CCH distance), not the
+                // post-unpack node_weights row sum — ties differ on the latter.
                 assert_eq!(
-                    f_dur, g_dur,
-                    "total duration for query_idx {} (parallel={parallel})",
+                    f.cch_distance, g.cch_distance,
+                    "CCH distance for query_idx {} (parallel={parallel})",
                     f.query_idx
                 );
                 let same = f.rows.len() == g.rows.len()
@@ -3751,7 +3767,7 @@ mod edges_batch_grouping_tests {
                 pairs.len(),
                 rate * 100.0
             );
-            // Reachability + total-duration are exact (asserted above). Edge
+            // Reachability + CCH distance are exact (asserted above). Edge
             // sequences match for all but rare equal-cost ties.
             assert!(
                 rate > 0.95,


### PR DESCRIPTION
Closes #468.

## What

Implements the fix plan from the last #468 comment (codex root-cause: **oracle artifact, not a routing bug**). The bench oracle compared post-unpack summed row durations (`node_weights` basis) while flat/grouped/tree all optimize **CCH weights** — equal-CCH-cost alternative paths legitimately differ on the compared metric, in both directions, with zero shortest-path error.

- **`route/src/server/flight.rs`**: `PairEdges` now carries a bench-internal `cch_distance: Option<u32>` (`QueryResult::distance` / `TreePath::distance`, the optimized metric; `None` = unreachable), filled in `emit_pair_rows` where the `QueryResult` is in scope for every variant (per-pair, grouped meet, tree backtrack — the tree path already wraps `TreePath` into a `QueryResult` before emitting). **Wire schema untouched** — `edges_batch_schema` and the Arrow emission never read the field.
- **`route/src/bench/main.rs` (`run_edges_batch_bench`)**: new CCH-METRIC oracle — per pair, **HARD `assert_eq!` on `cch_distance`** for flat-vs-grouped and flat-vs-tree (grouped-vs-tree follows by transitivity). Reachability asserts stay hard. The row-duration-sum comparison stays as a printed tie-tolerant warning — kept as a drift canary (a jump in tie count without a CCH mismatch still flags weight-basis drift).
- **`edges_grouped_matches_flat`** (env-gated lib test, `BT_EDGES_CONTAINER`): same oracle bug — it hard-asserted the row-sum metric and would flake on the 2026-06-10 container vintage for the exact tie-class reason of #468. Now asserts `cch_distance` instead.

## Known residual mechanism (documented, NOT a query-loop rewrite)

Codex point 3 on the ticket: on marginal pairs the variants can take different escalation routes (flat treats the K=1 `query()` connect/no-connect as terminal for snap choice; grouped/tree fall back from a failed shared-forward meet / bounded-tree miss into the full per-pair K=64 + 16-combo path). If two variants ever escalate onto **different snap candidates**, the (src,dst) rank pairs differ and a CCH-distance delta would be *legitimate snap divergence*, not a search bug. Analysis says this shouldn't fire here — the grouped/tree fallbacks re-run the exact per-pair routine (same K=1 ranks first, same escalation order), so same-input pairs converge to the same (snap, cost) — but if the container bench surfaces a CCH mismatch, inspect whether the ranks differ before suspecting the bidirectional termination. Per the ticket: no query-loop rewrite attempted.

## Validation

- `cargo build --release -p butterfly-route` — 0 errors
- `cargo clippy --workspace --all-targets --all-features` — 0 warnings
- `cargo fmt --all -- --check` — clean
- `cargo test -p butterfly-route --lib` — 669 passed, 0 failed (same as main; no tests removed)

## Container-level validation required before merge (orchestrator)

Run the Belgium bench on the 2026-06-10 container and confirm **0 CCH-distance mismatches** (the hard asserts must hold; row-sum warnings of ~3-48/6000 are the expected tie-class canary output):

```
butterfly-bench edges-batch --data <2026-06-10 container> --mode car \
  --n-sources 200 --targets-per-source 30 --seed 11 --radius 0.30
```

If a CCH mismatch fires, capture the printed exemplar (it includes both distances and the pair coords) and check snap-rank divergence first (see residual mechanism above).