### PR TITLE
fix(model): #470 unconditional motorway hard-deny for foot-class modes

### DIFF
--- a/models/bike.model.json
+++ b/models/bike.model.json
@@ -49,6 +49,10 @@
           "dismount"
         ]
       }
+    ],
+    "hard_deny_highways": [
+      "motorway",
+      "motorway_link"
     ]
   },
   "oneway": {

--- a/models/foot.model.json
+++ b/models/foot.model.json
@@ -53,6 +53,10 @@
           "private"
         ]
       }
+    ],
+    "hard_deny_highways": [
+      "motorway",
+      "motorway_link"
     ]
   },
   "oneway": {

--- a/models/scooter.model.json
+++ b/models/scooter.model.json
@@ -90,6 +90,10 @@
           "private"
         ]
       }
+    ],
+    "hard_deny_highways": [
+      "motorway",
+      "motorway_link"
     ]
   },
   "oneway": {

--- a/models/wheelchair.model.json
+++ b/models/wheelchair.model.json
@@ -67,6 +67,10 @@
           "private"
         ]
       }
+    ],
+    "hard_deny_highways": [
+      "motorway",
+      "motorway_link"
     ]
   },
   "oneway": {

--- a/route/src/model/compile.rs
+++ b/route/src/model/compile.rs
@@ -72,6 +72,10 @@ pub struct CompiledModel {
     pub access_table: Vec<bool>,
     pub deny_rules: Vec<CompiledDenyRule>,
     pub allow_if_rules: Vec<CompiledAllowRule>,
+    /// Unconditional legal class bans (#470), dense by highway value_id.
+    /// Checked FIRST in evaluation — beats `access_table`, `allow_if_rules`,
+    /// and every way tag.
+    pub hard_deny_table: Vec<bool>,
 
     // Oneway
     pub respect_oneway: bool,
@@ -117,6 +121,7 @@ impl CompiledModel {
             access_table: vec![],
             deny_rules: vec![],
             allow_if_rules: vec![],
+            hard_deny_table: vec![],
             respect_oneway: false,
             oneway_key_id: None,
             forward_value_ids: vec![],
@@ -207,6 +212,14 @@ pub fn compile_model(
             })
         })
         .collect();
+
+    // --- Hard-deny table (#470: unconditional legal class bans) ---
+    let mut hard_deny_table = vec![false; table_len];
+    for highway_type in &schema.access.hard_deny_highways {
+        if let Some(&vid) = rev_val.get(highway_type.as_str()) {
+            hard_deny_table[vid as usize] = true;
+        }
+    }
 
     // --- Allow-if rules (conditional access overrides) ---
     let allow_if_rules: Vec<CompiledAllowRule> = schema
