### PR TITLE
fix(serve): regions dispatch misses boot-registered modes (car_rush_hour 400)

### DIFF
--- a/route/src/server/mod.rs
+++ b/route/src/server/mod.rs
@@ -666,6 +666,14 @@ pub async fn serve(
                 ),
             }
         })?;
+        // #467: dynamic mode registrations (car_rush_hour) happen AFTER the
+        // RegionEntry cached its registration-time mode list — refresh it so
+        // the regions dispatch (has_mode / available_modes / the "Invalid
+        // mode across loaded regions" check) sees the live set. Same class
+        // of bug as the #450 car_freeflow 400.
+        let live_modes =
+            regions_state.regions[idx].with_loaded_state_mut(|s| s.mode_names.clone())?;
+        regions_state.regions[idx].mode_names = live_modes;
     }
 
     // ---- Per-region size metrics -----------------------------------


### PR DESCRIPTION
Registration-time mode-list cache vs dynamic boot registration — refreshed after the recustomize block. Production-found (#467 three-profile rollout). Tests green, clippy 0.