### PR TITLE
chore(engine): genericize provider/region-specific names (universal engine)

### DIFF
--- a/route/src/calibrate.rs
+++ b/route/src/calibrate.rs
@@ -11,8 +11,8 @@
 //! ## What this tool deliberately does NOT do
 //!
 //! - **It does not choose or fetch the observed-speed dataset.** The data
-//!   source (Sirius CDIS / TomTom Speed Profiles / INRIX / probe-vehicle
-//!   traces / …) is a licensing + coverage decision that belongs to the
+//!   source (probe-vehicle traces / commercial speed profiles / sensor
+//!   aggregates / …) is a licensing + coverage decision that belongs to the
 //!   operator — issue #388 open-question #1, "the real prerequisite". This
 //!   engine is *source-independent*: it takes whatever `(way_id,
 //!   observed_avg_speed_kmh, sample_count)` table the operator produces.
@@ -24,7 +24,7 @@
 //! ## Fitting (density-only variant of the #388 spec)
 //!
 //! The shipped [`TrafficProfile`] schema is five density factors with no
-//! highway dimension (see #392 — Belgium ships one baked friction profile).
+//! highway dimension (see #392 — one baked friction profile per region).
 //! Each way already carries its base (legal-limit) speed in
 //! `way_attrs.base_speed_mmps`, which encodes the highway class. So the right
 //! per-density quantity is the **ratio** `observed_kmh / base_kmh`, aggregated

--- a/route/src/cli.rs
+++ b/route/src/cli.rs
@@ -267,7 +267,8 @@ pub enum Commands {
         models_dir: PathBuf,
 
         /// Density classifier: `osm-tag` (default, deterministic, no extra
-        /// data) or `cdis-parquet` (proprietary plug-in, not implemented).
+        /// data) or `external-parquet` (external classification plug-in, not
+        /// implemented in this build).
         #[arg(long, default_value = "osm-tag")]
         density_classifier: String,
 

--- a/route/src/density.rs
+++ b/route/src/density.rs
@@ -13,10 +13,11 @@
 //!   way into one of the five density classes. Runs in O(n_ways), no spatial
 //!   index, no extra I/O.
 //!
-//! - [`DensityClassifier::CdisParquet`] — reserved plug-in point for the
-//!   Sirius proprietary CDIS sector geometries + rurban archetypes. Not
-//!   implemented in this repo; selecting it returns an error so operators
-//!   know they need a private build.
+//! - [`DensityClassifier::ExternalParquet`] — reserved plug-in point for
+//!   loading density classes from an external per-region classification
+//!   parquet (e.g. territorial/urbanity data). Not implemented in this repo;
+//!   selecting it returns an error so operators know they need a private
+//!   build that provides the classification source.
 //!
 //! ## Mapping rules (OsmTag classifier)
 //!
@@ -142,17 +143,19 @@ impl DensityClass {
 pub enum DensityClassifier {
     /// Tag-driven, no external data. Default.
     OsmTag,
-    /// Sirius proprietary CDIS parquet — not implemented in this repo.
-    CdisParquet,
+    /// External per-region classification parquet — not implemented in this repo.
+    ExternalParquet,
 }
 
 impl DensityClassifier {
     pub fn parse(s: &str) -> anyhow::Result<Self> {
         match s.to_ascii_lowercase().as_str() {
             "osm-tag" | "osm_tag" | "osmtag" => Ok(DensityClassifier::OsmTag),
-            "cdis-parquet" | "cdis_parquet" | "cdisparquet" => Ok(DensityClassifier::CdisParquet),
+            "external-parquet" | "external_parquet" | "externalparquet" => {
+                Ok(DensityClassifier::ExternalParquet)
+            }
             other => anyhow::bail!(
-                "unknown density classifier '{}': supported: osm-tag, cdis-parquet",
+                "unknown density classifier '{}': supported: osm-tag, external-parquet",
                 other
             ),
         }
@@ -241,8 +244,9 @@ pub fn classify_osm_tag(
     tags: &WayTagsView<'_>,
 ) -> DensityClass {
     if classifier != DensityClassifier::OsmTag {
-        // The CDIS classifier is plumbed at the CLI level; if we ever reach
-        // this point with another variant the caller forgot to dispatch.
+        // The external-parquet classifier is plumbed at the CLI level; if we
+        // ever reach this point with another variant the caller forgot to
+        // dispatch.
         return DensityClass::Suburban;
     }
 
@@ -352,8 +356,8 @@ mod tests {
             DensityClassifier::OsmTag
         );
         assert_eq!(
-            DensityClassifier::parse("CDIS-Parquet").unwrap(),
-            DensityClassifier::CdisParquet
+            DensityClassifier::parse("External-Parquet").unwrap(),
+            DensityClassifier::ExternalParquet
         );
         assert!(DensityClassifier::parse("nope").is_err());
     }

--- a/route/src/model/profiling.rs
+++ b/route/src/model/profiling.rs
@@ -215,10 +215,10 @@ pub fn run_profiling(config: ProfileConfig) -> Result<ProfileResult> {
     let mut way_attrs_per_mode: Vec<Vec<WayAttr>> = vec![Vec::new(); n_modes];
 
     // Density classifier: same call for every mode (density is mode-agnostic).
-    if config.density_classifier == DensityClassifier::CdisParquet {
+    if config.density_classifier == DensityClassifier::ExternalParquet {
         anyhow::bail!(
-            "density classifier 'cdis-parquet' is not implemented in this build; \
-             use --density-classifier osm-tag (proprietary CDIS data plug-in is a follow-up issue)"
+            "density classifier 'external-parquet' is not implemented in this build; \
+             use --density-classifier osm-tag (the external classification plug-in is a follow-up)"
         );
     }
 


### PR DESCRIPTION
butterfly is a **universal** routing engine — no provider or region names (Sirius/CDIS/rurban/Belgium/TomTom/INRIX) belong in its source.

**Changes (no behaviour change):**
- Reserved external density-classifier seam renamed `CdisParquet` → `ExternalParquet`; CLI value `cdis-parquet` → `external-parquet`. Still an unimplemented plug-in that errors at step 2 (use `osm-tag`).
- Stripped provider/region references from doc comments in `density.rs` ("Sirius proprietary CDIS … + rurban archetypes") and `calibrate.rs` ("Sirius CDIS / TomTom Speed Profiles / INRIX", "Belgium ships one baked friction profile"). The seam is now described generically as an "external per-region classification parquet" with no mention of what produces it.

**Kept:** `europe/belgium` in `dl/` — these are Geofabrik path *examples* of the universal downloader (alongside `north-america/us/california`), not couplings.

Verified: build + clippy `--all-targets --all-features` + density/profiling tests green.