@@ -330,6 +343,7 @@ pub fn compile_model(
         access_table,
         deny_rules,
         allow_if_rules,
+        hard_deny_table,
 
         respect_oneway: schema.oneway.respect,
         oneway_key_id,

--- a/route/src/model/evaluate.rs
+++ b/route/src/model/evaluate.rs
@@ -31,6 +31,14 @@ pub fn evaluate_way(
 
     let hw_idx = highway_val_id as usize;
 
+    // Hard legal class ban (#470): e.g. pedestrians/cyclists on
+    // motorway/motorway_link (Vienna-convention semantics). Highest
+    // precedence — cannot be overridden by `access.highway`, `allow_if`
+    // rules, or way tags (`foot=yes`, `sidewalk=*`, ...).
+    if hw_idx < model.hard_deny_table.len() && model.hard_deny_table[hw_idx] {
+        return output;
+    }
+
     // Check access
     let highway_allowed = hw_idx < model.access_table.len() && model.access_table[hw_idx];
 
@@ -297,4 +305,174 @@ fn check_conditional_with_key_dict(
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ModelSchema, compile_model};
+    use std::collections::HashMap;
+
+    // Dictionary ids used by every test below.
+    const K_HIGHWAY: u32 = 1;
+    const K_FOOT: u32 = 2;
+    const K_BICYCLE: u32 = 3;
+    const K_SIDEWALK: u32 = 4;
+
+    const V_MOTORWAY: u32 = 1;
+    const V_MOTORWAY_LINK: u32 = 2;
+    const V_RESIDENTIAL: u32 = 3;
+    const V_YES: u32 = 4;
+    const V_BOTH: u32 = 5;
+
+    fn dicts() -> (HashMap<u32, String>, HashMap<u32, String>) {
+        let key_dict: HashMap<u32, String> = [
+            (K_HIGHWAY, "highway"),
+            (K_FOOT, "foot"),
+            (K_BICYCLE, "bicycle"),
+            (K_SIDEWALK, "sidewalk"),
+        ]
+        .into_iter()
+        .map(|(id, s)| (id, s.to_string()))
+        .collect();
+        let val_dict: HashMap<u32, String> = [
+            (V_MOTORWAY, "motorway"),
+            (V_MOTORWAY_LINK, "motorway_link"),
+            (V_RESIDENTIAL, "residential"),
+            (V_YES, "yes"),
+            (V_BOTH, "both"),
+        ]
+        .into_iter()
+        .map(|(id, s)| (id, s.to_string()))
+        .collect();
+        (key_dict, val_dict)
+    }
+
+    /// Compile a SHIPPED model (models/<name>.model.json) against the
+    /// test dictionaries — exactly the path step2 profiling takes.
+    fn compile_shipped(name: &str) -> (CompiledModel, HashMap<u32, String>) {
+        let path = format!(
+            "{}/../models/{}.model.json",
+            env!("CARGO_MANIFEST_DIR"),
+            name
+        );
+        let json = std::fs::read_to_string(&path).unwrap();
+        let schema: ModelSchema = serde_json::from_str(&json).unwrap();
+        let (key_dict, val_dict) = dicts();
+        let compiled = compile_model(&schema, 0, [0u8; 32], &key_dict, &val_dict);
+        (compiled, val_dict)
+    }
+
+    fn assert_no_access(out: &WayOutput) {
+        assert!(!out.access_fwd, "access_fwd must be false");
+        assert!(!out.access_rev, "access_rev must be false");
+        assert_eq!(out.base_speed_mmps, 0, "speed must be 0 for denied way");
+    }
+
+    /// #470: `highway=motorway` + `foot=yes` must still evaluate to
+    /// no-access for foot. Pedestrians are banned on motorways
+    /// regardless of way tags (Vienna-convention semantics).
+    #[test]
+    fn foot_motorway_foot_yes_still_denied() {
+        let (model, val_dict) = compile_shipped("foot");
+        let out = evaluate_way(
+            &model,
+            &[K_HIGHWAY, K_FOOT],
+            &[V_MOTORWAY, V_YES],
+            &val_dict,
+        );
+        assert_no_access(&out);
+    }
+
+    /// #470: `highway=motorway_link` + `foot=yes` + `sidewalk=both`
+    /// must still evaluate to no-access for foot.
+    #[test]
+    fn foot_motorway_link_sidewalk_still_denied() {
+        let (model, val_dict) = compile_shipped("foot");
+        let out = evaluate_way(
+            &model,
+            &[K_HIGHWAY, K_FOOT, K_SIDEWALK],
+            &[V_MOTORWAY_LINK, V_YES, V_BOTH],
+            &val_dict,
+        );
+        assert_no_access(&out);
+    }
+
+    /// #470: same ban class for bike — `highway=motorway` +
+    /// `bicycle=yes` must still evaluate to no-access.
+    #[test]
+    fn bike_motorway_bicycle_yes_still_denied() {
+        let (model, val_dict) = compile_shipped("bike");
+        let out = evaluate_way(
+            &model,
+            &[K_HIGHWAY, K_BICYCLE],
+            &[V_MOTORWAY, V_YES],
+            &val_dict,
+        );
+        assert_no_access(&out);
+
+        let out = evaluate_way(
+            &model,
+            &[K_HIGHWAY, K_BICYCLE],
+            &[V_MOTORWAY_LINK, V_YES],
+            &val_dict,
+        );
+        assert_no_access(&out);
+    }
+
+    /// #470 precedence proof: even a model that explicitly maps
+    /// `motorway` to accessible AND carries a matching `allow_if` rule
+    /// is overridden by `hard_deny_highways`. This is the structural
+    /// guarantee — no future model edit or rule can re-grant access to
+    /// a hard-denied highway class.
+    #[test]
+    fn hard_deny_beats_class_allow_and_allow_if() {
+        let json = r#"{
+            "name": "adversarial",
+            "version": 1,
+            "speed": {"unit": "km/h", "highway": {"motorway": 5}, "overrides": []},
+            "access": {
+                "highway": {"motorway": true, "motorway_link": true},
+                "allow_if": [{"if": {"foot": "yes"}, "speed_kmh": 5}],
+                "hard_deny_highways": ["motorway", "motorway_link"]
+            },
+            "oneway": {"respect": false, "tag": "oneway", "forward_values": [], "reverse_values": [], "default_oneway_highways": []},
+            "priority": [],
+            "highway_class": {},
+            "class_bits": {},
+            "turn_penalties": {"turn_penalty_s": 0, "turn_bias": 1.0, "u_turn_penalty_s": 0, "min_degree_for_penalty": 3, "signal_delay_s": 0, "class_change_penalty_s_per_diff": 0, "max_class_diff_for_penalty": 0},
+            "turn_restrictions": {"respect": false, "restriction_tag": "restriction", "exception_values": []}
+        }"#;
+        let schema: ModelSchema = serde_json::from_str(json).unwrap();
+        let (key_dict, val_dict) = dicts();
+        let model = compile_model(&schema, 0, [0u8; 32], &key_dict, &val_dict);
+
+        for hw in [V_MOTORWAY, V_MOTORWAY_LINK] {
+            let out = evaluate_way(&model, &[K_HIGHWAY, K_FOOT], &[hw, V_YES], &val_dict);
+            assert_no_access(&out);
+        }
+    }
+
+    /// Positive control: the hard deny must not leak onto ordinary
+    /// roads — `highway=residential` stays accessible for foot/bike.
+    #[test]
+    fn residential_still_allowed_for_foot_and_bike() {
+        for name in ["foot", "bike"] {
+            let (model, val_dict) = compile_shipped(name);
+            let out = evaluate_way(&model, &[K_HIGHWAY], &[V_RESIDENTIAL], &val_dict);
+            assert!(out.access_fwd, "{name}: residential must stay accessible");
+            assert!(out.access_rev, "{name}: residential must stay accessible");
+            assert!(out.base_speed_mmps > 0, "{name}: residential speed > 0");
+        }
+    }
+
+    /// Regression control: car has no hard deny — motorway stays
+    /// accessible for car.
+    #[test]
+    fn car_motorway_still_allowed() {
+        let (model, val_dict) = compile_shipped("car");
+        let out = evaluate_way(&model, &[K_HIGHWAY], &[V_MOTORWAY], &val_dict);
+        assert!(out.access_fwd, "car must keep motorway access");
+        assert!(out.base_speed_mmps > 0);
+    }
 }

--- a/route/src/model/schema.rs
+++ b/route/src/model/schema.rs
@@ -50,6 +50,15 @@ pub struct AccessConfig {
     /// Example: allow track if tracktype=grade1 or tracktype=grade2.
     #[serde(default)]
     pub allow_if: Vec<AllowRule>,
+    /// Unconditional highway-type bans (#470) — legal class bans that no
+    /// way tag or rule may override. Highest precedence in evaluation:
+    /// a highway type listed here is denied even if `highway` maps it to
+    /// `true`, even if an `allow_if` rule matches, and regardless of way
+    /// tags (`foot=yes`, `sidewalk=*`, ...). Example: pedestrians and
+    /// cyclists are banned on `motorway`/`motorway_link` under
+    /// Vienna-convention semantics no matter how the way is tagged.
+    #[serde(default)]
+    pub hard_deny_highways: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -163,6 +172,11 @@ mod tests {
         assert_eq!(model.name, "bike");
         assert!(!model.oneway.respect);
         assert_eq!(model.turn_penalties.turn_bias, 1.4);
+        // #470: cyclists are hard-banned from motorways regardless of tags.
+        assert_eq!(
+            model.access.hard_deny_highways,
+            vec!["motorway", "motorway_link"]
+        );
     }
 
     #[test]
@@ -177,6 +191,45 @@ mod tests {
         assert!(!model.oneway.respect);
         assert_eq!(model.turn_penalties.turn_bias, 1.0);
         assert_eq!(model.turn_penalties.u_turn_penalty_s, 0);
+        // #470: pedestrians are hard-banned from motorways regardless of
+        // tags (foot=yes / sidewalk=* must not override the class ban).
+        assert_eq!(
+            model.access.hard_deny_highways,
+            vec!["motorway", "motorway_link"]
+        );
+    }
+
+    #[test]
+    fn test_pedestrian_class_models_carry_motorway_hard_deny() {
+        // #470: every non-motorized / moped-class model ships the
+        // unconditional motorway ban. Car/truck/motorcycle must NOT.
+        for name in ["foot", "bike", "wheelchair", "scooter"] {
+            let json = std::fs::read_to_string(format!(
+                "{}/../models/{}.model.json",
+                env!("CARGO_MANIFEST_DIR"),
+                name
+            ))
+            .unwrap();
+            let model: ModelSchema = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                model.access.hard_deny_highways,
+                vec!["motorway", "motorway_link"],
+                "{name} must hard-deny motorway + motorway_link"
+            );
+        }
+        for name in ["car", "truck", "motorcycle"] {
+            let json = std::fs::read_to_string(format!(
+                "{}/../models/{}.model.json",
+                env!("CARGO_MANIFEST_DIR"),
+                name
+            ))
+            .unwrap();
+            let model: ModelSchema = serde_json::from_str(&json).unwrap();
+            assert!(
+                model.access.hard_deny_highways.is_empty(),
+                "{name} must not carry a motorway hard deny"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Fixes #470 — foot profile routed pedestrians onto motorway/motorway_link segments (63 edges carrying foot flow on the 2026-06-11 national `edges_flow:foot` run, caught by traffic-flow's mode-integrity gate).

## Diagnosis (where the leak can come from)

At HEAD the foot and bike models already map `motorway`/`motorway_link` to `false` in `access.highway`, and every downstream layer (step5 weights/masks, customization 0→u32::MAX, mask-filtered snapping, edges_flow rank expansion) respects that. **But the ban was only a soft default**: `evaluate_way` checks `allow_if` rules even for class-denied highways (that's how car/truck conditionally re-allow denied classes), so any future `allow_if` rule or model edit could silently re-grant foot access to motorways. There was no structural guarantee of the legal rule.

The legal rule (Belgium / Vienna-convention): pedestrians and cyclists are banned on motorway + motorway_link **regardless of `foot=yes` / `sidewalk=*` tags**. This PR encodes that as an invariant with top precedence.

Note: since the current models already class-deny motorway and the deployed container (`a7945cb`) carries identical model code, the production leak most plausibly comes from **stale step2 artifacts** (way_attrs built before the current model/evaluator state) — the rebuild below plus a gate re-run will discriminate. If the gate still fails after the rebuild, the leak is downstream of model evaluation (or in the consumer-side gdf classification join) and #470 should be reopened with the dumped node pairs.

## Changes

- **schema**: `AccessConfig.hard_deny_highways: Vec<String>` (serde default = empty, fully backward compatible).
- **compile**: dense `hard_deny_table` indexed by highway value_id.
- **evaluate**: hard deny checked FIRST in `evaluate_way` — before `access_table`, `allow_if`, and `deny_if`. Nothing can override it.
- **models**: `foot`, `bike`, `wheelchair`, `scooter` carry `["motorway", "motorway_link"]` (all four are the same legal ban class — wheelchair is pedestrian, scooter is moped). `car`/`truck`/`motorcycle` unchanged and pinned empty by test.
- `trunk` stays a soft default-deny (not hard) — `highway=trunk` is not universally a pedestrian-ban class outside autoweg-signed roads.

## Tests (7 new, 676 total lib tests, all green)

Model-evaluation level (`route/src/model/evaluate.rs`):
- `foot_motorway_foot_yes_still_denied` — motorway + `foot=yes` → no access
- `foot_motorway_link_sidewalk_still_denied` — motorway_link + `foot=yes` + `sidewalk=both` → no access
- `bike_motorway_bicycle_yes_still_denied` — both classes + `bicycle=yes` → no access
- `hard_deny_beats_class_allow_and_allow_if` — adversarial model with `motorway: true` AND a matching `allow_if` is still denied (the structural guarantee)
- `residential_still_allowed_for_foot_and_bike`, `car_motorway_still_allowed` — positive/regression controls

Schema level (`route/src/model/schema.rs`): shipped foot/bike/wheelchair/scooter models carry the hard deny; car/truck/motorcycle do not.

## ⚠️ Takes effect only after a step2 rebuild

`way_attrs.*.bin` must be regenerated (`step2-profile`) and the pipeline re-run through step 5/7/8 + repack for the serve artifacts to pick this up — **the orchestrator handles the artifact rebuild**. Container-level validation before merge-to-prod: rebuild Belgium artifacts, re-run the traffic-flow mode-integrity gate (`edges_flow:foot`), expect 0 motorway edges with foot flow.

## Validation done here

- `cargo build --release -p butterfly-route` — 0 errors
- `cargo clippy --workspace --all-targets --all-features` — 0 warnings
- `cargo fmt --all -- --check` — clean
- `cargo test -p butterfly-route --lib` — 676 passed (669 on main + 7 added), 0 failed